### PR TITLE
Fix order of any-like rules

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/activator/event/EventActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/event/EventActivationRule.kt
@@ -6,4 +6,4 @@ abstract class EventActivationRule(val eventMatches: (String) -> Boolean): Activ
 
 open class EventByNameActivationRule(val event: String): EventActivationRule({ it == event})
 
-class AnyEventActivationRule: EventActivationRule({ true })
+class AnyEventActivationRule(val except: MutableList<String> = mutableListOf()): EventActivationRule({ it !in except })

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
@@ -6,4 +6,4 @@ abstract class IntentActivationRule(val intentMatches: (String) -> Boolean): Act
 
 open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it == intent })
 
-class AnyIntentActivationRule: IntentActivationRule({ true })
+class AnyIntentActivationRule(val except: MutableList<String> = mutableListOf()): IntentActivationRule({ it !in except })


### PR DESCRIPTION
Now any-like rules work as "any except defined explicitly"