### PR TITLE
release 0.8.0 + simplify BotEngine constructor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
 
     group = "com.justai.jaicf"
-    version = "0.7.1"
+    version = "0.7.2"
 
     repositories {
         google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
 
     group = "com.justai.jaicf"
-    version = "0.7.2"
+    version = "0.8.0"
 
     repositories {
         google()

--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -184,14 +184,10 @@ class BotEngine(
         if (res is SlotFillingInterrupted) {
             botContext.finishSlotFilling()
             activationContext = state
-                ?.let {
-                    ActivationContext(
-                        null, Activation(
-                            state,
-                            StrictActivatorContext()
-                        )
-                    )
-                }
+                ?.let { ActivationContext(null, Activation(
+                    state,
+                    StrictActivatorContext()
+                )) }
                 ?: selectActivation(botContext, request)
         }
         return shouldReturn to activationContext

--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -57,7 +57,7 @@ import com.justai.jaicf.slotfilling.*
 class BotEngine(
     val model: ScenarioModel,
     val defaultContextManager: BotContextManager = InMemoryBotContextManager,
-    activators: Array<ActivatorFactory>,
+    activators: Array<ActivatorFactory> = emptyArray(),
     private val activationSelector: ActivationSelector = ActivationSelector.default,
     private val slotReactor: SlotReactor? = null,
     private val conversationLoggers: Array<ConversationLogger> = arrayOf(Slf4jConversationLogger())
@@ -184,10 +184,14 @@ class BotEngine(
         if (res is SlotFillingInterrupted) {
             botContext.finishSlotFilling()
             activationContext = state
-                ?.let { ActivationContext(null, Activation(
-                    state,
-                    StrictActivatorContext()
-                )) }
+                ?.let {
+                    ActivationContext(
+                        null, Activation(
+                            state,
+                            StrictActivatorContext()
+                        )
+                    )
+                }
                 ?: selectActivation(botContext, request)
         }
         return shouldReturn to activationContext


### PR DESCRIPTION
As since last changes we provide built-in activators, we don't need to make default BotEngine constructor so hard. 
+ 0.8.0