### PR TITLE
Implement generic actions

### DIFF
--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaTypeToken.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaTypeToken.kt
@@ -1,0 +1,7 @@
+package com.justai.jaicf.activator.caila
+
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias CailaTypeToken = ActivatorTypeToken<CailaIntentActivatorContext>
+
+val caila: CailaTypeToken = ActivatorTypeToken()

--- a/activators/dialogflow/src/main/kotlin/com/justai/jaicf/activator/dialogflow/DialogflowTypeToken.kt
+++ b/activators/dialogflow/src/main/kotlin/com/justai/jaicf/activator/dialogflow/DialogflowTypeToken.kt
@@ -1,0 +1,7 @@
+package com.justai.jaicf.activator.dialogflow
+
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias DialogflowTypeToken = ActivatorTypeToken<DialogflowActivatorContext>
+
+val dialogflow: DialogflowTypeToken = ActivatorTypeToken()

--- a/activators/rasa/src/main/kotlin/com/justai/jaicf/activator/rasa/RasaTypeToken.kt
+++ b/activators/rasa/src/main/kotlin/com/justai/jaicf/activator/rasa/RasaTypeToken.kt
@@ -1,0 +1,7 @@
+package com.justai.jaicf.activator.rasa
+
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias RasaTypeToken = ActivatorTypeToken<RasaActivatorContext>
+
+val rasa: RasaTypeToken = ActivatorTypeToken()

--- a/channels/aimybox/src/main/kotlin/com/justai/jaicf/channel/aimybox/AimyboxTypeToken.kt
+++ b/channels/aimybox/src/main/kotlin/com/justai/jaicf/channel/aimybox/AimyboxTypeToken.kt
@@ -1,0 +1,8 @@
+package com.justai.jaicf.channel.aimybox
+
+import com.justai.jaicf.channel.aimybox.api.AimyboxBotRequest
+import com.justai.jaicf.generic.ChannelTypeToken
+
+typealias AimyboxTypeToken = ChannelTypeToken<AimyboxBotRequest, AimyboxReactions>
+
+val aimybox: AimyboxTypeToken = ChannelTypeToken()

--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaTypeToken.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaTypeToken.kt
@@ -1,0 +1,14 @@
+package com.justai.jaicf.channel.alexa
+
+import com.justai.jaicf.activator.event.EventActivatorContext
+import com.justai.jaicf.channel.alexa.activator.AlexaActivator
+import com.justai.jaicf.channel.alexa.activator.AlexaIntentActivatorContext
+import com.justai.jaicf.generic.ChannelTypeToken
+import com.justai.jaicf.generic.ContextTypeToken
+
+typealias AlexaTypeToken = ChannelTypeToken<AlexaBotRequest, AlexaReactions>
+
+val alexa: AlexaTypeToken = ChannelTypeToken()
+
+val AlexaTypeToken.intent get() = ContextTypeToken<AlexaIntentActivatorContext, AlexaIntentRequest, AlexaReactions>()
+val AlexaTypeToken.event get() = ContextTypeToken<EventActivatorContext, AlexaEventRequest, AlexaReactions>()

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookTypeToken.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookTypeToken.kt
@@ -1,0 +1,15 @@
+package com.justai.jaicf.channel.facebook
+
+import com.justai.jaicf.channel.facebook.api.FacebookBotRequest
+import com.justai.jaicf.channel.facebook.api.FacebookEventBotRequest
+import com.justai.jaicf.channel.facebook.api.FacebookQuickReplyBotRequest
+import com.justai.jaicf.channel.facebook.api.FacebookTextBotRequest
+import com.justai.jaicf.generic.ChannelTypeToken
+
+typealias FacebookTypeToken = ChannelTypeToken<FacebookBotRequest, FacebookReactions>
+
+val facebook: FacebookTypeToken = ChannelTypeToken()
+
+val FacebookTypeToken.text get() = ChannelTypeToken<FacebookTextBotRequest, FacebookReactions>()
+val FacebookTypeToken.quickReply get() = ChannelTypeToken<FacebookQuickReplyBotRequest, FacebookReactions>()
+val FacebookTypeToken.event get() = ChannelTypeToken<FacebookEventBotRequest, FacebookReactions>()

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookTypeToken.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookTypeToken.kt
@@ -1,9 +1,6 @@
 package com.justai.jaicf.channel.facebook
 
-import com.justai.jaicf.channel.facebook.api.FacebookBotRequest
-import com.justai.jaicf.channel.facebook.api.FacebookEventBotRequest
-import com.justai.jaicf.channel.facebook.api.FacebookQuickReplyBotRequest
-import com.justai.jaicf.channel.facebook.api.FacebookTextBotRequest
+import com.justai.jaicf.channel.facebook.api.*
 import com.justai.jaicf.generic.ChannelTypeToken
 
 typealias FacebookTypeToken = ChannelTypeToken<FacebookBotRequest, FacebookReactions>
@@ -13,3 +10,13 @@ val facebook: FacebookTypeToken = ChannelTypeToken()
 val FacebookTypeToken.text get() = ChannelTypeToken<FacebookTextBotRequest, FacebookReactions>()
 val FacebookTypeToken.quickReply get() = ChannelTypeToken<FacebookQuickReplyBotRequest, FacebookReactions>()
 val FacebookTypeToken.event get() = ChannelTypeToken<FacebookEventBotRequest, FacebookReactions>()
