### PR TITLE
remove duplicate reactions and resolve state path

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
@@ -39,7 +39,7 @@ abstract class Reactions : ReactionRegistrar() {
      * @param path the path of the state to jump to. May be absolute or relative.
      * @param callbackState an optional callback state path. Bot engine activates this state once the sub-scenario returned some result through goBack or changeStateBack methods.
      */
-    fun go(path: String, callbackState: String? = null) {
+    fun go(path: String, callbackState: String? = null): GoReaction {
         val dialogContext = botContext.dialogContext
         val currentState = StatePath.parse(dialogContext.currentState)
         val resolved = currentState.resolve(path).toString()
@@ -48,7 +48,7 @@ abstract class Reactions : ReactionRegistrar() {
         callbackState?.let {
             dialogContext.backStateStack.push(currentState.resolve(it).toString())
         }
-        GoReaction.create(resolved)
+        return GoReaction.create(resolved)
     }
 
     /**
@@ -57,7 +57,7 @@ abstract class Reactions : ReactionRegistrar() {
      * @param path the path of the state to jump to. May be absolute or relative.
      * @param callbackState an optional callback state path. Bot engine activates this state once the sub-scenario returned some result through goBack or changeStateBack methods.
      */
-    fun changeState(path: String, callbackState: String? = null) {
+    fun changeState(path: String, callbackState: String? = null): ChangeStateReaction {
         val dialogContext = botContext.dialogContext
         val currentState = StatePath.parse(dialogContext.currentState)
         val resolved = currentState.resolve(path).toString()
@@ -66,7 +66,7 @@ abstract class Reactions : ReactionRegistrar() {
         callbackState?.let {
             dialogContext.backStateStack.push(currentState.resolve(it).toString())
         }
-        ChangeStateReaction.create(resolved)
+        return ChangeStateReaction.create(resolved)
     }
 
     /**

--- a/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
@@ -48,7 +48,7 @@ abstract class Reactions : ReactionRegistrar() {
         callbackState?.let {
             dialogContext.backStateStack.push(currentState.resolve(it).toString())
         }
-        GoReaction.create(path)
+        GoReaction.create(resolved)
     }
 
     /**
@@ -66,7 +66,7 @@ abstract class Reactions : ReactionRegistrar() {
         callbackState?.let {
             dialogContext.backStateStack.push(currentState.resolve(it).toString())
         }
-        ChangeStateReaction.create(path)
+        ChangeStateReaction.create(resolved)
     }
 
     /**
@@ -81,7 +81,6 @@ abstract class Reactions : ReactionRegistrar() {
         result?.let { botContext.result = it }
         return state?.also {
             go(it)
-            GoReaction.create(it)
         }
     }
 
@@ -97,7 +96,6 @@ abstract class Reactions : ReactionRegistrar() {
         result?.let { botContext.result = it }
         return state?.also {
             changeState(it)
-            ChangeStateReaction.create(it)
         }
     }
 


### PR DESCRIPTION
This pull request solves two found issues: 
1. Removes duplicate reaction creation
2. Pushes resolved state path to reaction instead of relative. 