### PR TITLE
Make JAICP integration extendable and open

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -1,8 +1,12 @@
 package com.justai.jaicf.channel.jaicp
 
 import com.justai.jaicf.api.BotApi
+import com.justai.jaicf.channel.http.asHttpBotRequest
+import com.justai.jaicf.channel.jaicp.channels.JaicpNativeBotChannel
 import com.justai.jaicf.channel.jaicp.channels.JaicpNativeChannelFactory
 import com.justai.jaicf.channel.jaicp.dto.ChannelConfig
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
 import com.justai.jaicf.channel.jaicp.http.ChatAdapterConnector
 import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.helpers.logging.WithLogger
@@ -80,6 +84,16 @@ abstract class JaicpConnector(
 
     protected fun getChannelProxyUrl(config: ChannelConfig) =
         "$proxyUrl/${config.channel}/${config.channelType.toLowerCase()}".toUrl()
+
+    protected open fun processJaicpRequest(request: JaicpBotRequest, channel: JaicpBotChannel) = when (channel) {
+        is JaicpNativeBotChannel -> channel.process(request)
+        is JaicpCompatibleBotChannel -> channel.processCompatible(request)
+        is JaicpCompatibleAsyncBotChannel -> {
+            channel.process(request.raw.asHttpBotRequest(request.stringify()))
+            null
+        }
+        else -> null
+    }
 }
 
 val JaicpConnector.proxyUrl: String

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
@@ -26,7 +26,7 @@ import io.ktor.client.features.logging.LogLevel
  * @param accessToken can be configured in JAICP Web Interface
  * @param channels is a list of channels which will be managed by connector
  * */
