### PR TITLE
Add multiple-intent activator

### DIFF
--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceResultData.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceResultData.kt
@@ -20,7 +20,7 @@ data class CailaIntentData(
     val customData: String?,
     val slots: List<CailaSlotData>?
 )  : java.io.Serializable{
-    val name = path.substring(path.lastIndexOf('/') + 1)
+    val name = path.substring(1)
 }
 
 @Serializable

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
@@ -6,6 +6,6 @@ abstract class IntentActivationRule(val intentMatches: (String) -> Boolean): Act
 
 open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it == intent })
 
-class AnyIntentActivationRule(val except: MutableList<String> = mutableListOf()): IntentActivationRule({ it !in except })
+class IntentByPrefixActivationRule(val prefix: String): IntentActivationRule({ it.startsWith(prefix) })
 
-class ThemeActivationRule(val theme: String): IntentActivationRule({ it.startsWith(theme) })
+class AnyIntentActivationRule(val except: MutableList<String> = mutableListOf()): IntentActivationRule({ it !in except })

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
@@ -7,3 +7,5 @@ abstract class IntentActivationRule(val intentMatches: (String) -> Boolean): Act
 open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it == intent })
 
 class AnyIntentActivationRule(val except: MutableList<String> = mutableListOf()): IntentActivationRule({ it !in except })
+
+class ThemeActivationRule(val theme: String): IntentActivationRule({ it.startsWith(theme) })

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
@@ -4,7 +4,7 @@ import com.justai.jaicf.model.activation.ActivationRule
 
 abstract class IntentActivationRule(val intentMatches: (String) -> Boolean): ActivationRule
 
-open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it == intent })
+open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it.substring(it.lastIndexOf("/") + 1) == intent })
 
 class IntentByPrefixActivationRule(val prefix: String): IntentActivationRule({ it.startsWith(prefix) })
 

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -5,6 +5,7 @@ import com.justai.jaicf.activator.event.AnyEventActivationRule
 import com.justai.jaicf.activator.event.EventByNameActivationRule
 import com.justai.jaicf.activator.intent.AnyIntentActivationRule
 import com.justai.jaicf.activator.intent.IntentByNameActivationRule
+import com.justai.jaicf.activator.intent.ThemeActivationRule
 import com.justai.jaicf.activator.regex.RegexActivationRule
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.hook.BotHook
@@ -310,6 +311,19 @@ abstract class ScenarioBuilder(
             fromState,
             toState,
             IntentByNameActivationRule(intent)
+        ))
+
+        /**
+         * Appends a theme activator to this state. Means that any intent with its name beginning with such a theme can activate this state.
+         * Requires a [com.justai.jaicf.activator.intent.IntentActivator] in the activators' list of your [com.justai.jaicf.api.BotApi] instance.
+         *
+         * @see com.justai.jaicf.activator.intent.IntentActivator
+         * @see com.justai.jaicf.api.BotApi
+         */
+        fun theme(theme: String) = add(Transition(
+            fromState,
+            toState,
+            ThemeActivationRule(theme)
         ))
 
         /**

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -5,7 +5,7 @@ import com.justai.jaicf.activator.event.AnyEventActivationRule
 import com.justai.jaicf.activator.event.EventByNameActivationRule
 import com.justai.jaicf.activator.intent.AnyIntentActivationRule
 import com.justai.jaicf.activator.intent.IntentByNameActivationRule
-import com.justai.jaicf.activator.intent.ThemeActivationRule
+import com.justai.jaicf.activator.intent.IntentByPrefixActivationRule
 import com.justai.jaicf.activator.regex.RegexActivationRule
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.hook.BotHook
@@ -314,16 +314,16 @@ abstract class ScenarioBuilder(
         ))
 
         /**
-         * Appends a theme activator to this state. Means that any intent with its name beginning with such a theme can activate this state.
+         * Appends a multiple-intent activator to this state. Means that any intent having such a prefix can activate this state.
          * Requires a [com.justai.jaicf.activator.intent.IntentActivator] in the activators' list of your [com.justai.jaicf.api.BotApi] instance.
          *
          * @see com.justai.jaicf.activator.intent.IntentActivator
          * @see com.justai.jaicf.api.BotApi
          */
