### PR TITLE
New Alexa channel name in jaicp compatible channel factory

### DIFF
--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaChannel.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaChannel.kt
@@ -23,7 +23,7 @@ class AlexaChannel(
     }
 
     companion object : JaicpCompatibleChannelFactory {
-        override val channelType = "alexa"
+        override val channelType = "jaicp_alexa"
         override fun create(botApi: BotApi) = AlexaChannel(botApi)
     }
 }


### PR DESCRIPTION
@morfeusys JAICP new Alexa implementation was named jaicp_alexa, so we change name here too. 