+val FacebookTypeToken.optIn get() = ChannelTypeToken<FacebookOptInBotRequest, FacebookReactions>()
+val FacebookTypeToken.accountLinking get() = ChannelTypeToken<FacebookAccountLinkingBotRequest, FacebookReactions>()
+val FacebookTypeToken.attachment get() = ChannelTypeToken<FacebookAttachmentBotRequest, FacebookReactions>()
+val FacebookTypeToken.fallback get() = ChannelTypeToken<FacebookFallbackBotRequest, FacebookReactions>()
+val FacebookTypeToken.instantGame get() = ChannelTypeToken<FacebookInstantGameBotRequest, FacebookReactions>()
+val FacebookTypeToken.messageDelivered get() = ChannelTypeToken<FacebookMessageDeliveredBotRequest, FacebookReactions>()
+val FacebookTypeToken.messageEcho get() = ChannelTypeToken<FacebookMessageEchoBotRequest, FacebookReactions>()
+val FacebookTypeToken.messageRead get() = ChannelTypeToken<FacebookMessageReadBotRequest, FacebookReactions>()
+val FacebookTypeToken.postBack get() = ChannelTypeToken<FacebookPostBackBotRequest, FacebookReactions>()
+val FacebookTypeToken.referral get() = ChannelTypeToken<FacebookReferralBotRequest, FacebookReactions>()

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookBotRequest.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookBotRequest.kt
@@ -6,8 +6,20 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.api.QueryBotRequest
 
-val BotRequest.facebook
-    get() = this as? FacebookBotRequest
+val BotRequest.facebook get() = this as? FacebookBotRequest
+
+val FacebookBotRequest.text get() = this as? FacebookTextBotRequest
+val FacebookBotRequest.quickReply get() = this as? FacebookQuickReplyBotRequest
+val FacebookBotRequest.optIn get() = this as? FacebookOptInBotRequest
+val FacebookBotRequest.accountLinking get() = this as? FacebookAccountLinkingBotRequest
+val FacebookBotRequest.attachment get() = this as? FacebookAttachmentBotRequest
+val FacebookBotRequest.fallback get() = this as? FacebookFallbackBotRequest
+val FacebookBotRequest.instantGame get() = this as? FacebookInstantGameBotRequest
+val FacebookBotRequest.messageDelivered get() = this as? FacebookMessageDeliveredBotRequest
+val FacebookBotRequest.messageEcho get() = this as? FacebookMessageEchoBotRequest
+val FacebookBotRequest.messageRead get() = this as? FacebookMessageReadBotRequest
+val FacebookBotRequest.postBack get() = this as? FacebookPostBackBotRequest
+val FacebookBotRequest.referral get() = this as? FacebookReferralBotRequest
 
 interface FacebookBotRequest: BotRequest {
     val event: BaseEvent
@@ -15,25 +27,16 @@ interface FacebookBotRequest: BotRequest {
 
 data class FacebookTextBotRequest(
     override val event: TextMessageEvent
-): FacebookBotRequest, QueryBotRequest(
-    clientId = event.senderId(),
-    input = event.text()
-)
+): FacebookBotRequest, QueryBotRequest(clientId = event.senderId(), input = event.text())
 
 data class FacebookQuickReplyBotRequest(
     override val event: QuickReplyMessageEvent
-): FacebookBotRequest, QueryBotRequest(
-    clientId = event.senderId(),
-    input = event.text()
-)
+): FacebookBotRequest, QueryBotRequest(clientId = event.senderId(), input = event.text())
 
 sealed class FacebookEventBotRequest(
     override val event: BaseEvent,
     type: String
-): FacebookBotRequest, EventBotRequest(
-    clientId = event.senderId(),
-    input = type
-)
+): FacebookBotRequest, EventBotRequest(clientId = event.senderId(), input = type)
 
 data class FacebookOptInBotRequest(
     override val event: OptInEvent

--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/ActionsTypeToken.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/ActionsTypeToken.kt
@@ -6,7 +6,7 @@ import com.justai.jaicf.generic.ContextTypeToken
 
 typealias ActionsTypeToken = ChannelTypeToken<ActionsBotRequest, ActionsReactions>
 
-val googleActions: ActionsTypeToken = ChannelTypeToken()
+val actions: ActionsTypeToken = ChannelTypeToken()
 
 val ActionsTypeToken.intent get() = ContextTypeToken<ActionsDialogflowActivatorContext, ActionsIntentRequest, ActionsReactions>()
 val ActionsTypeToken.text get() = ChannelTypeToken<ActionsTextRequest, ActionsReactions>()

--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/ActionsTypeToken.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/ActionsTypeToken.kt
@@ -1,0 +1,12 @@
+package com.justai.jaicf.channel.googleactions
+
+import com.justai.jaicf.channel.googleactions.dialogflow.ActionsDialogflowActivatorContext
+import com.justai.jaicf.generic.ChannelTypeToken
+import com.justai.jaicf.generic.ContextTypeToken
+
+typealias ActionsTypeToken = ChannelTypeToken<ActionsBotRequest, ActionsReactions>
+
+val googleActions: ActionsTypeToken = ChannelTypeToken()
+
+val ActionsTypeToken.intent get() = ContextTypeToken<ActionsDialogflowActivatorContext, ActionsIntentRequest, ActionsReactions>()
+val ActionsTypeToken.text get() = ChannelTypeToken<ActionsTextRequest, ActionsReactions>()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpTypeToken.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpTypeToken.kt
@@ -1,0 +1,22 @@
+package com.justai.jaicf.channel.jaicp
+
+import com.justai.jaicf.channel.jaicp.dto.ChatApiBotRequest
+import com.justai.jaicf.channel.jaicp.dto.ChatWidgetBotRequest
+import com.justai.jaicf.channel.jaicp.dto.TelephonyBotRequest
+import com.justai.jaicf.channel.jaicp.reactions.ChatApiReactions
+import com.justai.jaicf.channel.jaicp.reactions.ChatWidgetReactions
+import com.justai.jaicf.channel.jaicp.reactions.TelephonyReactions
+import com.justai.jaicf.generic.ChannelTypeToken
+
+
+typealias ChatApiTypeToken = ChannelTypeToken<ChatApiBotRequest, ChatApiReactions>
+
+val chatapi: ChatApiTypeToken = ChannelTypeToken()
+
+typealias ChatWidgetTypeToken = ChannelTypeToken<ChatWidgetBotRequest, ChatWidgetReactions>
+
+val chatwidget: ChatWidgetTypeToken = ChannelTypeToken()
+
+typealias TelephonyTypeToken = ChannelTypeToken<TelephonyBotRequest, TelephonyReactions>
+
+val telephony: TelephonyTypeToken = ChannelTypeToken()

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/ScenarioFactory.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/ScenarioFactory.kt
@@ -10,7 +10,7 @@ object ScenarioFactory {
         }
     }
 
