### PR TITLE
Update TelegramChannel.kt

### DIFF
--- a/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramChannel.kt
+++ b/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramChannel.kt
@@ -14,7 +14,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 class TelegramChannel(
     override val botApi: BotApi,
     private val telegramBotToken: String,
-    private val telegramApiUrl: String = "https://api.telegram.org/bot",
+    private val telegramApiUrl: String = "https://api.telegram.org/",
     private val telegramLogLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BASIC
 ) : BotChannel {
 


### PR DESCRIPTION
previous value `    private val telegramApiUrl: String = "https://api.telegram.org/bot",` provide wrong link to telegram api with result `{"ok":false,"error_code":404,"description":"Not Found"}`
so I changed it to a correct one - ` "https://api.telegram.org/",`