### PR TITLE
Fix cleaning temp data after request processing finished

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -107,6 +107,7 @@ class BotEngine(
                 processStates(context)
                 saveContext(cm, botContext, request, reactions)
             }
+            botContext.cleanTempData()
         }
     }
 

--- a/core/src/main/kotlin/com/justai/jaicf/context/BotContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/BotContext.kt
@@ -53,8 +53,15 @@ data class BotContext(
      * Cleans the session-scoped data: [result], [temp] and [session]
      */
     fun cleanSessionData() {
+        cleanTempData()
         result = null
-        temp.clear()
         session.clear()
+    }
+
+    /**
+     * Cleans the request-scoped data: [temp]
+     */
+    fun cleanTempData() {
+        temp.clear()
     }
 }


### PR DESCRIPTION
This PR fixes a bug that `BotContext#temp` gets cleaned only when the new session starts. 
Now it is cleaned after a request processing finished.

Two things to notice:
- `temp` is not cleaned if slot filling in progress;
- `temp` is not cleaned if `BotRequestHook` interrupts request processing.

If it is not the desired logic, I'll fix it.

**EDIT:** Thanks, @Denire for pointing me out that `temp` data is actually gets cleaned implicitly as it's not saved after a request and so isn't loaded on the next request.
So the question is either we want to clean `temp` explicitly or remain implicit. 