### PR TITLE
[#49] remove exception throwing in BotEngine, add tests for ActionErrorHook

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -234,6 +234,7 @@ class BotEngine(
                                 state.action.execute(this)
                                 withHook(AfterActionHook(botContext, request, reactions, activator, state))
                             } catch (e: Exception) {
+                                logger.warn("Action exception on state ${dc.currentState}", e)
                                 hooks.triggerHook(ActionErrorHook(botContext, request, reactions, activator, state, e))
                             }
                         }

--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -235,7 +235,6 @@ class BotEngine(
                                 withHook(AfterActionHook(botContext, request, reactions, activator, state))
                             } catch (e: Exception) {
                                 hooks.triggerHook(ActionErrorHook(botContext, request, reactions, activator, state, e))
-                                throw RuntimeException("Error on state " + dc.currentState, e)
                             }
                         }
                     }

--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -234,7 +234,7 @@ class BotEngine(
                                 state.action.execute(this)
                                 withHook(AfterActionHook(botContext, request, reactions, activator, state))
                             } catch (e: Exception) {
-                                logger.warn("Action exception on state ${dc.currentState}", e)
+                                logger.error("Action exception on state ${dc.currentState}", e)
                                 hooks.triggerHook(ActionErrorHook(botContext, request, reactions, activator, state, e))
                             }
                         }

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/hooks/ActionErrorHookHandlingTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/hooks/ActionErrorHookHandlingTest.kt
@@ -1,0 +1,44 @@
+package com.justai.jaicf.core.test.hooks
+
+import com.justai.jaicf.hook.ActionErrorHook
+import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.test.ScenarioTest
+import org.junit.jupiter.api.Test
+
+val scenarioWithErrorHook = object : Scenario() {
+    init {
+        handle<ActionErrorHook> {
+            it.reactions.say("Error happened. Sorry.")
+        }
+
+        state("error") {
+            activators { regex("error") }
+            action {
+                error("This is error")
+            }
+        }
+
+        state("ok") {
+            activators { regex("ok") }
+            action {
+                reactions.say("ok")
+            }
+        }
+    }
+}
+
+class ActionErrorHookHandlingTest : ScenarioTest(scenarioWithErrorHook.model) {
+
+    @Test
+    fun `should handle error with some reaction`() {
+        query("error") responds "Error happened. Sorry."
+    }
+
+    @Test
+    fun `should not invoke error hook when no errors`() {
+        query("ok") responds "ok"
+    }
+
+}
+
+


### PR DESCRIPTION
On action exception we don't need to throw error outside or `BotEngine`. There was issues when exceptions in `action` block crashed `TelegramChannel` as there was no handlers inside.
This PR should fix it.