### PR TITLE
cleanup mdc setting

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -32,9 +32,6 @@ abstract class JaicpConnector(
 
     private val chatAdapterConnector = ChatAdapterConnector(accessToken, url, httpClient)
     private val registeredChannels = parseChannels()
-    protected val accountId = registeredChannels.first().second.accountId.also {
-        JaicpMDC.setAccountId(it)
-    }
 
     protected fun registerChannels() {
         registeredChannels.forEach { (factory, cfg) ->

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpMDC.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpMDC.kt
@@ -7,10 +7,6 @@ object JaicpMDC {
     fun setFromRequest(request: JaicpBotRequest) {
         MDC.put("requestId", request.questionId)
         MDC.put("channelId", request.channelBotId)
-    }
-
-    fun setAccountId(accountId: String) {
-        MDC.put("accountId", accountId)
+        MDC.put("accountId", request.channelBotId.split("-").first())
     }
 }
-

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
@@ -48,7 +48,6 @@ class JaicpWebhookConnector(
     }
 
     override fun process(request: HttpBotRequest): HttpBotResponse? {
-        JaicpMDC.setAccountId(accountId)
         val botRequest = request.receiveText()
             .also { logger.debug("Received botRequest: $it") }
             .asJaicpBotRequest()


### PR DESCRIPTION
This PR cleans up setting accountId in MDC. ChannelId contains accountId in suffix, so we can cleanup some of code. 