-    fun echoWithAction(block: ActionContext.() -> Unit) = object : Scenario() {
+    fun echoWithAction(block: ActionContext<*, *, *>.() -> Unit) = object : Scenario() {
         init {
             fallback {
                 block()

--- a/channels/slack/src/main/kotlin/com/justai/jaicf/channel/slack/SlackTypeToken.kt
+++ b/channels/slack/src/main/kotlin/com/justai/jaicf/channel/slack/SlackTypeToken.kt
@@ -1,0 +1,11 @@
+package com.justai.jaicf.channel.slack
+
+import com.justai.jaicf.generic.ChannelTypeToken
+
+typealias SlackTypeToken = ChannelTypeToken<SlackBotRequest, SlackReactions>
+
+val slack: SlackTypeToken = ChannelTypeToken()
+
+val SlackTypeToken.event get() = ChannelTypeToken<SlackEventRequest, SlackReactions>()
+val SlackTypeToken.command get() = ChannelTypeToken<SlackCommandRequest, SlackReactions>()
+val SlackTypeToken.action get() = ChannelTypeToken<SlackActionRequest, SlackReactions>()

--- a/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramBotRequest.kt
+++ b/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramBotRequest.kt
@@ -7,124 +7,89 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.api.QueryBotRequest
 
-val BotRequest.telegram
-    get() = this as? TelegramBotRequest
+val BotRequest.telegram get() = this as? TelegramBotRequest
 
-val TelegramBotRequest.location
-    get() = this as? TelegramLocationRequest
+val TelegramBotRequest.text get() = this as? TelegramTextRequest
+val TelegramBotRequest.callback get() = this as? TelegramQueryRequest
+val TelegramBotRequest.location get() = this as? TelegramLocationRequest
+val TelegramBotRequest.contact get() = this as? TelegramContactRequest
+val TelegramBotRequest.audio get() = this as? TelegramAudioRequest
+val TelegramBotRequest.document get() = this as? TelegramDocumentRequest
+val TelegramBotRequest.animation get() = this as? TelegramAnimationRequest
+val TelegramBotRequest.game get() = this as? TelegramGameRequest
+val TelegramBotRequest.photos get() = this as? TelegramPhotosRequest
+val TelegramBotRequest.sticker get() = this as? TelegramStickerRequest
+val TelegramBotRequest.video get() = this as? TelegramVideoRequest
+val TelegramBotRequest.videoNote get() = this as? TelegramVideoNoteRequest
+val TelegramBotRequest.voice get() = this as? TelegramVoiceRequest
 
-val TelegramBotRequest.contact
-    get() = this as? TelegramContactRequest
-
-internal val Message.clientId
-    get() = chat.id.toString()
+internal val Message.clientId get() = chat.id.toString()
 
 interface TelegramBotRequest: BotRequest {
     val message: Message
-
-    val chatId: Long
-        get() = message.chat.id
+    val chatId: Long get() = message.chat.id
 }
 
 data class TelegramTextRequest(
     override val message: Message
-): TelegramBotRequest, QueryBotRequest(
-    clientId = message.clientId,
-    input = message.text.toString()
-)
+): TelegramBotRequest, QueryBotRequest(clientId = message.clientId, input = message.text.toString())
 
 data class TelegramQueryRequest(
     override val message: Message,
     val data: String
-): TelegramBotRequest, QueryBotRequest(
-    clientId = message.clientId,
-    input = data
-)
+): TelegramBotRequest, QueryBotRequest(clientId = message.clientId, input = data)
 
 data class TelegramLocationRequest(
     override val message: Message,
     val location: Location
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.LOCATION
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.LOCATION)
 
 data class TelegramContactRequest(
     override val message: Message,
     val contact: Contact
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.CONTACT
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.CONTACT)
 
 data class TelegramAudioRequest(
     override val message: Message,
     val audio: Audio
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.AUDIO
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.AUDIO)
 
 data class TelegramDocumentRequest(
     override val message: Message,
     val document: Document
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.DOCUMENT
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.DOCUMENT)
 
 data class TelegramAnimationRequest(
     override val message: Message,
     val animation: Animation
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.ANIMATION
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.ANIMATION)
 
 data class TelegramGameRequest(
     override val message: Message,
     val game: Game
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.GAME
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.GAME)
 
 data class TelegramPhotosRequest(
     override val message: Message,
     val photos: List<PhotoSize>
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.PHOTOS
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.PHOTOS)
 
 data class TelegramStickerRequest(
     override val message: Message,
     val sticker: Sticker
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.STICKER
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.STICKER)
 
 data class TelegramVideoRequest(
     override val message: Message,
     val video: Video
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.VIDEO
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.VIDEO)
 
 data class TelegramVideoNoteRequest(
     override val message: Message,
     val videoNote: VideoNote
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.VIDEO_NOTE
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.VIDEO_NOTE)
 
 data class TelegramVoiceRequest(
     override val message: Message,
     val voice: Voice
-): TelegramBotRequest, EventBotRequest(
-    clientId = message.clientId,
-    input = TelegramEvent.VOICE
-)
+): TelegramBotRequest, EventBotRequest(clientId = message.clientId, input = TelegramEvent.VOICE)

--- a/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramTypeToken.kt
+++ b/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramTypeToken.kt
@@ -1,0 +1,10 @@
+package com.justai.jaicf.channel.telegram
+
+import com.justai.jaicf.generic.ChannelTypeToken
+
+typealias TelegramTypeToken = ChannelTypeToken<TelegramBotRequest, TelegramReactions>
+
+val telegram: TelegramTypeToken = ChannelTypeToken()
+
+val TelegramTypeToken.location get() = ChannelTypeToken<TelegramLocationRequest, TelegramReactions>()
+val TelegramTypeToken.contact get() = ChannelTypeToken<TelegramContactRequest, TelegramReactions>()

--- a/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramTypeToken.kt
+++ b/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramTypeToken.kt
@@ -6,5 +6,16 @@ typealias TelegramTypeToken = ChannelTypeToken<TelegramBotRequest, TelegramReact
 
 val telegram: TelegramTypeToken = ChannelTypeToken()
 
+val TelegramTypeToken.text get() = ChannelTypeToken<TelegramTextRequest, TelegramReactions>()
+val TelegramTypeToken.callback get() = ChannelTypeToken<TelegramQueryRequest, TelegramReactions>()
 val TelegramTypeToken.location get() = ChannelTypeToken<TelegramLocationRequest, TelegramReactions>()
 val TelegramTypeToken.contact get() = ChannelTypeToken<TelegramContactRequest, TelegramReactions>()
+val TelegramTypeToken.audio get() = ChannelTypeToken<TelegramAudioRequest, TelegramReactions>()
+val TelegramTypeToken.document get() = ChannelTypeToken<TelegramDocumentRequest, TelegramReactions>()
+val TelegramTypeToken.animation get() = ChannelTypeToken<TelegramAnimationRequest, TelegramReactions>()
+val TelegramTypeToken.game get() = ChannelTypeToken<TelegramGameRequest, TelegramReactions>()
+val TelegramTypeToken.photos get() = ChannelTypeToken<TelegramPhotosRequest, TelegramReactions>()
+val TelegramTypeToken.sticker get() = ChannelTypeToken<TelegramStickerRequest, TelegramReactions>()
+val TelegramTypeToken.video get() = ChannelTypeToken<TelegramVideoRequest, TelegramReactions>()
+val TelegramTypeToken.videoNote get() = ChannelTypeToken<TelegramVideoNoteRequest, TelegramReactions>()
+val TelegramTypeToken.voice get() = ChannelTypeToken<TelegramVoiceRequest, TelegramReactions>()

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceTypeToken.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceTypeToken.kt
@@ -1,0 +1,12 @@
+package com.justai.jaicf.channel.yandexalice
+
+import com.justai.jaicf.channel.yandexalice.activator.AliceIntentActivatorContext
+import com.justai.jaicf.channel.yandexalice.api.AliceBotRequest
+import com.justai.jaicf.generic.ChannelTypeToken
+import com.justai.jaicf.generic.ContextTypeToken
+
+typealias AliceTypeToken = ChannelTypeToken<AliceBotRequest, AliceReactions>
+
+val alice: AliceTypeToken = ChannelTypeToken()
+
+val AliceTypeToken.intent get() = ContextTypeToken<AliceIntentActivatorContext, AliceBotRequest, AliceReactions>()

--- a/core/src/main/kotlin/com/justai/jaicf/activator/catchall/CatchAllTypeToken.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/catchall/CatchAllTypeToken.kt
@@ -1,0 +1,7 @@
+package com.justai.jaicf.activator.catchall
+
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias CatchAllTypeToken = ActivatorTypeToken<CatchAllActivatorContext>
+
+val catchAll: CatchAllTypeToken = ActivatorTypeToken()

--- a/core/src/main/kotlin/com/justai/jaicf/activator/event/EventTypeToken.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/event/EventTypeToken.kt
@@ -1,0 +1,7 @@
+package com.justai.jaicf.activator.event
+
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias EventTypeToken = ActivatorTypeToken<EventActivatorContext>
+
+val event: EventTypeToken = ActivatorTypeToken()

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentTypeToken.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentTypeToken.kt
@@ -1,0 +1,7 @@
+package com.justai.jaicf.activator.intent
+
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias IntentTypeToken = ActivatorTypeToken<IntentActivatorContext>
+
+val intent: IntentTypeToken = ActivatorTypeToken()

--- a/core/src/main/kotlin/com/justai/jaicf/activator/regex/RegexTypeToken.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/regex/RegexTypeToken.kt
@@ -1,0 +1,8 @@
+package com.justai.jaicf.activator.regex
+
+import com.justai.jaicf.activator.catchall.CatchAllActivatorContext
+import com.justai.jaicf.generic.ActivatorTypeToken
+
+typealias RegexTypeToken = ActivatorTypeToken<RegexActivatorContext>
+
+val regex: RegexTypeToken = ActivatorTypeToken()

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -222,39 +222,39 @@ abstract class ScenarioBuilder(
 
         /**
          * An action that should be executed once this state was activated.
-         * The action will be executed only if [ActionContext] type matches the given [token]
+         * The action will be executed only if [ActionContext] type matches the given [activatorToken]
          *
-         * @param token an activator type token
+         * @param activatorToken an activator type token
          * @param body a code block of the action
          */
         fun <A: ActivatorContext> action(
-            token: ActivatorTypeToken<A>,
+            activatorToken: ActivatorTypeToken<A>,
             body: ActionContext<A, BotRequest, Reactions>.() -> Unit
-        ) = action { token(body) }
+        ) = action { activatorToken(body) }
 
         /**
          * An action that should be executed once this state was activated.
-         * The action will be executed only if [ActionContext] type matches the given [token]
+         * The action will be executed only if [ActionContext] type matches the given [channelToken]
          *
-         * @param token a channel type token
+         * @param channelToken a channel type token
          * @param body a code block of the action
          */
         fun <B: BotRequest, R: Reactions> action(
-            token: ChannelTypeToken<B, R>,
+            channelToken: ChannelTypeToken<B, R>,
             body: ActionContext<ActivatorContext, B, R>.() -> Unit
-        ) = action { token(body) }
+        ) = action { channelToken(body) }
 
         /**
          * An action that should be executed once this state was activated.
-         * The action will be executed only if [ActionContext] type matches the given [token]
+         * The action will be executed only if [ActionContext] type matches the given [contextTypeToken]
          *
-         * @param token a full context type token
+         * @param contextTypeToken a full context type token
          * @param body a code block of the action
          */
         fun <A: ActivatorContext, B: BotRequest, R: Reactions> action(
-            token: ContextTypeToken<A, B, R>,
+            contextTypeToken: ContextTypeToken<A, B, R>,
             body: ActionContext<A, B, R>.() -> Unit
-        ) = action { token(body) }
+        ) = action { contextTypeToken(body) }
 
         /**
          * Appends an inner state to the current state.

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -9,6 +9,9 @@ import com.justai.jaicf.activator.regex.RegexActivationRule
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.ActivatorContext
+import com.justai.jaicf.generic.ActivatorTypeToken
+import com.justai.jaicf.generic.ChannelTypeToken
+import com.justai.jaicf.generic.ContextTypeToken
 import com.justai.jaicf.hook.BotHook
 import com.justai.jaicf.hook.BotHookAction
 import com.justai.jaicf.hook.BotHookException
@@ -216,6 +219,42 @@ abstract class ScenarioBuilder(
         fun action(body: ActionContext<ActivatorContext, BotRequest, Reactions>.() -> Unit) {
             action = body
         }
+
+        /**
+         * An action that should be executed once this state was activated.
+         * The action will be executed only if [ActionContext] type matches the given [token]
+         *
+         * @param token an activator type token
+         * @param body a code block of the action
+         */
+        fun <A: ActivatorContext> action(
+            token: ActivatorTypeToken<A>,
+            body: ActionContext<A, BotRequest, Reactions>.() -> Unit
+        ) = action { token(body) }
+
+        /**
+         * An action that should be executed once this state was activated.
+         * The action will be executed only if [ActionContext] type matches the given [token]
+         *
+         * @param token a channel type token
+         * @param body a code block of the action
+         */
+        fun <B: BotRequest, R: Reactions> action(
+            token: ChannelTypeToken<B, R>,
+            body: ActionContext<ActivatorContext, B, R>.() -> Unit
+        ) = action { token(body) }
+
+        /**
+         * An action that should be executed once this state was activated.
+         * The action will be executed only if [ActionContext] type matches the given [token]
+         *
+         * @param token a full context type token
+         * @param body a code block of the action
+         */
+        fun <A: ActivatorContext, B: BotRequest, R: Reactions> action(
+            token: ContextTypeToken<A, B, R>,
+            body: ActionContext<A, B, R>.() -> Unit
+        ) = action { token(body) }
 
         /**
          * Appends an inner state to the current state.

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -1,13 +1,14 @@
 package com.justai.jaicf.builder
 
 import com.justai.jaicf.activator.catchall.CatchAllActivationRule
-import com.justai.jaicf.activator.catchall.CatchAllActivatorContext
 import com.justai.jaicf.activator.event.AnyEventActivationRule
 import com.justai.jaicf.activator.event.EventByNameActivationRule
 import com.justai.jaicf.activator.intent.AnyIntentActivationRule
 import com.justai.jaicf.activator.intent.IntentByNameActivationRule
 import com.justai.jaicf.activator.regex.RegexActivationRule
+import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActionContext
+import com.justai.jaicf.context.ActivatorContext
 import com.justai.jaicf.hook.BotHook
 import com.justai.jaicf.hook.BotHookAction
 import com.justai.jaicf.hook.BotHookException
@@ -16,6 +17,7 @@ import com.justai.jaicf.model.scenario.ScenarioModel
 import com.justai.jaicf.model.state.State
 import com.justai.jaicf.model.state.StatePath
 import com.justai.jaicf.model.transition.Transition
+import com.justai.jaicf.reactions.Reactions
 import java.util.*
 import kotlin.reflect.KClass
 
@@ -177,7 +179,7 @@ abstract class ScenarioBuilder(
         private val modal: Boolean = false
     ) {
 
-        private var action: (ActionContext<*, *, *>.() -> Unit)? = null
+        private var action: (ActionContext<ActivatorContext, BotRequest, Reactions>.() -> Unit)? = null
 
         internal fun build() : State {
             return State(
@@ -211,7 +213,7 @@ abstract class ScenarioBuilder(
          * An action that should be executed once this state was activated.
          * @param body a code block of the action
          */
