### PR TITLE
#43 add strict transitions from buttons

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -6,6 +6,7 @@ import com.justai.jaicf.channel.jaicp.dto.ImageReply
 import com.justai.jaicf.logging.ButtonsReaction
 import com.justai.jaicf.logging.ImageReaction
 import com.justai.jaicf.reactions.Reactions
+import com.justai.jaicf.reactions.buttons
 
 val Reactions.chatwidget
     get() = this as? ChatWidgetReactions
@@ -20,10 +21,8 @@ class ChatWidgetReactions : JaicpReactions() {
         return ImageReaction.create(imageUrl)
     }
 
-    fun button(text: String, transition: String? = null): ButtonsReaction {
-        replies.add(ButtonsReply(Button(text, transition)))
-        return ButtonsReaction.create(listOf(text))
-    }
+    fun button(text: String, transition: String? = null): ButtonsReaction =
+        transition?.let { buttons(text to transition) } ?: buttons(text)
 
     override fun buttons(vararg buttons: String): ButtonsReaction {
         return buttons(buttons.asList())

--- a/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
@@ -2,6 +2,8 @@ package com.justai.jaicf.context
 
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.helpers.action.smartRandom
+import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.model.state.StatePath
 import com.justai.jaicf.reactions.Reactions
 import kotlin.random.Random
 
@@ -73,4 +75,11 @@ open class ActionContext(
      * @param texts a list of String to select random from
      */
     fun Reactions.sayRandom(texts: List<String>) = say(random(texts))
+
+    infix fun ButtonsReaction?.toStates(states: List<String>) {
+        this?.buttons?.zip(states)?.forEach { (text, state) ->
+            context.dialogContext.transitions[text] =
+                StatePath.parse(context.dialogContext.currentState).resolve(state).toString()
+        }
+    }
 }

--- a/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
@@ -132,3 +132,15 @@ abstract class Reactions : ReactionRegistrar() {
     open fun audio(url: String): AudioReaction = AudioReaction(url, currentState)
 }
 
+typealias ButtonToState = Pair<String, String>
+
+fun Reactions.buttons(vararg buttons: ButtonToState): ButtonsReaction {
+    buttons.forEach { (text, transition) ->
+        botContext.dialogContext.transitions[text] = resolveStatePath(transition)
+    }
+    return buttons(*buttons.map { it.first }.toTypedArray())
+}
+
+private fun Reactions.resolveStatePath(statePath: String) =
+    StatePath.parse(botContext.dialogContext.currentState).resolve(statePath).toString()
+

--- a/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
@@ -134,13 +134,16 @@ abstract class Reactions : ReactionRegistrar() {
 
 typealias ButtonToState = Pair<String, String>
 
+/**
+ * Appends buttons with transitions to response.
+ * When button is clicked, a corresponding state will activate
+ *
+ * @param buttons a collection with button texts to states
+ * */
 fun Reactions.buttons(vararg buttons: ButtonToState): ButtonsReaction {
     buttons.forEach { (text, transition) ->
-        botContext.dialogContext.transitions[text] = resolveStatePath(transition)
+        botContext.dialogContext.transitions[text] =
+            StatePath.parse(botContext.dialogContext.currentState).resolve(transition).toString()
     }
     return buttons(*buttons.map { it.first }.toTypedArray())
 }
-
-private fun Reactions.resolveStatePath(statePath: String) =
-    StatePath.parse(botContext.dialogContext.currentState).resolve(statePath).toString()
-

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
@@ -11,6 +11,7 @@ import com.justai.jaicf.channel.facebook.facebook
 import com.justai.jaicf.channel.googleactions.dialogflow.DialogflowIntent
 import com.justai.jaicf.channel.telegram.telegram
 import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.reactions.buttons
 
 object HelloWorldScenario: Scenario(
     dependencies = listOf(HelperScenario)
@@ -44,7 +45,7 @@ object HelloWorldScenario: Scenario(
                     reactions.run {
                         image("https://www.bluecross.org.uk/sites/default/files/d8/assets/images/118809lprLR.jpg")
                         sayRandom("Hello $name!", "Hi $name!", "Glad to hear you $name!")
-                        buttons("Mew", "Wake up")
+                        buttons("Mew" to "/mew", "Wake up" to "/wakeup")
                         aimybox?.endConversation()
                     }
                 }


### PR DESCRIPTION
This pull request makes use of strict transitions with buttons. 
After it's merged, it will be possible to write:
```
reactions.buttons("Mew" to "/mew", "Wake up" to "/wakeup")
```

And when `Mew` or `Wake up` is clicked, corresponding state `/mew` or `/wakeup` will be activated.
