### PR TITLE
#55 MDCContext and gelf-appender for graylog

### DIFF
--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -13,6 +13,7 @@ object Version {
     const val serializationRuntime = "0.14.0"
     const val coroutinesCore = "1.3.3"
     const val javaxServletApi = "3.0.1"
+    const val logbackGelfAppender = "1.5"
 }
 
 infix fun String.version(versionProvider: Version.() -> String) =

--- a/channels/jaicp/build.gradle.kts
+++ b/channels/jaicp/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(kotlin("stdlib", Version.stdLib))
 
     implementation("javax.servlet:javax.servlet-api" version { javaxServletApi })
+    implementation("de.appelgriepsch.logback:logback-gelf-appender" version { logbackGelfAppender })
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j" version { coroutinesCore })
 
     api("org.jetbrains.kotlinx:kotlinx-serialization-runtime" version { serializationRuntime })
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core" version { coroutinesCore })

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -7,7 +7,6 @@ import com.justai.jaicf.channel.jaicp.http.ChatAdapterConnector
 import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.HttpClient
-import org.slf4j.MDC
 
 const val DEFAULT_PROXY_URL = "https://bot.jaicp.com"
 
@@ -34,7 +33,7 @@ abstract class JaicpConnector(
     private val chatAdapterConnector = ChatAdapterConnector(accessToken, url, httpClient)
     private val registeredChannels = parseChannels()
     protected val accountId = registeredChannels.first().second.accountId.also {
-        MDC.put("accountId", it)
+        JaicpMDC.setAccountId(it)
     }
 
     protected fun registerChannels() {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -32,8 +32,9 @@ abstract class JaicpConnector(
 ) : WithLogger {
 
     private val chatAdapterConnector = ChatAdapterConnector(accessToken, url, httpClient)
-    private val registeredChannels = parseChannels().also {
-        MDC.put("accountId", it.first().second.accountId)
+    private val registeredChannels = parseChannels()
+    protected val accountId = registeredChannels.first().second.accountId.also {
+        MDC.put("accountId", it)
     }
 
     protected fun registerChannels() {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -7,6 +7,7 @@ import com.justai.jaicf.channel.jaicp.http.ChatAdapterConnector
 import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.HttpClient
+import org.slf4j.MDC
 
 const val DEFAULT_PROXY_URL = "https://bot.jaicp.com"
 
@@ -31,8 +32,9 @@ abstract class JaicpConnector(
 ) : WithLogger {
 
     private val chatAdapterConnector = ChatAdapterConnector(accessToken, url, httpClient)
-    private val registeredChannels = parseChannels()
-
+    private val registeredChannels = parseChannels().also {
+        MDC.put("accountId", it.first().second.accountId)
+    }
 
     protected fun registerChannels() {
         registeredChannels.forEach { (factory, cfg) ->

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpMDC.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpMDC.kt
@@ -1,0 +1,16 @@
+package com.justai.jaicf.channel.jaicp
+
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
+import org.slf4j.MDC
+
+object JaicpMDC {
+    fun setFromRequest(request: JaicpBotRequest) {
+        MDC.put("requestId", request.questionId)
+        MDC.put("channelId", request.channelBotId)
+    }
+
+    fun setAccountId(accountId: String) {
+        MDC.put("accountId", accountId)
+    }
+}
+

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
@@ -48,9 +48,11 @@ class JaicpWebhookConnector(
     }
 
     override fun process(request: HttpBotRequest): HttpBotResponse? {
+        JaicpMDC.setAccountId(accountId)
         val botRequest = request.receiveText()
             .also { logger.debug("Received botRequest: $it") }
             .asJaicpBotRequest()
+            .also { JaicpMDC.setFromRequest(it) }
 
         return when (val channel = channelMap[botRequest.channelBotId]) {
             is JaicpNativeBotChannel -> channel.process(botRequest).deserialized().asJsonHttpBotResponse()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotRequest.kt
@@ -27,11 +27,6 @@ data class JaicpBotRequest(
     override val clientId = channelUserId
     override val input: String = query ?: event ?: ""
 
-    init {
-        MDC.put("requestId", questionId)
-        MDC.put("channelId", channelBotId)
-    }
-
     val raw: String get() = rawRequest.toString()
 
     fun stringify() = JSON.stringify(serializer(), this)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotRequest.kt
@@ -6,6 +6,7 @@ import com.justai.jaicf.channel.jaicp.JSON
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import org.slf4j.MDC
 
 @Serializable
 data class JaicpBotRequest(
@@ -25,6 +26,11 @@ data class JaicpBotRequest(
     override val type: BotRequestType = if (query != null) BotRequestType.QUERY else BotRequestType.EVENT
     override val clientId = channelUserId
     override val input: String = query ?: event ?: ""
+
+    init {
+        MDC.put("requestId", questionId)
+        MDC.put("channelId", channelBotId)
+    }
 
     val raw: String get() = rawRequest.toString()
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/logging/JaicpConversationLogger.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/logging/JaicpConversationLogger.kt
@@ -18,6 +18,7 @@ import io.ktor.client.features.logging.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.slf4j.MDCContext
 
 /**
  * Implements [ConversationLogger] for JAICP Application Console.
@@ -44,7 +45,7 @@ class JaicpConversationLogger(
 
     override fun doLog(loggingContext: LoggingContext) {
         try {
-            launch {
+            launch(MDCContext()) {
                 doLogAsync(loggingContext)
             }
         } catch (e: Exception) {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
@@ -2,6 +2,7 @@ package com.justai.jaicf.channel.jaicp.polling
 
 import com.justai.jaicf.channel.http.asHttpBotRequest
 import com.justai.jaicf.channel.jaicp.*
+import com.justai.jaicf.channel.jaicp.JaicpMDC
 import com.justai.jaicf.channel.jaicp.channels.JaicpNativeBotChannel
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
@@ -40,6 +41,7 @@ internal class Dispatcher(client: HttpClient) :
         poller.getUpdates(channel.url).collect { rawRequest ->
             logger.info("Received bot request: $rawRequest")
             val request = rawRequest.asJaicpPollingRequest().request
+            JaicpMDC.setFromRequest(request)
             when (val botChannel = channel.botChannel) {
                 is JaicpNativeBotChannel -> processNativeChannel(botChannel, channel.url, request)
                 is JaicpCompatibleBotChannel -> processCompatibleChannel(botChannel, channel.url, request)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
@@ -10,6 +10,7 @@ import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.slf4j.MDCContext
 
 
 internal class Dispatcher(client: HttpClient) :
@@ -27,7 +28,7 @@ internal class Dispatcher(client: HttpClient) :
 
     fun startPollingBlocking() {
         val jobs = pollingChannels.map { channel ->
-            launch {
+            launch(MDCContext()) {
                 logger.info("Starting polling coroutine for channel ${channel.botChannel}")
                 runPollingForChannel(channel)
             }


### PR DESCRIPTION
This PR adds transitive dependencies for gelf appenders for graylog and ensures fields for JAICP logging, such as accountId, channelId and requestId.