### PR TITLE
Fix the bug with the RegexActivator when unmatched group cause exception

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/activator/regex/RegexActivatorContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/regex/RegexActivatorContext.kt
@@ -15,8 +15,8 @@ data class RegexActivatorContext(
     val pattern: Pattern
 ): StrictActivatorContext() {
 
-    val groups = mutableListOf<String>()
-    val namedGroups = mutableMapOf<String, String>()
+    val groups = mutableListOf<String?>()
+    val namedGroups = mutableMapOf<String, String?>()
 }
 
 val ActivatorContext.regex


### PR DESCRIPTION
This changes make RegexActivatorContext#groups and RegexActivatorContext#namedGroups hold nullable values, as Matcher.group(id) will return null on unmatched group.

Closes #62 