-        fun theme(theme: String) = add(Transition(
+        fun intents(prefix: String) = add(Transition(
             fromState,
             toState,
-            ThemeActivationRule(theme)
+            IntentByPrefixActivationRule(prefix)
         ))
 
         /**

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/activators/IntentActivatorTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/activators/IntentActivatorTest.kt
@@ -12,9 +12,9 @@ private val intentActivationScenario = object : Scenario() {
             }
         }
 
-        state("theme") {
+        state("intents") {
             activators {
-                theme("/bar")
+                intents("/bar")
             }
         }
 
@@ -32,7 +32,7 @@ class IntentActivatorTest : ScenarioTest(intentActivationScenario.model) {
 
     @Test
     fun `should activate on any intent with the same prefix`() {
-        intent("/bar") goesToState "/theme"
-        intent("/bar/baz") goesToState "/theme"
+        intent("/bar") goesToState "/intents"
+        intent("/bar/baz") goesToState "/intents"
     }
 }

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/activators/IntentActivatorTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/activators/IntentActivatorTest.kt
@@ -1,0 +1,38 @@
+package com.justai.jaicf.core.test.activators
+
+import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.test.ScenarioTest
+import org.junit.jupiter.api.Test
+
+private val intentActivationScenario = object : Scenario() {
+    init {
+        state("intent") {
+            activators {
+                intent("/foo")
+            }
+        }
+
+        state("theme") {
+            activators {
+                theme("/bar")
+            }
+        }
+
+        fallback {  }
+    }
+}
+
+class IntentActivatorTest : ScenarioTest(intentActivationScenario.model) {
+
+    @Test
+    fun `should activate on strict intent match only`() {
+        intent("/foo") goesToState "/intent"
+        intent("/foo/bar") goesToState "/fallback"
+    }
+
+    @Test
+    fun `should activate on any intent with the same prefix`() {
+        intent("/bar") goesToState "/theme"
+        intent("/bar/baz") goesToState "/theme"
+    }
+}

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/activators/IntentActivatorTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/activators/IntentActivatorTest.kt
@@ -8,13 +8,13 @@ private val intentActivationScenario = object : Scenario() {
     init {
         state("intent") {
             activators {
-                intent("/foo")
+                intent("foo")
             }
         }
 
         state("intents") {
             activators {
-                intents("/bar")
+                intents("bar")
             }
         }
 
@@ -26,13 +26,13 @@ class IntentActivatorTest : ScenarioTest(intentActivationScenario.model) {
 
     @Test
     fun `should activate on strict intent match only`() {
-        intent("/foo") goesToState "/intent"
-        intent("/foo/bar") goesToState "/fallback"
+        intent("foo") goesToState "/intent"
+        intent("foo/bar") goesToState "/fallback"
     }
 
     @Test
     fun `should activate on any intent with the same prefix`() {
-        intent("/bar") goesToState "/intents"
-        intent("/bar/baz") goesToState "/intents"
+        intent("bar") goesToState "/intents"
+        intent("bar/baz") goesToState "/intents"
     }
 }


### PR DESCRIPTION
Hi!

This PR adds a public `intents` activator, which activates a state on any intent having the same prefix as the one provided.

The motivation behind this is that my classifier has a number of intents (FAQ intents in my case) that all need to be processed in the same way, e.g.
```kotlin
activators {
    intent("FAQ/Address")
    intent("FAQ/BusinessHours")
    intent("FAQ/WorkEmail")
    intent("FAQ/WorkPhone")
    // ...
}

action {
    activator.caila?.topIntent?.answer?.let {
        reactions.say(it)
    }
}
```

Adding all intents like this would be tedious and non-scalable, and I can’t use `anyIntent()` since there are other intents in my classifier that have nothing to do with FAQ.

This feature solves the problem and allows rewriting the example above simply as
```kotlin
activators {
    intents("FAQ")
}
```