### PR TITLE
Fix the bug with the RegexActivator when unmatched group cause exception

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/BaseIntentActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/BaseIntentActivator.kt
@@ -10,7 +10,7 @@ import com.justai.jaicf.model.scenario.ScenarioModel
 
 /**
  * A base implementation of [IntentActivator].
- * This activator handles intent requests and activates a state if it contains an intent with name that equals to the request's input.
+ * This activator handles intent requests and activates a state if its activation rule matches intent name from the request's input.
  *
  * @param model dialogue scenario model
  *
@@ -25,7 +25,7 @@ open class BaseIntentActivator(
 
     override fun provideRuleMatcher(botContext: BotContext, request: BotRequest): ActivationRuleMatcher {
         val intents = recogniseIntent(botContext, request)
-        return ruleMatcher<IntentActivationRule> { rule -> intents.firstOrNull { it.intent == rule.intent } }
+        return ruleMatcher<IntentActivationRule> { rule -> intents.firstOrNull { rule.intentMatches(it.intent) } }
     }
 
     override fun recogniseIntent(botContext: BotContext, request: BotRequest) =

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/BaseIntentActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/BaseIntentActivator.kt
@@ -25,7 +25,9 @@ open class BaseIntentActivator(
 
     override fun provideRuleMatcher(botContext: BotContext, request: BotRequest): ActivationRuleMatcher {
         val intents = recogniseIntent(botContext, request)
-        return ruleMatcher<IntentActivationRule> { rule -> intents.firstOrNull { rule.intentMatches(it.intent) } }
+        return ruleMatcher<IntentActivationRule> { rule ->
+            intents.sortedByDescending { it.confidence }.firstOrNull { rule.intentMatches(it.intent) }
+        }
     }
 
     override fun recogniseIntent(botContext: BotContext, request: BotRequest) =

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
@@ -2,4 +2,8 @@ package com.justai.jaicf.activator.intent
 
 import com.justai.jaicf.model.activation.ActivationRule
 
-open class IntentActivationRule(val intent: String): ActivationRule
+abstract class IntentActivationRule(val intentMatches: (String) -> Boolean): ActivationRule
+
+open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it == intent })
+
+class AnyIntentActivationRule: IntentActivationRule({ true })

--- a/core/src/main/kotlin/com/justai/jaicf/activator/regex/RegexActivatorContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/regex/RegexActivatorContext.kt
@@ -15,8 +15,8 @@ data class RegexActivatorContext(
     val pattern: Pattern
 ): StrictActivatorContext() {
 
-    val groups = mutableListOf<String>()
-    val namedGroups = mutableMapOf<String, String>()
+    val groups = mutableListOf<String?>()
+    val namedGroups = mutableMapOf<String, String?>()
 }
 
 val ActivatorContext.regex

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -2,11 +2,14 @@ package com.justai.jaicf.builder
 
 import com.justai.jaicf.activator.catchall.CatchAllActivationRule
 import com.justai.jaicf.activator.event.EventActivationRule
-import com.justai.jaicf.activator.intent.IntentActivationRule
+import com.justai.jaicf.activator.intent.AnyIntentActivationRule
+import com.justai.jaicf.activator.intent.IntentByNameActivationRule
 import com.justai.jaicf.activator.regex.RegexActivationRule
 import com.justai.jaicf.context.ActionContext
-import com.justai.jaicf.hook.*
-import com.justai.jaicf.model.*
+import com.justai.jaicf.hook.BotHook
+import com.justai.jaicf.hook.BotHookAction
+import com.justai.jaicf.hook.BotHookException
+import com.justai.jaicf.model.ActionAdapter
 import com.justai.jaicf.model.scenario.ScenarioModel
 import com.justai.jaicf.model.state.State
 import com.justai.jaicf.model.state.StatePath
@@ -276,7 +279,21 @@ abstract class ScenarioBuilder(
         fun intent(intent: String) = add(Transition(
             fromState,
             toState,
-            IntentActivationRule(intent)
+            IntentByNameActivationRule(intent)
+        ))
+
+        /**
+         * Appends any-intent activator to this state. Means that any intent can activate this state.
+         * Requires a [com.justai.jaicf.activator.intent.IntentActivator] in the activators' list of your [com.justai.jaicf.api.BotApi] instance.
+         *
+         * @see com.justai.jaicf.activator.intent.IntentActivator
+         * @see com.justai.jaicf.api.BotApi
+         */
+        fun anyIntent() = add(
+            Transition(
+            fromState,
+            toState,
+            AnyIntentActivationRule()
         ))
     }
 

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -121,6 +121,37 @@ abstract class ScenarioBuilder(
     }
 
     /**
+     * Appends an any-intent state to the scenario.
+     * This state will be activated for every request that has any intent in its input, recognized by
+     * any registered IntentActivator.
+     *
+     * The current dialogue's context won't be changed.
+     * This builder requires an IntentActivator to be added to the activators list of your BotEngine instance.
+     *
+     * ```
+     * anyIntent {
+     *   activator.caila?.topIntent?.answer?.let {
+     *       reactions.say(it)
+     *   }
+     * }
+     * ```
+     *
+     * @param state an optional state name ("anyIntent" by default)
+     * @param action an action block that will be executed
+     */
+    fun anyIntent(
+        state: String = "anyIntent",
+        action: ActionContext.() -> Unit
+    ) = state(
+        name = state,
+        noContext = true,
+        body = {
+            activators { anyIntent() }
+            action(action)
+        }
+    )
+
+    /**
      * Appends a fallback state to the scenario.
      * This state will be activated for every request that doesn't match to any other state.
      * The current dialogue's context won't be changed.
@@ -289,8 +320,7 @@ abstract class ScenarioBuilder(
          * @see com.justai.jaicf.activator.intent.IntentActivator
          * @see com.justai.jaicf.api.BotApi
          */
-        fun anyIntent() = add(
-            Transition(
+        internal fun anyIntent() = add(Transition(
             fromState,
             toState,
             AnyIntentActivationRule()


### PR DESCRIPTION
This changes make `RegexActivatorContext#groups` and `RegexActivatorContext#namedGroups` hold nullable values, as `Matcher.group(id)` will return null on unmatched group.

Closes #62 