### PR TITLE
#43 strict transitions impl with buttons

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -6,6 +6,7 @@ import com.justai.jaicf.channel.jaicp.dto.ImageReply
 import com.justai.jaicf.logging.ButtonsReaction
 import com.justai.jaicf.logging.ImageReaction
 import com.justai.jaicf.reactions.Reactions
+import com.justai.jaicf.reactions.buttons
 
 val Reactions.chatwidget
     get() = this as? ChatWidgetReactions
@@ -20,10 +21,8 @@ class ChatWidgetReactions : JaicpReactions() {
         return ImageReaction.create(imageUrl)
     }
 
-    fun button(text: String, transition: String? = null): ButtonsReaction {
-        replies.add(ButtonsReply(Button(text, transition)))
-        return ButtonsReaction.create(listOf(text))
-    }
+    fun button(text: String, transition: String? = null): ButtonsReaction =
+        transition?.let { buttons(text to transition) } ?: buttons(text)
 
     override fun buttons(vararg buttons: String): ButtonsReaction {
         return buttons(buttons.asList())

--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -13,7 +13,7 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.*
 import com.justai.jaicf.context.manager.BotContextManager
 import com.justai.jaicf.context.manager.InMemoryBotContextManager
-import com.justai.jaicf.helpers.kotlin.runIfTrueElseNull
+import com.justai.jaicf.helpers.kotlin.ifTrue
 import com.justai.jaicf.helpers.logging.WithLogger
 import com.justai.jaicf.hook.*
 import com.justai.jaicf.logging.ConversationLogger
@@ -108,7 +108,7 @@ class BotEngine(
 
         withHook(BotRequestHook(botContext, request, reactions)) {
             val activation = botContext.isActiveSlotFilling().not()
-                .runIfTrueElseNull { selectActivation(botContext, request) }
+                .ifTrue { selectActivation(botContext, request) }
                 .withAppliedSlotFilling(botContext, request, reactions, cm)
                 .let { if (it.first) return else it.second }
 

--- a/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
@@ -77,15 +77,7 @@ abstract class BaseActivator(private val model: ScenarioModel) : Activator {
             override fun match(rule: ActivationRule) = (rule as? R)?.let(matcher)
         }
 
-    /**
-     * Generates a list of transitions for current [BaseActivator] implementation.
-     *
-     * Generally, transitions are computed from scenario model.
-     * This may be overridden if you need to add non-scenario transitions.
-     *
-     * @param botContext a current user's [BotContext]
-     * */
-    protected open fun generateTransitions(botContext: BotContext): List<Transition> {
+    private fun generateTransitions(botContext: BotContext): List<Transition> {
         val currentState = botContext.dialogContext.currentContext
         val isModal = currentState != "/" && model.states[currentState]?.modal
                 ?: error("State $currentState is not registered in model")

--- a/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/BaseActivator.kt
@@ -77,7 +77,15 @@ abstract class BaseActivator(private val model: ScenarioModel) : Activator {
             override fun match(rule: ActivationRule) = (rule as? R)?.let(matcher)
         }
 
-    private fun generateTransitions(botContext: BotContext): List<Transition> {
+    /**
+     * Generates a list of transitions for current [BaseActivator] implementation.
+     *
+     * Generally, transitions are computed from scenario model.
+     * This may be overridden if you need to add non-scenario transitions.
+     *
+     * @param botContext a current user's [BotContext]
+     * */
+    protected open fun generateTransitions(botContext: BotContext): List<Transition> {
         val currentState = botContext.dialogContext.currentContext
         val isModal = currentState != "/" && model.states[currentState]?.modal
                 ?: error("State $currentState is not registered in model")

--- a/core/src/main/kotlin/com/justai/jaicf/activator/strict/ButtonActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/strict/ButtonActivator.kt
@@ -10,7 +10,7 @@ import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.model.activation.Activation
 import com.justai.jaicf.model.scenario.ScenarioModel
 
-class ButtonActivator : Activator {
+internal class ButtonActivator : Activator {
 
     override val name = "buttonActivator"
 

--- a/core/src/main/kotlin/com/justai/jaicf/activator/strict/ButtonActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/strict/ButtonActivator.kt
@@ -1,0 +1,34 @@
+package com.justai.jaicf.activator.strict
+
+import com.justai.jaicf.activator.ActivatorFactory
+import com.justai.jaicf.activator.BaseActivator
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.api.hasQuery
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.StrictActivatorContext
+import com.justai.jaicf.model.scenario.ScenarioModel
+import com.justai.jaicf.model.transition.Transition
+
+class ButtonActivator(model: ScenarioModel) : BaseActivator(model) {
+
+    override val name = "buttonActivator"
+
+    override fun canHandle(request: BotRequest) = request.hasQuery()
+
+    override fun provideRuleMatcher(botContext: BotContext, request: BotRequest) =
+        ruleMatcher<StrictActivationRule> {
+            val req = request.input.toLowerCase()
+            val strictTransitions = botContext.dialogContext.transitions
+            strictTransitions[req]
+                ?.let { StrictActivatorContext() }
+                .also { strictTransitions.clear() }
+        }
+
+    companion object : ActivatorFactory {
+        override fun create(model: ScenarioModel) = ButtonActivator(model)
+    }
+
+    override fun generateTransitions(botContext: BotContext) = botContext.dialogContext.transitions.map {
+        Transition(botContext.dialogContext.currentContext, it.value, StrictActivationRule())
+    }
+}

--- a/core/src/main/kotlin/com/justai/jaicf/activator/strict/ButtonActivator.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/strict/ButtonActivator.kt
@@ -1,34 +1,29 @@
 package com.justai.jaicf.activator.strict
 
+import com.justai.jaicf.activator.Activator
 import com.justai.jaicf.activator.ActivatorFactory
-import com.justai.jaicf.activator.BaseActivator
+import com.justai.jaicf.activator.selection.ActivationSelector
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.hasQuery
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.StrictActivatorContext
+import com.justai.jaicf.model.activation.Activation
 import com.justai.jaicf.model.scenario.ScenarioModel
-import com.justai.jaicf.model.transition.Transition
 
-class ButtonActivator(model: ScenarioModel) : BaseActivator(model) {
+class ButtonActivator : Activator {
 
     override val name = "buttonActivator"
 
-    override fun canHandle(request: BotRequest) = request.hasQuery()
+    override fun canHandle(request: BotRequest): Boolean = request.hasQuery()
 
-    override fun provideRuleMatcher(botContext: BotContext, request: BotRequest) =
-        ruleMatcher<StrictActivationRule> {
-            val req = request.input.toLowerCase()
-            val strictTransitions = botContext.dialogContext.transitions
-            strictTransitions[req]
-                ?.let { StrictActivatorContext() }
-                .also { strictTransitions.clear() }
-        }
-
-    companion object : ActivatorFactory {
-        override fun create(model: ScenarioModel) = ButtonActivator(model)
+    override fun activate(botContext: BotContext, request: BotRequest, selector: ActivationSelector): Activation? {
+        val req = request.input.toLowerCase()
+        val strictTransitions = botContext.dialogContext.transitions
+        val context = strictTransitions[req].also { strictTransitions.clear() }
+        return context?.let { Activation(it, StrictActivatorContext()) }
     }
 
-    override fun generateTransitions(botContext: BotContext) = botContext.dialogContext.transitions.map {
-        Transition(botContext.dialogContext.currentContext, it.value, StrictActivationRule())
+    companion object : ActivatorFactory {
+        override fun create(model: ScenarioModel) = ButtonActivator()
     }
 }

--- a/core/src/main/kotlin/com/justai/jaicf/activator/strict/StrictActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/strict/StrictActivationRule.kt
@@ -1,0 +1,5 @@
+package com.justai.jaicf.activator.strict
+
+import com.justai.jaicf.model.activation.ActivationRule
+
+class StrictActivationRule : ActivationRule

--- a/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
@@ -2,6 +2,8 @@ package com.justai.jaicf.context
 
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.helpers.action.smartRandom
+import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.model.state.StatePath
 import com.justai.jaicf.reactions.Reactions
 import kotlin.random.Random
 
@@ -73,4 +75,11 @@ open class ActionContext(
      * @param texts a list of String to select random from
      */
     fun Reactions.sayRandom(texts: List<String>) = say(random(texts))
+
+    infix fun ButtonsReaction?.toStates(states: List<String>) {
+        this?.buttons?.zip(states)?.forEach { (text, state) ->
+            context.dialogContext.transitions[text.toLowerCase()] =
+                StatePath.parse(context.dialogContext.currentState).resolve(state).toString()
+        }
+    }
 }

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/kotlin/Extensions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/kotlin/Extensions.kt
@@ -1,3 +1,3 @@
 package com.justai.jaicf.helpers.kotlin
 
-internal fun <T> Boolean.runIfTrueElseNull(function: () -> T?): T? = if (this) function.invoke() else null
+internal fun <T> Boolean.ifTrue(function: () -> T?): T? = if (this) function.invoke() else null

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/kotlin/Extensions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/kotlin/Extensions.kt
@@ -1,0 +1,3 @@
+package com.justai.jaicf.helpers.kotlin
+
+internal fun <T> Boolean.runIfTrueElseNull(function: () -> T?): T? = if (this) function.invoke() else null

--- a/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
@@ -132,3 +132,18 @@ abstract class Reactions : ReactionRegistrar() {
     open fun audio(url: String): AudioReaction = AudioReaction(url, currentState)
 }
 
+typealias ButtonToState = Pair<String, String>
+
+/**
+ * Appends buttons with transitions to response.
+ * When button is clicked, a corresponding state will activate
+ *
+ * @param buttons a collection with button texts to states
+ * */
+fun Reactions.buttons(vararg buttons: ButtonToState): ButtonsReaction {
+    buttons.forEach { (text, transition) ->
+        botContext.dialogContext.transitions[text.toLowerCase()] =
+            StatePath.parse(botContext.dialogContext.currentState).resolve(transition).toString()
+    }
+    return buttons(*buttons.map { it.first }.toTypedArray())
+}

--- a/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/reactions/Reactions.kt
@@ -136,7 +136,7 @@ typealias ButtonToState = Pair<String, String>
 
 /**
  * Appends buttons with transitions to response.
- * When button is clicked, a corresponding state will activate
+ * When button is clicked, a corresponding state will be activated
  *
  * @param buttons a collection with button texts to states
  * */

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/activators/StrictActivatorsTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/activators/StrictActivatorsTest.kt
@@ -1,0 +1,58 @@
+package com.justai.jaicf.core.test.activators
+
+import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.reactions.buttons
+import com.justai.jaicf.test.ScenarioTest
+import org.junit.jupiter.api.Test
+
+private val strictActivationScenario = object : Scenario() {
+    init {
+        state("activate") {
+            activators {
+                regex("activate")
+            }
+            action {
+                reactions.buttons("test" to "/test")
+            }
+        }
+
+        state("test") {
+            action {
+                reactions.say("test is fine")
+            }
+        }
+
+        state("notActivate"){
+            activators {
+                regex("notActivate")
+            }
+        }
+
+        fallback {  }
+    }
+}
+
+class StrictActivatorsTest : ScenarioTest(strictActivationScenario.model) {
+
+    @Test
+    fun `should activate strict transition`() {
+        query("activate") goesToState "/activate"
+        query("test") goesToState "/test"
+    }
+
+    @Test
+    fun `should not activate strict transition`() {
+        query("notActivate") goesToState "/notActivate"
+        query("test") goesToState "/fallback"
+    }
+
+    @Test
+    fun `should clear strict transitions on activation`() {
+        query("activate") goesToState "/activate"
+        query("notActivate") goesToState "/notActivate"
+        query("test") goesToState "/fallback"
+
+        query("activate") goesToState "/activate"
+        query("test") goesToState "/test"
+    }
+}

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
@@ -11,6 +11,7 @@ import com.justai.jaicf.channel.facebook.facebook
 import com.justai.jaicf.channel.googleactions.dialogflow.DialogflowIntent
 import com.justai.jaicf.channel.telegram.telegram
 import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.reactions.buttons
 
 object HelloWorldScenario: Scenario(
     dependencies = listOf(HelperScenario)
@@ -44,7 +45,7 @@ object HelloWorldScenario: Scenario(
                     reactions.run {
                         image("https://www.bluecross.org.uk/sites/default/files/d8/assets/images/118809lprLR.jpg")
                         sayRandom("Hello $name!", "Hi $name!", "Glad to hear you $name!")
-                        buttons("Mew", "Wake up")
+                        buttons("Mew" to "/mew", "Wake up" to "wakeup")
                         aimybox?.endConversation()
                     }
                 }


### PR DESCRIPTION
This pull request makes use of strict transitions with buttons.
After it's merged, it will be possible to write:
```
reactions.buttons("Mew" to "/mew", "Wake up" to "/wakeup")
```
And when Mew or Wake up is clicked, corresponding state /mew or /wakeup will be activated.