### PR TITLE
Make HttpClientFactory return HttpClient with non-strict deserialization

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/ChannelConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/ChannelConfig.kt
@@ -17,6 +17,5 @@ data class ChannelConfig(
     val tariffBlocked: Boolean?,
     val phraseCount: Long?,
     val knowledgeBasePhraseCount: Long?,
-    val externalBotToken: String?,
-    val blocked: Boolean
+    val externalBotToken: String?
 )

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/HttpClientFactory.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/HttpClientFactory.kt
@@ -1,10 +1,15 @@
 package com.justai.jaicf.channel.jaicp.http
 
-import io.ktor.client.*
-import io.ktor.client.engine.cio.*
-import io.ktor.client.features.json.*
-import io.ktor.client.features.json.serializer.*
-import io.ktor.client.features.logging.*
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.cio.endpoint
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.logging.DEFAULT
+import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.features.logging.Logger
+import io.ktor.client.features.logging.Logging
+import kotlinx.serialization.json.Json
 
 internal object HttpClientFactory {
     fun create(logLevel: LogLevel) = HttpClient(CIO) {
@@ -21,7 +26,7 @@ internal object HttpClientFactory {
             this.level = logLevel
         }
         install(JsonFeature) {
-            serializer = KotlinxSerializer()
+            serializer = KotlinxSerializer(Json.nonstrict)
         }
     }
 }


### PR DESCRIPTION
- Remove `blocked` property from `ChannelConfig`
- Make default ktor `HttpClient` non-strict