### PR TITLE
Enable stepup

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
@@ -66,7 +66,7 @@ abstract class BaseActivator(private val model: ScenarioModel) : Activator {
 
         val currentPath = StatePath.parse(currentState)
         val availableStates = mutableListOf(currentPath.toString()).apply {
-            if (!isModal) addAll(currentPath.parents)
+            if (!isModal) addAll(currentPath.parents.reversedArray())
         }
 
         val transitionsMap = model.transitions.groupBy { it.fromState }

--- a/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
@@ -66,7 +66,7 @@ abstract class BaseActivator(private val model: ScenarioModel) : Activator {
 
         val currentPath = StatePath.parse(currentState)
         val availableStates = mutableListOf(currentPath.toString()).apply {
-            if (isModal) addAll(currentPath.parents)
+            if (!isModal) addAll(currentPath.parents)
         }
 
         val transitionsMap = model.transitions.groupBy { it.fromState }

--- a/core/src/main/kotlin/com/justai/jaicf/activator/selection/ContextFirstActivationSelector.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/selection/ContextFirstActivationSelector.kt
@@ -19,12 +19,14 @@ class ContextFirstActivationSelector : ActivationSelector {
     ): Activation? {
         val current = botContext.dialogContext.currentContext
 
-        val toChildren = activations.filter { it.first.isFrom(current) }.maxBy { it.second.confidence }
-        val toCurrent = activations.filter { it.first.isTo(current) }.maxBy { it.second.confidence }
-        val fromRoot = activations.filter { it.first.isFromRoot }.maxBy { it.second.confidence }
+        val (transition, activatorContext) = activations.sortedWith(
+            compareByDescending<Pair<Transition, ActivatorContext>> {
+                it.first.fromState.commonPrefixWith(current).length
+            }.thenByDescending {
+                it.second.confidence
+            }
+        ).firstOrNull() ?: return null
 
-        val best = toChildren ?: toCurrent ?: fromRoot
-        return best?.let { Activation(it.first.toState, it.second) }
+        return Activation(transition.toState, activatorContext)
     }
-
 }

--- a/core/src/main/kotlin/com/justai/jaicf/activator/selection/ContextRankingActivationSelector.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/selection/ContextRankingActivationSelector.kt
@@ -15,8 +15,8 @@ import com.justai.jaicf.model.transition.Transition
  * 2. The current state itself;
  * 3. States available from the root of scenario.
  */
-open class ContextRankingActivationSelector :
-    ActivationSelector {
+// Let it be private while we don't fix it after step-ups enabled
+private open class ContextRankingActivationSelector : ActivationSelector {
     override fun selectActivation(
         botContext: BotContext,
         activations: List<Pair<Transition, ActivatorContext>>


### PR DESCRIPTION
- Step up now works as before. 
- `modal = true` disables step ups.
- `ContextRankingActivationSelector` is now hidden while we don't reimplement ranking