### PR TITLE
use tomcat servlet api instead of javax

### DIFF
--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -12,7 +12,7 @@ object Version {
     const val ktor = "1.3.1"
     const val serializationRuntime = "0.14.0"
     const val coroutinesCore = "1.3.3"
-    const val javaxServletApi = "3.0.1"
+    const val tomcatServletApi = "6.0.53"
     const val logbackGelfAppender = "1.5"
 }
 

--- a/channels/facebook/src/main/java/com/justai/jaicf/channel/facebook/messenger/LICENSE
+++ b/channels/facebook/src/main/java/com/justai/jaicf/channel/facebook/messenger/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2017 Max Grabenhorst
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/channels/jaicp/build.gradle.kts
+++ b/channels/jaicp/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     implementation(project(":core"))
     implementation(kotlin("stdlib", Version.stdLib))
 
-    implementation("javax.servlet:javax.servlet-api" version { javaxServletApi })
+    implementation("org.apache.tomcat:servlet-api" version { tomcatServletApi })
     implementation("de.appelgriepsch.logback:logback-gelf-appender" version { logbackGelfAppender })
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j" version { coroutinesCore })
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpServlet.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpServlet.kt
@@ -36,13 +36,13 @@ open class JaicpServlet(private val connector: JaicpWebhookConnector) : HttpBotC
     }
 
     private fun HttpServletResponse.ok() {
-        status = HttpServletResponse.SC_OK
+        setStatus(HttpServletResponse.SC_OK)
         writer.write("OK")
         writer.flush()
     }
 
     private fun HttpServletResponse.notFound(message: String) {
-        status = HttpServletResponse.SC_NOT_FOUND
+        setStatus(HttpServletResponse.SC_NOT_FOUND)
         writer.write(message)
         writer.flush()
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 
     api("org.slf4j:slf4j-api" version {slf4j})
 
-    implementation("javax.servlet:javax.servlet-api" version {javaxServletApi})
+    implementation("org.apache.tomcat:servlet-api" version { tomcatServletApi })
     implementation("io.ktor:ktor-server-core" version {ktor})
     implementation("org.junit.jupiter:junit-jupiter-api" version {jUnit})
 

--- a/core/src/main/java/com/justai/jaicf/helpers/java/WeakIdentityHashMap.java
+++ b/core/src/main/java/com/justai/jaicf/helpers/java/WeakIdentityHashMap.java
@@ -1,26 +1,21 @@
 /*
- * Hibernate, Relational Persistence for Idiomatic Java
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
  *
- * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
- * indicated by the @author tags or express copyright attribution
- * statements applied by the authors.  All third-party contributions are
- * distributed under license by Red Hat, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This copyrighted material is made available to anyone wishing to use, modify,
- * copy, or redistribute it subject to the terms and conditions of the GNU
- * Lesser General Public License, as published by the Free Software Foundation.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this distribution; if not, write to:
- * Free Software Foundation, Inc.
- * 51 Franklin Street, Fifth Floor
- * Boston, MA  02110-1301  USA
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 
 package com.justai.jaicf.helpers.java;
 

--- a/core/src/main/kotlin/com/justai/jaicf/channel/http/HttpBotChannelServlet.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/channel/http/HttpBotChannelServlet.kt
@@ -11,16 +11,19 @@ import javax.servlet.http.HttpServletResponse
  * @param channel an [HttpBotChannel] implementation
  * @see HttpBotChannel
  */
+@Suppress("unchecked_cast")
 open class HttpBotChannelServlet(
     private val channel: HttpBotChannel
-): HttpServlet(), WithLogger {
+) : HttpServlet(), WithLogger {
 
     override fun doPost(req: HttpServletRequest?, resp: HttpServletResponse?) {
         req?.run {
             val request = HttpBotRequest(
                 stream = req.inputStream,
-                headers = req.headerNames.asSequence().map { it to listOf(req.getHeader(it)) }.toMap(),
-                parameters = req.parameterMap.mapValues { it.value.toList() }
+                headers = req.headerNames.asSequence().map { it as String to listOf(req.getHeader(it)) }.toMap(),
+                parameters = req.parameterMap.map { (k, v) ->
+                    (k as String) to (v as Array<out String>).toList()
+                }.toMap()
             )
 
             logger.info("{} received request {}", channel, request)
@@ -31,7 +34,7 @@ open class HttpBotChannelServlet(
             when (response) {
                 null -> resp?.sendError(HttpServletResponse.SC_NOT_FOUND, "Bot didn't respond")
                 else -> resp?.run {
-                    status = HttpServletResponse.SC_OK
+                    setStatus(HttpServletResponse.SC_OK)
 
                     contentType = response.contentType
                     response.headers.forEach { addHeader(it.key, it.value) }


### PR DESCRIPTION
Using javax servlet api under GPL license violated Apache 2.0 license as they are incompatible.

This PR suggests using tomcat servlet api, distributed under Apache 2.0 and compatible with Spring servletRegistrationBean