### PR TITLE
AWS Lambda and Dynamo DB support for Alexa skills

### DIFF
--- a/channels/alexa/README.md
+++ b/channels/alexa/README.md
@@ -121,14 +121,29 @@ class AlexaController: HttpBotChannelServlet(
 )
 ```
 
+Using [AWS Lambda](https://developer.amazon.com/en-US/docs/alexa/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html)
+
+```kotlin
+class AWSLambda: AlexaLambdaSkill(helloWorldBot)
+```
+
 #### 5. Configure Alexa Custom Skill
 
 Create and sign-in to your **Developer account** on [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask).
 
-Create new custom skill and setup a **HTTPS Endpoint** on the Build tab using your public URL of the webhook.
-_Select "My development endpoint is a sub-domain of a domain that has a wildcard certificate from a certificate authority" in the drop-down list._
+**Using external hosting**
 
-You can obtain a public URL of your webhook using [ngrok](https://ngrok.com) for example.
+- Create new custom skill and setup a **HTTPS Endpoint** on the Build tab using your public URL of the webhook.
+- Select "My development endpoint is a sub-domain of a domain that has a wildcard certificate from a certificate authority" in the drop-down list.
+
+> You can obtain a public URL of your webhook using [ngrok](https://ngrok.com) for example.
+In the case of using [JAICP](https://github.com/just-ai/jaicf-kotlin/tree/master/channels/jaicp) just create new Alexa channel and use its webhook URL.
+
+**Using AWS Lambda**
+
+- Create new [AWS Lambda](https://aws.amazon.com/lambda/) with Java 11 runtime and add _Alexa Skills Kit_ trigger.
+- Build your JAICF project using shadowJar [as described here](https://github.com/just-ai/jaicf-kotlin/blob/master/examples/game-clock/build.gradle.kts) and upload the resulting JAR file to your lambda.
+- Define the full name of your handler in _Runtime settings_, for example `com.justai.jaicf.examples.gameclock.channel.AWSLambda::handleRequest`
 
 #### 6. Provide custom intents
 
@@ -214,3 +229,15 @@ reactions.say("Hello there! $break500ms Let's listen this audio ${audio("https:/
 ```
 
 > Learn more about available SSML helpers [here](https://github.com/just-ai/jaicf-kotlin/blob/master/core/src/main/kotlin/com/justai/jaicf/helpers/ssml/SSML.kt).
+
+### Using AWS Lambda and DynamoDB
+
+Amazon provides an [AWS Lambda](https://developer.amazon.com/en-US/docs/alexa/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html) serverless cloud that can host your Alexa voice skills.
+It's also possible to use a built-in [DynamoDB](https://aws.amazon.com/dynamodb) database to store skill's persistent data during its work.
+
+> For most developers, the [Lambda free tier](http://aws.amazon.com/lambda/pricing/) is sufficient for the function supporting an Alexa skill.
+
+JAICF powered Alexa skills are ready to be deployed to AWS Lambda with DynamoDB support.
+Please [learn how to use AWS Lambda and DynamoDB](https://github.com/just-ai/jaicf-kotlin/wiki/AWS-Lambda) with your JAICF projects here.
+
+> It's also a [ready to use example](https://github.com/just-ai/jaicf-kotlin/tree/master/examples/game-clock) that shows the complete project that can be deployed to AWS Lambda.

--- a/channels/alexa/build.gradle.kts
+++ b/channels/alexa/build.gradle.kts
@@ -7,7 +7,8 @@ dependencies {
     implementation(project(":core"))
     implementation(kotlin("stdlib", Version.stdLib))
 
-    api("com.amazon.alexa:ask-sdk:2.35.0")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin" version {jackson})
+    api("com.amazon.alexa:ask-sdk:2.37.1")
 }
 
 tasks {

--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaLambdaSkill.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaLambdaSkill.kt
@@ -1,0 +1,9 @@
+package com.justai.jaicf.channel.alexa
+
+import com.amazon.ask.SkillStreamHandler
+import com.justai.jaicf.api.BotApi
+
+abstract class AlexaLambdaSkill(
+    botApi: BotApi,
+    dynamoDBTableName: String? = null
+): SkillStreamHandler(AlexaSkill.create(botApi, dynamoDBTableName))

--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaSkill.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaSkill.kt
@@ -6,7 +6,11 @@ import com.justai.jaicf.api.BotApi
 
 object AlexaSkill {
 
-    fun create(botApi: BotApi): Skill = Skills.standard()
-        .addRequestHandler(AlexaRequestHandler(botApi))
+    fun create(
+        botApi: BotApi,
+        dynamoDBTableName: String? = null
+    ): Skill = Skills.standard()
+        .addRequestHandler(AlexaRequestHandler(botApi, !dynamoDBTableName.isNullOrEmpty()))
+        .withTableName(dynamoDBTableName)
         .build()
 }

--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/manager/AlexaBotContextManager.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/manager/AlexaBotContextManager.kt
@@ -38,7 +38,7 @@ class AlexaBotContextManager: BotContextManager {
                 this.client.putAll(client ?: emptyMap())
                 this.session.putAll(session?.session ?: emptyMap())
             }
-        } ?: BotContext(request.clientId, DialogContext())
+        } ?: BotContext(request.clientId)
     }
 
     override fun saveContext(botContext: BotContext, request: BotRequest?, response: BotResponse?) {

--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/manager/AlexaBotContextManager.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/manager/AlexaBotContextManager.kt
@@ -1,0 +1,57 @@
+package com.justai.jaicf.channel.alexa.manager
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.api.BotResponse
+import com.justai.jaicf.channel.alexa.alexa
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.DialogContext
+import com.justai.jaicf.context.manager.BotContextManager
+
+class AlexaBotContextManager: BotContextManager {
+
+    private val mapper = jacksonObjectMapper().apply {
+        activateDefaultTyping(
+            polymorphicTypeValidator,
+            ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY
+        )
+    }
+
+    override fun loadContext(request: BotRequest): BotContext {
+        return request.alexa?.handlerInput?.attributesManager?.let { attributesManager ->
+            val client = attributesManager.persistentAttributes[ATTR_NAME]?.let { user ->
+                mapper.readValue(user.toString(), MutableMap::class.java).mapKeys { it.key as String }
+            }
+
+            val session = attributesManager.sessionAttributes[ATTR_NAME]?.let { session ->
+                mapper.readValue(session.toString(), SessionModel::class.java)
+            }
+
+            BotContext(
+                clientId = request.clientId,
+                dialogContext = session?.dialogContext ?: DialogContext()
+            ).apply {
+                this.result = session?.result
+                this.client.putAll(client ?: emptyMap())
+                this.session.putAll(session?.session ?: emptyMap())
+            }
+        } ?: BotContext(request.clientId, DialogContext())
+    }
+
+    override fun saveContext(botContext: BotContext, request: BotRequest?, response: BotResponse?) {
+        request?.alexa?.handlerInput?.attributesManager?.let { attributesManager ->
+            val session = mapper.writeValueAsString(SessionModel(botContext))
+            val client = mapper.writeValueAsString(botContext.client.toMutableMap())
+            attributesManager.sessionAttributes[ATTR_NAME] = session
+            attributesManager.persistentAttributes = mapOf(ATTR_NAME to client)
+            attributesManager.savePersistentAttributes()
+        }
+    }
+
+    companion object {
+        private const val ATTR_NAME = "com.justai.jaicf"
+    }
+}

--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/manager/SessionModel.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/manager/SessionModel.kt
@@ -1,0 +1,16 @@
+package com.justai.jaicf.channel.alexa.manager
+
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.DialogContext
+
+data class SessionModel(
+    val result: Any?,
+    val session: Map<String, Any?>,
+    val dialogContext: DialogContext?
+) {
+    constructor(botContext: BotContext): this(
+        result = botContext.result,
+        session = botContext.session.toMutableMap(),
+        dialogContext = botContext.dialogContext
+    )
+}

--- a/examples/game-clock/build.gradle.kts
+++ b/examples/game-clock/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version Version.kotlin
+    id("com.github.johnrengelman.shadow") version "5.0.0"
 }
 
 repositories {
@@ -32,5 +33,8 @@ tasks {
     }
     test {
         useJUnitPlatform()
+    }
+    build {
+        dependsOn(shadowJar)
     }
 }

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/channel/AWSLambda.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/channel/AWSLambda.kt
@@ -1,0 +1,6 @@
+package com.justai.jaicf.examples.gameclock.channel
+
+import com.justai.jaicf.channel.alexa.AlexaLambdaSkill
+import com.justai.jaicf.examples.gameclock.gameClockBot
+
+class AWSLambda: AlexaLambdaSkill(gameClockBot, "GameClock")

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/channel/AWSLambda.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/channel/AWSLambda.kt
@@ -3,4 +3,4 @@ package com.justai.jaicf.examples.gameclock.channel
 import com.justai.jaicf.channel.alexa.AlexaLambdaSkill
 import com.justai.jaicf.examples.gameclock.gameClockBot
 
-class AWSLambda: AlexaLambdaSkill(gameClockBot, "GameClock")
+class AWSLambda: AlexaLambdaSkill(botApi = gameClockBot, dynamoDBTableName = "GameClock")


### PR DESCRIPTION
This PR introduces an AWS lambda and Amazon Dynamo DB support for Alexa skills.
These features enable user to deploy JAICF powered Alexa skills to the AWS lambda free tier and use built-in Dynamo DB to persist clients' data transparently.