### PR TITLE
Jaicp plugin: make shadow version dynamic

### DIFF
--- a/gradle-plugins/jaicp-build-plugin/README.md
+++ b/gradle-plugins/jaicp-build-plugin/README.md
@@ -79,11 +79,15 @@ during the `jaicpBuild` task execution, but will remain unchanged if the `jaicpB
 you can use custom values for these properties for local `shadowJar` builds. 
 
 During _JAICP Cloud_ build these properties values can be accessed via the following project properties:
-```
-com.justai.jaicf.jaicp.build.jarFileName
-com.justai.jaicf.jaicp.build.jarDestinationDir
-```
+`com.justai.jaicf.jaicp.build.jarFileName` and `com.justai.jaicf.jaicp.build.jarDestinationDir`.
 
+By default the latest verion of the `ShadowPlugin` applies, but any versions greater than `5.0.0` are also supported.
+If you want to use a custom `ShadowJar` version, just apply the `ShadowJar` plugin with version specified:
+```
+plugins {
+    id("com.github.johnrengelman.shadow") version "5.2.0"
+}
+```
 
 If you don't need to customize the `shadowJar` or if you want to use different main classes for local development 
 and _JAICP Cloud_, you can provide `mainClassName` to the `jaicpBuld` task. In this case `mainClassName` will be 

--- a/gradle-plugins/jaicp-build-plugin/build.gradle.kts
+++ b/gradle-plugins/jaicp-build-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ gradlePlugin {
 
 dependencies {
     implementation(kotlin("stdlib", "1.3.61"))
-    implementation("com.github.jengelman.gradle.plugins", "shadow", "6.1.0")
+    implementation("com.github.jengelman.gradle.plugins", "shadow", "[5.0.0,)")
 }
 
 tasks {


### PR DESCRIPTION
Strict specifying the `ShadowPlugin` version will limit the user in Gradle versions. For example, Shadow 6+ supports only Gradle 6+.

I changed the shadow plugin dependency version to dynamic 5+, so the user can use any version down to 5.0.0, if he needs it. 

It allows user to use our plugin with Gradle 5+