### PR TITLE
Get rid of skippedActivators

### DIFF
--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingHelper.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingHelper.kt
@@ -33,7 +33,7 @@ internal class CailaSlotFillingHelper(
         }
 
         val actionContext =
-            ActionContext(botContext, ctx.initialActivatorContext, botRequest, reactions, mutableListOf())
+            ActionContext(botContext, ctx.initialActivatorContext, botRequest, reactions)
 
         val filled = fillSlots(ctx, botRequest.input)
         for (slot in required) {

--- a/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
@@ -14,7 +14,6 @@ import kotlin.random.Random
  * @property activator a particular [ActivatorContext] of the activator that handled the user's request
  * @property request a particular channel-related [BotRequest] that contains request's details
  * @property reactions a particular channel-related [Reactions] that contains methods for building and sending a response
- * @property skippedActivators a list of activators that returned some data but weren't selected by the bot engine because there is no related state in scenario
  *
  * @see [BotContext]
  * @see [ActivatorContext]
@@ -25,8 +24,7 @@ open class ActionContext(
     val context: BotContext,
     val activator: ActivatorContext,
     val request: BotRequest,
-    val reactions: Reactions,
-    val skippedActivators: List<ActivatorContext>
+    val reactions: Reactions
 ) {
 
     /**

--- a/core/src/main/kotlin/com/justai/jaicf/context/ProcessContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ProcessContext.kt
@@ -14,6 +14,5 @@ data class ProcessContext(
     val requestContext: RequestContext,
     val botContext: BotContext,
     val activationContext: ActivationContext,
-    val skippedActivators: List<ActivatorContext>,
     val loggingContext: LoggingContext
 )

--- a/core/src/main/kotlin/com/justai/jaicf/model/ActionAdapter.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/ActionAdapter.kt
@@ -17,8 +17,7 @@ class ActionAdapter(
                     botContext,
                     activationContext.activation.context,
                     request,
-                    reactions,
-                    skippedActivators
+                    reactions
                 )
             )
         }

--- a/core/src/main/kotlin/com/justai/jaicf/model/activation/Activation.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/activation/Activation.kt
@@ -5,7 +5,7 @@ import com.justai.jaicf.context.ActivatorContext
 /**
  * The instance of this class produced by every [com.justai.jaicf.activator.Activator] once it handled a request.
  * Contains [ActivatorContext] with activation details and optional state that was found by the activator in scenario model.
- * Null state means that there is no state in the model related to the user's request. In this case such activation becomes a part of skippedActivators in [com.justai.jaicf.context.ActionContext].
+ * Null state means that there is no state in the model related to the user's request.
  *
  * @property state an optional state of the dialogue scenario model related to the user's request
  * @property context an [ActivatorContext] that contains an activator-related details like named entities, confidence and etc.

--- a/core/src/main/kotlin/com/justai/jaicf/test/context/TestActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/test/context/TestActionContext.kt
@@ -14,8 +14,7 @@ data class TestActionContext(
     context = processContext.botContext,
     activator = processContext.activationContext.activation.context,
     request = processContext.request,
-    reactions = processContext.reactions,
-    skippedActivators = processContext.skippedActivators
+    reactions = processContext.reactions
 ) {
     private val requestContext = processContext.requestContext as TestRequestContext
 

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
@@ -22,8 +22,7 @@ class SmartRandomTest {
             BotContext(UUID.randomUUID().toString()),
             StrictActivatorContext(),
             QueryBotRequest("", ""),
-            TextReactions(TextResponse()),
-            listOf()
+            TextReactions(TextResponse())
         )
     }
 


### PR DESCRIPTION
This PR fully removes `skippedActivators` from `ActionContext`, `ProcessContext`, `BotEngine`, etc.
A user is supposed to use `anyIntent` or `anyEvent` activation rules instead

Closes #53 as it's no longer needed