-        fun action(body: ActionContext<*, *, *>.() -> Unit) {
+        fun action(body: ActionContext<ActivatorContext, BotRequest, Reactions>.() -> Unit) {
             action = body
         }
 

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -1,6 +1,7 @@
 package com.justai.jaicf.builder
 
 import com.justai.jaicf.activator.catchall.CatchAllActivationRule
+import com.justai.jaicf.activator.catchall.CatchAllActivatorContext
 import com.justai.jaicf.activator.event.AnyEventActivationRule
 import com.justai.jaicf.activator.event.EventByNameActivationRule
 import com.justai.jaicf.activator.intent.AnyIntentActivationRule
@@ -154,7 +155,7 @@ abstract class ScenarioBuilder(
      */
     fun fallback(
         state: String = "fallback",
-        action: ActionContext.() -> Unit
+        action: ActionContext<*, *, *>.() -> Unit
     ) = state(
         name = state,
         noContext = true,
@@ -176,7 +177,7 @@ abstract class ScenarioBuilder(
         private val modal: Boolean = false
     ) {
 
-        private var action: (ActionContext.() -> Unit)? = null
+        private var action: (ActionContext<*, *, *>.() -> Unit)? = null
 
         internal fun build() : State {
             return State(
@@ -210,7 +211,7 @@ abstract class ScenarioBuilder(
          * An action that should be executed once this state was activated.
          * @param body a code block of the action
          */
-        fun action(body: ActionContext.() -> Unit) {
+        fun action(body: ActionContext<*, *, *>.() -> Unit) {
             action = body
         }
 
@@ -219,7 +220,7 @@ abstract class ScenarioBuilder(
          * Means that inner state could be activated only if it's prarent state was activated previously.
          *
          * @param name a name of the state. Could be plain text or contains slashes to define a state path
-         * @param noContext indicates if this state should not to change the current dialogue's context
+         * @param noContext indicates if this state sh<*, *, *>ould not to change the current dialogue's context
          * @param modal indicates if this state should process the user's request in modal mode ignoring all other states
          * @param body a code block of the state that contains activators, action and inner states definitions
          */

--- a/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
@@ -22,11 +22,11 @@ import kotlin.random.Random
  * @see [BotRequest]
  * @see [Reactions]
  */
-open class ActionContext(
-    val context: BotContext,
-    val activator: ActivatorContext,
-    val request: BotRequest,
-    val reactions: Reactions
+open class ActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
+    open val context: BotContext,
+    open val activator: A,
+    open val request: B,
+    open val reactions: R
 ) {
 
     /**

--- a/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
@@ -1,6 +1,9 @@
 package com.justai.jaicf.context
 
 import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.generic.ActivatorTypeToken
+import com.justai.jaicf.generic.ChannelTypeToken
+import com.justai.jaicf.generic.ContextTypeToken
 import com.justai.jaicf.helpers.action.smartRandom
 import com.justai.jaicf.logging.ButtonsReaction
 import com.justai.jaicf.model.state.StatePath
@@ -80,6 +83,33 @@ open class ActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
         this?.buttons?.zip(states)?.forEach { (text, state) ->
             context.dialogContext.transitions[text.toLowerCase()] =
                 StatePath.parse(context.dialogContext.currentState).resolve(state).toString()
+        }
+    }
+
+    operator fun <A1: A, T> ActivatorTypeToken<A1>.invoke(action: ActionContext<A1, B, R>.() -> T): T? {
+        return if (isInstance(activator)) {
+            @Suppress("UNCHECKED_CAST")
+            (this@ActionContext as ActionContext<A1, B, R>).action()
+        } else {
+            null
+        }
+    }
+
+    operator fun <B1: B, R1: R, T> ChannelTypeToken<B1, R1>.invoke(action: ActionContext<A, B1, R1>.() -> T): T? {
+        return if (isInstance(request) && isInstance(reactions)) {
+            @Suppress("UNCHECKED_CAST")
+            (this@ActionContext as ActionContext<A, B1, R1>).action()
+        } else {
+            null
+        }
+    }
+
+    operator fun <A1: A, B1: B, R1: R, T> ContextTypeToken<A1, B1, R1>.invoke(action: ActionContext<A1, B1, R1>.() -> T): T? {
+        return if (isInstance(activator)) {
+            @Suppress("UNCHECKED_CAST")
+            (this@ActionContext as ActionContext<A1, B1, R1>).action()
+        } else {
+            null
         }
     }
 }

--- a/core/src/main/kotlin/com/justai/jaicf/generic/Compositions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/generic/Compositions.kt
@@ -1,0 +1,42 @@
+package com.justai.jaicf.generic
+
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.context.ActivatorContext
+import com.justai.jaicf.reactions.Reactions
+
+// -- Type tokens' compositions
+
+private typealias Act<A> = ActivatorContextTypeToken<A>
+private typealias Ch<B, R> = ChannelTypeToken<B, R>
+private typealias Ctx<A, B, R> = ContextTypeToken<A, B, R>
+
+private typealias Req = BotRequest
+private typealias React = Reactions
+private typealias ActCtx = ActivatorContext
+
+// ---- ActivatorTypeToken and ActivatorTypeToken
+infix fun <A1: ActCtx, A2: A1> Act<A1>.and(other: Act<A2>): Act<A2> = other
+
+// ---- ActivatorTypeToken and ChannelTypeToken
+infix fun <A: ActCtx, B: Req, R: React> Act<A>.and(other: Ch<B, R>): Ctx<A, B, R> = Ctx(activatorType, other.requestType, other.reactionsType)
+
+// ---- ActivatorTypeToken and ContextTypeToken
+infix fun <A1: ActCtx, A2: A1, B: Req, R: React> Act<A1>.and(other: Ctx<A2, B, R>): Ctx<A2, B, R> = other
+
+// ---- ChannelTypeToken and ActivatorTypeToken
+infix fun <A: ActCtx, B: Req, R: React> Ch<B, R>.and(other: Act<A>): Ctx<A, B, R> = Ctx(other.activatorType, requestType, reactionsType)
+
+// ---- ChannelTypeToken and ChannelTypeToken
+infix fun <B1: Req, R1: React, B2: B1, R2: R1> Ch<B1, R1>.and(other: Ch<B2, R2>): Ch<B2, R2> = other
+
+// ---- ChannelTypeToken and ContextTypeToken
+infix fun <B1: Req, R1: React, A: ActCtx, B2: B1, R2: R1> Ch<B1, R1>.and(other: Ctx<A, B2, R2>): Ctx<A, B2, R2> = other
+
+// ---- ContextTypeToken and ActivatorTypeToken
+infix fun <A1: ActCtx, B: Req, R: React, A2: A1> Ctx<A1, B, R>.and(other: Act<A2>): Ctx<A2, B, R> = Ctx(other.activatorType, requestType, reactionsType)
+
+// ---- ContextTypeToken and ChannelTypeToken
+infix fun <A: ActCtx, B1: Req, R1: React, B2: B1, R2: R1> Ctx<A, B1, R1>.and(other: Ch<B2, R2>): Ctx<A, B2, R2> = Ctx(activatorType, other.requestType, other.reactionsType)
+
+// ---- ContextTypeToken and ContextTypeToken
+infix fun <A1: ActCtx, B1: Req, R1: React, A2: A1, B2: B1, R2: R1> Ctx<A1, B1, R1>.and(other: Ctx<A2, B2, R2>): Ctx<A2, B2, R2> = other

--- a/core/src/main/kotlin/com/justai/jaicf/generic/Compositions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/generic/Compositions.kt
@@ -6,7 +6,7 @@ import com.justai.jaicf.reactions.Reactions
 
 // -- Type tokens' compositions
 
-private typealias Act<A> = ActivatorContextTypeToken<A>
+private typealias Act<A> = ActivatorTypeToken<A>
 private typealias Ch<B, R> = ChannelTypeToken<B, R>
 private typealias Ctx<A, B, R> = ContextTypeToken<A, B, R>
 

--- a/core/src/main/kotlin/com/justai/jaicf/generic/Compositions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/generic/Compositions.kt
@@ -4,7 +4,15 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActivatorContext
 import com.justai.jaicf.reactions.Reactions
 
-// -- Type tokens' compositions
+/*
+ * All type tokens' compositions are presented here
+ *
+ * The fowlloing are true for all compositions:
+ *  1. the second argument of the composition must always be more (or no less) specific
+ *     by all common type parameters than the first one;
+ *  2. the result of the composition is the type token,
+ *     that the most specific by all presented in both arguments type parameters
+ */
 
 private typealias Act<A> = ActivatorTypeToken<A>
 private typealias Ch<B, R> = ChannelTypeToken<B, R>

--- a/core/src/main/kotlin/com/justai/jaicf/generic/TypeToken.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/generic/TypeToken.kt
@@ -25,7 +25,7 @@ data class ContextTypeToken<A: ActivatorContext, B: BotRequest, R: Reactions>(
  * Can be used in some contexts in order to provide type-specific functionality.
  * Can be composed with other type tokens, see [and] functions.
  */
-data class ActivatorContextTypeToken<A: ActivatorContext>(
+data class ActivatorTypeToken<A: ActivatorContext>(
     val activatorType: KClass<A>
 ) {
     fun isInstance(activatorContext: ActivatorContext) = activatorType.isInstance(activatorContext)
@@ -52,10 +52,10 @@ inline fun <reified A: ActivatorContext, reified B: BotRequest, reified R: React
     ContextTypeToken(A::class, B::class, R::class)
 
 /**
- * Creates [ActivatorContextTypeToken] of type [A]
+ * Creates [ActivatorTypeToken] of type [A]
  */
-inline fun <reified A: ActivatorContext> ActivatorContextTypeToken(): ActivatorContextTypeToken<A> =
-    ActivatorContextTypeToken(A::class)
+inline fun <reified A: ActivatorContext> ActivatorTypeToken(): ActivatorTypeToken<A> =
+    ActivatorTypeToken(A::class)
 
 /**
  * Creates [ChannelTypeToken] of types [B] and [R]

--- a/core/src/main/kotlin/com/justai/jaicf/generic/TypeToken.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/generic/TypeToken.kt
@@ -1,0 +1,64 @@
+package com.justai.jaicf.generic
+
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.context.ActivatorContext
+import com.justai.jaicf.reactions.Reactions
+import kotlin.reflect.KClass
+
+/**
+ * Type token that holds information about certain types of [ActivatorContext], [BotRequest] and [Reactions].
+ * Can be used in some contexts in order to provide type-specific functionality.
+ * Can be composed with other type tokens, see [and] functions.
+ */
+data class ContextTypeToken<A: ActivatorContext, B: BotRequest, R: Reactions>(
+    val activatorType: KClass<A>,
+    val requestType: KClass<B>,
+    val reactionsType: KClass<R>
+) {
+    fun isInstance(activatorContext: ActivatorContext) = activatorType.isInstance(activatorContext)
+    fun isInstance(request: BotRequest) = requestType.isInstance(request)
+    fun isInstance(reactions: Reactions) = reactionsType.isInstance(reactions)
+}
+
+/**
+ * Type token that holds information about certain type of [ActivatorContext].
+ * Can be used in some contexts in order to provide type-specific functionality.
+ * Can be composed with other type tokens, see [and] functions.
+ */
+data class ActivatorContextTypeToken<A: ActivatorContext>(
+    val activatorType: KClass<A>
+) {
+    fun isInstance(activatorContext: ActivatorContext) = activatorType.isInstance(activatorContext)
+}
+
+/**
+ * Type token that holds information about certain types of [BotRequest] and [Reactions].
+ * Can be used in some contexts in order to provide type-specific functionality.
+ * Can be composed with other type tokens, see [and] functions.
+ */
+data class ChannelTypeToken<B: BotRequest, R: Reactions>(
+    val requestType: KClass<B>,
+    val reactionsType: KClass<R>
+) {
+    fun isInstance(request: BotRequest) = requestType.isInstance(request)
+    fun isInstance(reactions: Reactions) = reactionsType.isInstance(reactions)
+}
+
+
+/**
+ * Creates [ContextTypeToken] of types [A], [B] and [R]
+ */
+inline fun <reified A: ActivatorContext, reified B: BotRequest, reified R: Reactions> ContextTypeToken(): ContextTypeToken<A, B, R> =
+    ContextTypeToken(A::class, B::class, R::class)
+
+/**
+ * Creates [ActivatorContextTypeToken] of type [A]
+ */
+inline fun <reified A: ActivatorContext> ActivatorContextTypeToken(): ActivatorContextTypeToken<A> =
+    ActivatorContextTypeToken(A::class)
+
+/**
+ * Creates [ChannelTypeToken] of types [B] and [R]
+ */
+inline fun <reified B: BotRequest, reified R: Reactions> ChannelTypeToken(): ChannelTypeToken<B, R> =
+    ChannelTypeToken(B::class, R::class)

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
@@ -4,14 +4,14 @@ import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.test.context.TestActionContext
 import kotlin.random.Random
 
-internal fun random(max: Int, context: ActionContext): Int {
+internal fun random(max: Int, context: ActionContext<*, *, *>): Int {
     return when(context) {
         is TestActionContext -> context.nextRandomInt()
         else -> Random.nextInt(max)
     }
 }
 
-internal fun smartRandom(max: Int, context: ActionContext): Int {
+internal fun smartRandom(max: Int, context: ActionContext<*, *, *>): Int {
     val bc = context.context
     val id = "${bc.dialogContext.currentState}_$max"
     var smartRandom: MutableMap<String, MutableList<Int>>? by bc.session

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/logging/Log.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/logging/Log.kt
@@ -3,7 +3,7 @@ package com.justai.jaicf.helpers.logging
 import com.justai.jaicf.context.ActionContext
 import org.slf4j.LoggerFactory
 
-val ActionContext.logger
+val ActionContext<*, *, *>.logger
     get() = LoggerFactory.getLogger(this.context.dialogContext.currentState)
 
-fun ActionContext.log(msg: String) = logger.info(msg)
+fun ActionContext<*, *, *>.log(msg: String) = logger.info(msg)

--- a/core/src/main/kotlin/com/justai/jaicf/model/ActionAdapter.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/ActionAdapter.kt
@@ -1,11 +1,14 @@
 package com.justai.jaicf.model
 
+import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActionContext
+import com.justai.jaicf.context.ActivatorContext
 import com.justai.jaicf.context.ProcessContext
+import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.test.context.TestActionContext
 import com.justai.jaicf.test.context.TestRequestContext
 
-class ActionAdapter(private val action: ActionContext<*, *, *>.() -> Unit) {
+class ActionAdapter(private val action: ActionContext<ActivatorContext, BotRequest, Reactions>.() -> Unit) {
 
     fun execute(context: ProcessContext) = with(context) {
         val actionContext = if (context.requestContext is TestRequestContext) {

--- a/core/src/main/kotlin/com/justai/jaicf/model/ActionAdapter.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/ActionAdapter.kt
@@ -5,21 +5,16 @@ import com.justai.jaicf.context.ProcessContext
 import com.justai.jaicf.test.context.TestActionContext
 import com.justai.jaicf.test.context.TestRequestContext
 
-class ActionAdapter(
-    private val action: ActionContext.() -> Unit
-) {
+class ActionAdapter(private val action: ActionContext<*, *, *>.() -> Unit) {
+
     fun execute(context: ProcessContext) = with(context) {
-        if (context.requestContext is TestRequestContext) {
-            action.invoke(TestActionContext(this))
+        val actionContext = if (context.requestContext is TestRequestContext) {
+            TestActionContext(botContext, activationContext.activation.context, request, reactions, context.requestContext)
         } else {
-            action.invoke(
-                ActionContext(
-                    botContext,
-                    activationContext.activation.context,
-                    request,
-                    reactions
-                )
-            )
+            ActionContext(botContext, activationContext.activation.context, request, reactions)
         }
+
+        actionContext.action()
     }
+
 }

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
@@ -14,7 +14,7 @@ import java.util.*
 
 class SmartRandomTest {
 
-    private lateinit var context: ActionContext
+    private lateinit var context: ActionContext<*, *, *>
 
     @BeforeEach
     fun createContext() {

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
@@ -31,11 +31,11 @@ object HelloWorldScenario: Scenario(
                 var name = context.client["name"]
 
                 if (name == null) {
-                    request.telegram?.run {
-                        name = message.chat.firstName ?: message.chat.username
+                    name = telegram {
+                        request.message.chat.firstName ?: request.message.chat.username
                     }
-                    request.facebook?.run {
-                        name = reactions.facebook?.queryUserProfile()?.firstName()
+                    name = facebook {
+                        reactions.queryUserProfile()?.firstName()
                     }
                 }
 
@@ -79,7 +79,9 @@ object HelloWorldScenario: Scenario(
             }
 
             action {
-                reactions.alexa?.endSession("See you latter! Bye bye!")
+                alexa {
+                    reactions.endSession("See you latter! Bye bye!")
+                }
             }
         }
 
@@ -98,8 +100,8 @@ object HelloWorldScenario: Scenario(
                 intent("wake_up")
             }
             action {
-                activator.dialogflow?.run {
-                    val dt = slots["date-time"]
+                dialogflow {
+                    val dt = activator.slots["date-time"]
                     reactions.say("Okay! I'll wake you up ${dt?.stringValue}")
                 }
             }

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
@@ -78,10 +78,8 @@ object HelloWorldScenario: Scenario(
                 intent(AlexaIntent.STOP)
             }
 
-            action {
-                alexa {
-                    reactions.endSession("See you latter! Bye bye!")
-                }
+            action(alexa.intent) {
+                reactions.endSession("See you latter! Bye bye!")
             }
         }
 
@@ -99,11 +97,10 @@ object HelloWorldScenario: Scenario(
             activators {
                 intent("wake_up")
             }
-            action {
-                dialogflow {
-                    val dt = activator.slots["date-time"]
-                    reactions.say("Okay! I'll wake you up ${dt?.stringValue}")
-                }
+
+            action(dialogflow) {
+                val dt = activator.slots["date-time"]
+                reactions.say("Okay! I'll wake you up ${dt?.stringValue}")
             }
         }
 

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/HelloWorldScenario.kt
@@ -31,11 +31,11 @@ object HelloWorldScenario: Scenario(
                 var name = context.client["name"]
 
                 if (name == null) {
-                    name = telegram {
-                        request.message.chat.firstName ?: request.message.chat.username
+                    telegram {
+                        name = request.message.chat.firstName ?: request.message.chat.username
                     }
-                    name = facebook {
-                        reactions.queryUserProfile()?.firstName()
+                    facebook {
+                        name = reactions.queryUserProfile()?.firstName()
                     }
                 }
 


### PR DESCRIPTION
* Every activator, channel, whatever, could define its own type token that holds information about certain types of context variables. This token can be used in different contexts in order to provide type-specific behavior.
* Type tokens can be composed with each other (e.g. `telegram and caila`)
* Type tokens can be invoked with lambdas inside the action block
* Type token can be passed to the `action` function as a parameter
* ActionContext became generic