### PR TITLE
Add telephony channel transfer call reaction

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -1,6 +1,7 @@
 package com.justai.jaicf.channel.jaicp.dto
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 internal sealed class Reply(val type: String)
@@ -31,3 +32,15 @@ internal data class AudioReply(val audioUrl: String) : Reply("audio")
 
 @Serializable
 internal class HangupReply : Reply("hangup")
+
+@Serializable
+internal data class SwitchReply(
+    val phoneNumber: String? = null,
+    val headers: Map<String, String>? = null,
+    val firstMessage: String? = null,
+    val lastMessage: String? = null,
+    val closeChatPhrases: List<String>? = emptyList(),
+    val ignoreOffline: Boolean? = false,
+    val destination: String? = null,
+    val attributes: JsonObject? = null
+) : Reply("switch")

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -36,10 +36,10 @@ internal class HangupReply : Reply("hangup")
 @Serializable
 internal data class SwitchReply(
     val phoneNumber: String? = null,
-    val headers: Map<String, String>? = emptyMap(),
+    val headers: Map<String, String> = emptyMap(),
     val firstMessage: String? = null,
     val lastMessage: String? = null,
-    val closeChatPhrases: List<String>? = emptyList(),
+    val closeChatPhrases: List<String> = emptyList(),
     val ignoreOffline: Boolean? = false,
     val destination: String? = null,
     val attributes: JsonObject? = null

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -36,7 +36,7 @@ internal class HangupReply : Reply("hangup")
 @Serializable
 internal data class SwitchReply(
     val phoneNumber: String? = null,
-    val headers: Map<String, String>? = null,
+    val headers: Map<String, String>? = emptyMap(),
     val firstMessage: String? = null,
     val lastMessage: String? = null,
     val closeChatPhrases: List<String>? = emptyList(),

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
@@ -1,12 +1,7 @@
 package com.justai.jaicf.channel.jaicp.reactions
 
-import com.justai.jaicf.channel.jaicp.dto.Reply
 import com.justai.jaicf.channel.jaicp.JSON
-import com.justai.jaicf.channel.jaicp.dto.AudioReply
-import com.justai.jaicf.channel.jaicp.dto.ButtonsReply
-import com.justai.jaicf.channel.jaicp.dto.HangupReply
-import com.justai.jaicf.channel.jaicp.dto.ImageReply
-import com.justai.jaicf.channel.jaicp.dto.TextReply
+import com.justai.jaicf.channel.jaicp.dto.*
 import com.justai.jaicf.reactions.Reactions
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -40,6 +35,9 @@ open class JaicpReactions : Reactions() {
                 )
                 is HangupReply -> JSON.toJson(
                     HangupReply.serializer(), reply
+                )
+                is SwitchReply -> JSON.toJson(
+                    SwitchReply.serializer(), reply
                 )
             }
         }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -18,7 +18,7 @@ class TelephonyReactions : JaicpReactions() {
         replies.add(HangupReply())
     }
 
-    fun transferCall(phoneNumber: String, sipHeaders: Map<String, String>? = null) {
+    fun transferCall(phoneNumber: String, sipHeaders: Map<String, String> = emptyMap()) {
         replies.add(SwitchReply(phoneNumber, sipHeaders))
     }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -2,6 +2,7 @@ package com.justai.jaicf.channel.jaicp.reactions
 
 import com.justai.jaicf.channel.jaicp.dto.AudioReply
 import com.justai.jaicf.channel.jaicp.dto.HangupReply
+import com.justai.jaicf.channel.jaicp.dto.SwitchReply
 import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.reactions.Reactions
 
@@ -13,7 +14,11 @@ class TelephonyReactions : JaicpReactions() {
         replies.add(AudioReply(url.toUrl()))
     }
 
-    fun hangup(){
+    fun hangup() {
         replies.add(HangupReply())
+    }
+
+    fun transferCall(phoneNumber: String, sipHeaders: Map<String, String>? = null) {
+        replies.add(SwitchReply(phoneNumber, sipHeaders))
     }
 }

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBot.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBot.kt
@@ -8,7 +8,7 @@ import com.justai.jaicf.activator.regex.RegexActivator
 
 val cailaIntentActivator = CailaIntentActivator.Factory(nluSettings)
 
-val citiesGameBot = BotEngine(
+val telephonyCallScenario = BotEngine(
     TelephonyBotScenario.model,
     activators = arrayOf(
         BaseEventActivator,

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
@@ -55,6 +55,8 @@ object TelephonyBotScenario : Scenario(), WithLogger {
             }
             action {
                 reactions.say("I'm sorry, I can't hear you!")
+                logger.info("")
+                reactions.telephony?.transferCall("+79999999999")
             }
         }
 

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
@@ -55,7 +55,7 @@ object TelephonyBotScenario : Scenario(), WithLogger {
             }
             action {
                 reactions.say("I'm sorry, I can't hear you!")
-                logger.info("")
+                logger.debug("Transferring call from ${request.telephony?.caller} to operator")
                 reactions.telephony?.transferCall("+79999999999")
             }
         }

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/channels/PollingConnection.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/channels/PollingConnection.kt
@@ -3,12 +3,12 @@ package com.justai.jaicf.examples.jaicptelephony.channels
 import com.justai.jaicf.channel.jaicp.JaicpPollingConnector
 import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
 import com.justai.jaicf.examples.jaicptelephony.accessToken
-import com.justai.jaicf.examples.jaicptelephony.citiesGameBot
+import com.justai.jaicf.examples.jaicptelephony.telephonyCallScenario
 
 
 fun main() {
     JaicpPollingConnector(
-        botApi = citiesGameBot,
+        botApi = telephonyCallScenario,
         accessToken = accessToken,
         channels = listOf(TelephonyChannel)
     ).runBlocking()

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/channels/WebhookConnection.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/channels/WebhookConnection.kt
@@ -4,7 +4,7 @@ import com.justai.jaicf.channel.http.httpBotRouting
 import com.justai.jaicf.channel.jaicp.JaicpWebhookConnector
 import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
 import com.justai.jaicf.examples.jaicptelephony.accessToken
-import com.justai.jaicf.examples.jaicptelephony.citiesGameBot
+import com.justai.jaicf.examples.jaicptelephony.telephonyCallScenario
 import io.ktor.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -14,7 +14,7 @@ fun main() {
         routing {
             httpBotRouting(
                 "/" to JaicpWebhookConnector(
-                    botApi = citiesGameBot,
+                    botApi = telephonyCallScenario,
                     accessToken = accessToken,
                     channels = listOf(TelephonyChannel)
                 )


### PR DESCRIPTION
This reply with type switch is used in JAICP Infrastructure to transfer call/dialog to operator. 
Reaction is created only in telephone channel now, until livechat channels (e.g., salesforce) are supported in JAICF.