### PR TITLE
Fix bug with strict transitions check

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -180,12 +180,14 @@ class BotEngine(
     }
 
     private fun checkStrictTransitions(botContext: BotContext, request: BotRequest): String? {
-        return request.hasQuery().takeIf { true }?.let {
-            val dc = botContext.dialogContext
-            val transition = dc.transitions[request.input.toLowerCase()]
-            dc.transitions.clear()
-            return transition
+        if (!request.hasQuery()) {
+            return null
         }
+
+        val dc = botContext.dialogContext
+        val transition = dc.transitions[request.input.toLowerCase()]
+        dc.transitions.clear()
+        return transition
     }
 
     private fun selectActivation(


### PR DESCRIPTION
In previous code, block under `let` expression is always executed, because `this.takeIf { true }` always returns `this` despite of value of `this`.