-class JaicpPollingConnector(
+open class JaicpPollingConnector(
     botApi: BotApi,
     accessToken: String,
     url: String = DEFAULT_PROXY_URL,
@@ -36,7 +36,7 @@ class JaicpPollingConnector(
 ) : JaicpConnector(botApi, channels, accessToken, url, httpClient),
     WithLogger {
 
-    private val dispatcher = Dispatcher(httpClient)
+    private val dispatcher = Dispatcher(httpClient, this::processJaicpRequest)
 
     init {
         loadConfig()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/channels/JaicpNativeChannel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/channels/JaicpNativeChannel.kt
@@ -20,9 +20,9 @@ abstract class JaicpNativeChannel(
     override val botApi: BotApi
 ) : JaicpNativeBotChannel, WithLogger {
 
-    internal abstract fun createRequest(request: JaicpBotRequest): BotRequest
+    abstract fun createRequest(request: JaicpBotRequest): BotRequest
 
-    internal abstract fun createReactions(): JaicpReactions
+    abstract fun createReactions(): JaicpReactions
 
     override fun process(request: HttpBotRequest): HttpBotResponse? {
         val botRequest = request.receiveText().asJaicpBotRequest()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -4,10 +4,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
 @Serializable
-internal sealed class Reply(val type: String)
+abstract class Reply(val type: String)
 
 @Serializable
-internal data class TextReply(
+data class TextReply(
     val text: String,
     val markup: String? = null,
     val tts: String? = null,
@@ -15,13 +15,13 @@ internal data class TextReply(
 ) : Reply("text")
 
 @Serializable
-internal data class Button(
+data class Button(
     val text: String,
     val transition: String? = null
 )
 
 @Serializable
-internal data class ButtonsReply(
+data class ButtonsReply(
     val buttons: List<Button>,
     val state: String? = null
 ) : Reply("buttons") {
@@ -29,23 +29,23 @@ internal data class ButtonsReply(
 }
 
 @Serializable
-internal data class ImageReply(
+data class ImageReply(
     val imageUrl: String,
     val text: String? = null,
     val state: String? = null
 ) : Reply("image")
 
 @Serializable
-internal data class AudioReply(
+data class AudioReply(
     val audioUrl: String,
     val state: String? = null
 ) : Reply("audio")
 
 @Serializable
-internal class HangupReply(val state: String? = null) : Reply("hangup")
+class HangupReply(val state: String? = null) : Reply("hangup")
 
 @Serializable
-internal data class SwitchReply(
+data class SwitchReply(
     val phoneNumber: String? = null,
     val headers: Map<String, String> = emptyMap(),
     val firstMessage: String? = null,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -1,10 +1,13 @@
 package com.justai.jaicf.channel.jaicp.dto
 
+import com.justai.jaicf.channel.jaicp.JSON
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
 @Serializable
-abstract class Reply(val type: String)
+abstract class Reply(val type: String) {
+    abstract fun serialized(): String
+}
 
 @Serializable
 data class TextReply(
@@ -12,7 +15,9 @@ data class TextReply(
     val markup: String? = null,
     val tts: String? = null,
     val state: String? = null
-) : Reply("text")
+) : Reply("text") {
+    override fun serialized() = JSON.stringify(serializer(), this)
+}
 
 @Serializable
 data class Button(
@@ -26,6 +31,8 @@ data class ButtonsReply(
     val state: String? = null
 ) : Reply("buttons") {
     constructor(button: Button) : this(arrayListOf(button))
+
+    override fun serialized() = JSON.stringify(serializer(), this)
 }
 
 @Serializable
@@ -33,16 +40,23 @@ data class ImageReply(
     val imageUrl: String,
     val text: String? = null,
     val state: String? = null
-) : Reply("image")
+) : Reply("image") {
+    override fun serialized() = JSON.stringify(serializer(), this)
+}
 
 @Serializable
 data class AudioReply(
     val audioUrl: String,
     val state: String? = null
-) : Reply("audio")
+) : Reply("audio") {
+
+    override fun serialized() = JSON.stringify(serializer(), this)
+}
 
 @Serializable
-class HangupReply(val state: String? = null) : Reply("hangup")
+class HangupReply(val state: String? = null) : Reply("hangup") {
+    override fun serialized() = JSON.stringify(serializer(), this)
+}
 
 @Serializable
 data class SwitchReply(
@@ -54,4 +68,6 @@ data class SwitchReply(
     val ignoreOffline: Boolean? = false,
     val destination: String? = null,
     val attributes: JsonObject? = null
-) : Reply("switch")
+) : Reply("switch") {
+    override fun serialized() = JSON.stringify(serializer(), this)
+}

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
@@ -1,10 +1,9 @@
 package com.justai.jaicf.channel.jaicp.reactions
 
-import com.justai.jaicf.channel.jaicp.JSON
 import com.justai.jaicf.channel.jaicp.dto.*
+import com.justai.jaicf.channel.jaicp.toJson
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.logging.SayReaction
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.json
 import kotlinx.serialization.json.jsonArray
@@ -21,28 +20,8 @@ open class JaicpReactions : Reactions() {
     }
 
     fun collect(): JsonObject {
-        val jsonReplies: List<JsonElement> = replies.mapNotNull { reply ->
-            when (reply) {
-                is TextReply -> JSON.toJson(
-                    TextReply.serializer(), reply
-                )
-                is ButtonsReply -> JSON.toJson(
-                    ButtonsReply.serializer(), reply
-                )
-                is ImageReply -> JSON.toJson(
-                    ImageReply.serializer(), reply
-                )
-                is AudioReply -> JSON.toJson(
-                    AudioReply.serializer(), reply
-                )
-                is HangupReply -> JSON.toJson(
-                    HangupReply.serializer(), reply
-                )
-                is SwitchReply -> JSON.toJson(
-                    SwitchReply.serializer(), reply
-                )
-                else -> null
-            }
+        val jsonReplies = replies.map { reply ->
+            reply.serialized().toJson()
         }
 
         val answer = replies.joinToString(separator = "\n\n") {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.jsonArray
 
 open class JaicpReactions : Reactions() {
 
-    internal val replies: MutableList<Reply> = mutableListOf()
+    protected val replies: MutableList<Reply> = mutableListOf()
 
     internal fun getCurrentState() = botContext.dialogContext.currentState
 
@@ -21,7 +21,7 @@ open class JaicpReactions : Reactions() {
     }
 
     fun collect(): JsonObject {
-        val jsonReplies: List<JsonElement> = replies.map { reply ->
+        val jsonReplies: List<JsonElement> = replies.mapNotNull { reply ->
             when (reply) {
                 is TextReply -> JSON.toJson(
                     TextReply.serializer(), reply
@@ -41,6 +41,7 @@ open class JaicpReactions : Reactions() {
                 is SwitchReply -> JSON.toJson(
                     SwitchReply.serializer(), reply
                 )
+                else -> null
             }
         }
 

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
@@ -30,7 +30,7 @@ object TelephonyBotScenario : Scenario(), WithLogger {
             }
         }
 
-        state("hangup") {
+        state("bye") {
             activators {
                 intent("bye")
             }


### PR DESCRIPTION
The purpose of this PR is to make JAICP channel and JAICP integrations easier to extend.

- removes internal modifiers in some classes
- refactor and simplify code in jaicp connectors
- make some classes open and fields protected

