### PR TITLE
Long Polling new API and scalable request execution for JAICP 

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JSON.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JSON.kt
@@ -2,16 +2,15 @@ package com.justai.jaicf.channel.jaicp
 
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
+import com.justai.jaicf.channel.jaicp.dto.JaicpPollingRequest
 import com.justai.jaicf.channel.jaicp.dto.JaicpPollingResponse
 import kotlinx.serialization.json.Json
 
-internal val JSON = Json { ignoreUnknownKeys = true }
+internal val JSON = Json { ignoreUnknownKeys = true; isLenient = true }
 
 internal fun String.asJaicpBotRequest() = JSON.decodeFromString(JaicpBotRequest.serializer(), this)
 
 internal fun String.asJaicpBotResponse() = JSON.decodeFromString(JaicpBotResponse.serializer(), this)
-
-internal fun String.asJaicpPollingRequest() = JSON.decodeFromString(JaicpPollingRequest.serializer(), this)
 
 internal fun JaicpBotResponse.deserialized() = JSON.encodeToString(JaicpBotResponse.serializer(), this)
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JSON.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JSON.kt
@@ -2,7 +2,6 @@ package com.justai.jaicf.channel.jaicp
 
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
-import com.justai.jaicf.channel.jaicp.dto.JaicpPollingRequest
 import com.justai.jaicf.channel.jaicp.dto.JaicpPollingResponse
 import kotlinx.serialization.json.Json
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -34,16 +34,10 @@ abstract class JaicpConnector(
     executorThreadPoolSize: Int = DEFAULT_REQUEST_EXECUTOR_THREAD_POOL_SIZE
 ) : WithLogger {
 
-    private val threadPoolRequestExecutor = ThreadPoolRequestExecutor(executorThreadPoolSize)
+    protected val threadPoolRequestExecutor = ThreadPoolRequestExecutor(executorThreadPoolSize)
     private val chatAdapterConnector = ChatAdapterConnector(accessToken, url, httpClient)
     private var registeredChannels = fetchChannels()
-    protected val useLegacyPollingApi: Boolean
-
-    init {
-        useLegacyPollingApi = chatAdapterConnector.getVersion().run {
-            equals("release-1.10.1") || equals("release-1.10.2")
-        }
-    }
+    protected val useLegacyPollingApi = chatAdapterConnector.getVersion() in listOf("release-1.10.1", "release-1.10.2")
 
     protected fun loadConfig() {
         registeredChannels.forEach { (factory, cfg) ->

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
@@ -38,7 +38,7 @@ open class JaicpPollingConnector(
     WithLogger {
 
 
-    private val dispatcher = Dispatcher(httpClient, useLegacyPollingApi, threadPoolSize)
+    private val dispatcher = Dispatcher(httpClient, useLegacyPollingApi, threadPoolRequestExecutor)
 
     init {
         loadConfig()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
@@ -32,19 +32,19 @@ open class JaicpPollingConnector(
     url: String = DEFAULT_PROXY_URL,
     channels: List<JaicpChannelFactory>,
     logLevel: LogLevel = LogLevel.INFO,
-    httpClient: HttpClient = null ?: HttpClientFactory.create(logLevel)
-) : JaicpConnector(botApi, channels, accessToken, url, httpClient),
+    httpClient: HttpClient = null ?: HttpClientFactory.create(logLevel),
+    threadPoolSize: Int = DEFAULT_REQUEST_EXECUTOR_THREAD_POOL_SIZE
+) : JaicpConnector(botApi, channels, accessToken, url, httpClient, threadPoolSize),
     WithLogger {
 
-    private val dispatcher = Dispatcher(httpClient, this::processJaicpRequest)
+
+    private val dispatcher = Dispatcher(httpClient, useLegacyPollingApi, threadPoolSize)
 
     init {
         loadConfig()
     }
 
-    fun runBlocking() {
-        dispatcher.startPollingBlocking()
-    }
+    fun runBlocking() = dispatcher.startPollingBlocking()
 
     override fun register(channel: JaicpBotChannel, channelConfig: ChannelConfig) {
         logger.debug("Register channel ${channelConfig.channelType}")

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
@@ -45,7 +45,7 @@ import com.justai.jaicf.channel.jaicp.endpoints.ktor.reloadConfigEndpoint
  * @param accessToken can be configured in JAICP Web Interface
  * @param channels is a list of channels which will be managed by connector
  * */
-@Suppress("MemberVisibilityCanBePrivate")
+
 open class JaicpWebhookConnector(
     botApi: BotApi,
     accessToken: String,
@@ -58,6 +58,7 @@ open class JaicpWebhookConnector(
     HttpBotChannel,
     JaicpConnector(botApi, channels, accessToken, url, httpClient, threadPoolSize) {
 
+    @Suppress("MemberVisibilityCanBePrivate")
     protected val channelMap: MutableMap<String, JaicpBotChannel> = mutableMapOf()
 
     init {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotRequest.kt
@@ -6,7 +6,6 @@ import com.justai.jaicf.channel.jaicp.JSON
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import org.slf4j.MDC
 
 @Serializable
 data class JaicpBotRequest(
@@ -21,7 +20,8 @@ data class JaicpBotRequest(
     val rawRequest: JsonObject,
     val userFrom: JsonElement,
     val event: String? = null,
-    val startProcessingTime: Long = System.currentTimeMillis()
+    val startProcessingTime: Long = System.currentTimeMillis(),
+    val timestamp: String = ""
 ) : BotRequest {
     override val type: BotRequestType = if (query != null) BotRequestType.QUERY else BotRequestType.EVENT
     override val clientId = channelUserId

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpPollingRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpPollingRequest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@Deprecated("Deprecated long poll api. Will be deleted with all references in further releases.")
 internal data class JaicpPollingRequest(
     @SerialName("questionId")
     val requestId: String,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpPollingResponse.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpPollingResponse.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+@Deprecated("Deprecated long poll api. Will be deleted with all references in further releases.")
 internal data class JaicpPollingResponse(
     @SerialName("questionId")
     private val requestId: String,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/execution/ThreadPoolRequestExecutor.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/execution/ThreadPoolRequestExecutor.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.runBlocking
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 
-internal class ThreadPoolRequestExecutor(nThreads: Int) : CoroutineScope {
+class ThreadPoolRequestExecutor(nThreads: Int) : CoroutineScope {
 
     override val coroutineContext: CoroutineContext =
         Executors.newFixedThreadPool(nThreads).asCoroutineDispatcher()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/execution/ThreadPoolRequestExecutor.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/execution/ThreadPoolRequestExecutor.kt
@@ -1,0 +1,52 @@
+package com.justai.jaicf.channel.jaicp.execution
+
+import com.justai.jaicf.channel.BotChannel
+import com.justai.jaicf.channel.http.asHttpBotRequest
+import com.justai.jaicf.channel.jaicp.JaicpCompatibleAsyncBotChannel
+import com.justai.jaicf.channel.jaicp.JaicpCompatibleBotChannel
+import com.justai.jaicf.channel.jaicp.JaicpMDC
+import com.justai.jaicf.channel.jaicp.channels.JaicpNativeBotChannel
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
+import com.justai.jaicf.channel.jaicp.processCompatible
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
+
+internal class ThreadPoolRequestExecutor(nThreads: Int) : CoroutineScope {
+
+    override val coroutineContext: CoroutineContext =
+        Executors.newFixedThreadPool(nThreads).asCoroutineDispatcher()
+
+    fun executeAsync(request: JaicpBotRequest, channel: BotChannel) = async(coroutineContext) {
+        execute(request, channel)
+    }
+
+    fun executeSync(request: JaicpBotRequest, channel: BotChannel) = runBlocking {
+        executeAsync(request, channel).await()
+    }
+
+    private fun execute(request: JaicpBotRequest, channel: BotChannel): JaicpBotResponse? {
+        JaicpMDC.setFromRequest(request)
+        return when (channel) {
+            is JaicpNativeBotChannel -> executeNative(channel, request)
+            is JaicpCompatibleBotChannel -> executeCompatible(channel, request)
+            is JaicpCompatibleAsyncBotChannel -> {
+                executeAsync(channel, request); null
+            }
+            else -> null
+        }
+    }
+
+    private fun executeNative(channel: JaicpNativeBotChannel, request: JaicpBotRequest) =
+        channel.process(request)
+
+    private fun executeCompatible(channel: JaicpCompatibleBotChannel, request: JaicpBotRequest) =
+        channel.processCompatible(request)
+
+    private fun executeAsync(channel: JaicpCompatibleAsyncBotChannel, request: JaicpBotRequest) =
+        channel.process(request.raw.asHttpBotRequest(request.stringify()))
+}

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/ChatAdapterConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/ChatAdapterConnector.kt
@@ -9,6 +9,8 @@ import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.content
 
 
 internal class ChatAdapterConnector(
@@ -18,6 +20,7 @@ internal class ChatAdapterConnector(
 ) : WithLogger {
 
     private val baseUrl = "$url/restapi/external-bot/$accessToken"
+    private val versionUrl = "$url/version"
 
     fun listChannels(): List<ChannelConfig> = runBlocking {
         try {
@@ -26,6 +29,8 @@ internal class ChatAdapterConnector(
             throw error("Invalid access token: $e")
         }
     }
+
+    fun getVersion() = runBlocking { httpClient.get<JsonObject>(versionUrl)["buildBranch"]?.content }
 
     suspend fun processLogAsync(logModel: JaicpLogModel) {
         try {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/ChatAdapterConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/ChatAdapterConnector.kt
@@ -10,7 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.content
+import kotlinx.serialization.json.jsonPrimitive
 
 
 internal class ChatAdapterConnector(
@@ -24,13 +24,13 @@ internal class ChatAdapterConnector(
 
     fun listChannels(): List<ChannelConfig> = runBlocking {
         try {
-            httpClient.get<List<ChannelConfig>>("$baseUrl/channels")
+            httpClient.get("$baseUrl/channels")
         } catch (e: ClientRequestException) {
             throw error("Invalid access token: $e")
         }
     }
 
-    fun getVersion() = runBlocking { httpClient.get<JsonObject>(versionUrl)["buildBranch"]?.content }
+    fun getVersion() = runBlocking { httpClient.get<JsonObject>(versionUrl)["buildBranch"]?.jsonPrimitive?.content }
 
     suspend fun processLogAsync(logModel: JaicpLogModel) {
         try {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/logging/JaicpConversationLogger.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/logging/JaicpConversationLogger.kt
@@ -39,7 +39,7 @@ open class JaicpConversationLogger(
     httpClient: HttpClient? = null
 ) : ConversationLogger(logObfuscators),
     WithLogger,
-    CoroutineScope by CoroutineScope(Dispatchers.Default) {
+    CoroutineScope by CoroutineScope(Dispatchers.IO + MDCContext()) {
 
     private val client = httpClient ?: HttpClientFactory.create(logLevel)
     private val connector = ChatAdapterConnector(accessToken, url, client)
@@ -48,9 +48,7 @@ open class JaicpConversationLogger(
         try {
             val req = loggingContext.request.jaicpNative?.jaicp ?: extractJaicpRequest(loggingContext) ?: return
             val session = getOrCreateSessionId(loggingContext)
-            launch(MDCContext()) {
-                doLogAsync(req, loggingContext, session)
-            }
+            launch { doLogAsync(req, loggingContext, session) }
         } catch (e: Exception) {
             logger.debug("Failed to produce JAICP LogRequest: ", e)
         }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
@@ -1,56 +1,53 @@
 package com.justai.jaicf.channel.jaicp.polling
 
-import com.justai.jaicf.channel.jaicp.*
-import com.justai.jaicf.channel.jaicp.JaicpMDC
-import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
+import com.justai.jaicf.channel.jaicp.JaicpBotChannel
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
-import com.justai.jaicf.channel.jaicp.dto.JaicpPollingResponse
+import com.justai.jaicf.channel.jaicp.execution.ThreadPoolRequestExecutor
 import com.justai.jaicf.helpers.logging.WithLogger
-import io.ktor.client.HttpClient
+import io.ktor.client.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.slf4j.MDCContext
+import kotlin.coroutines.CoroutineContext
 
 
 internal class Dispatcher(
-    client: HttpClient,
-    private val requestProcessor: (JaicpBotRequest, JaicpBotChannel) -> JaicpBotResponse?
-) :
-    WithLogger,
-    CoroutineScope by CoroutineScope(Dispatchers.Default) {
+    private val client: HttpClient,
+    private val isLegacy: Boolean,
+    nThreads: Int
+) : WithLogger, CoroutineScope {
 
+    private val supervisor = SupervisorJob()
+    override val coroutineContext: CoroutineContext = supervisor + MDCContext()
     private val pollingChannels = mutableListOf<PollingChannel>()
-    private val poller = RequestPoller(client)
-    private val sender = ResponseSender(client)
+    private val sender = ResponseSender(client, isLegacy)
+    private val executor = ThreadPoolRequestExecutor(nThreads)
 
-    fun registerPolling(channel: JaicpBotChannel, proxyUrl: String) {
-        pollingChannels.add(PollingChannel(proxyUrl, channel))
-            .also { logger.info("Registered polling for channel $channel") }
-    }
+    fun registerPolling(channel: JaicpBotChannel, proxyUrl: String) = pollingChannels
+        .add(PollingChannel(proxyUrl, channel, RequestPollerFactory.getPoller(client, proxyUrl, isLegacy)))
+        .also { logger.info("Registered polling for channel $channel") }
 
-    fun startPollingBlocking() {
-        val jobs = pollingChannels.map { channel ->
+    fun startPollingBlocking() = runBlocking {
+        pollingChannels.map { channel ->
             launch(MDCContext()) {
                 logger.info("Starting polling coroutine for channel ${channel.botChannel}")
-                runPollingForChannel(channel)
+                runPolling(channel)
             }
-        }
-        runBlocking { jobs.joinAll() }
+        }.joinAll()
     }
 
-    private suspend fun runPollingForChannel(channel: PollingChannel) {
-        poller.getUpdates(channel.url).collect { rawRequest ->
-            logger.info("Received bot request: $rawRequest")
-            val request = rawRequest.asJaicpPollingRequest().request
-            JaicpMDC.setFromRequest(request)
-            requestProcessor.invoke(request, channel.botChannel)?.let { response ->
-                sendResponse(response, channel.url)
+    private suspend fun runPolling(channel: PollingChannel) {
+        channel.poller.getUpdates().collect { reqs ->
+            reqs.forEach { req ->
+                sendResponse(executor.executeAsync(req, channel.botChannel), channel.url)
             }
         }
     }
 
-    private fun sendResponse(botResponse: JaicpBotResponse, url: String) = launch {
-        sender.processResponse(url, JaicpPollingResponse(botResponse.questionId, botResponse))
+    private fun sendResponse(botResponse: Deferred<JaicpBotResponse?>, url: String) {
+        launch(Dispatchers.IO) {
+            sender.send(url, botResponse)
+        }
     }
 }
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
@@ -14,14 +14,13 @@ import kotlin.coroutines.CoroutineContext
 internal class Dispatcher(
     private val client: HttpClient,
     private val isLegacy: Boolean,
-    nThreads: Int
+    private val executor: ThreadPoolRequestExecutor
 ) : WithLogger, CoroutineScope {
 
     private val supervisor = SupervisorJob()
     override val coroutineContext: CoroutineContext = supervisor + MDCContext()
     private val pollingChannels = mutableListOf<PollingChannel>()
     private val sender = ResponseSender(client, isLegacy)
-    private val executor = ThreadPoolRequestExecutor(nThreads)
 
     fun registerPolling(channel: JaicpBotChannel, proxyUrl: String) = pollingChannels
         .add(PollingChannel(proxyUrl, channel, RequestPollerFactory.getPoller(client, proxyUrl, isLegacy)))

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
@@ -4,5 +4,6 @@ import com.justai.jaicf.channel.jaicp.JaicpBotChannel
 
 internal data class PollingChannel(
     val url: String,
-    val botChannel: JaicpBotChannel
+    val botChannel: JaicpBotChannel,
+    val poller: AbstractRequestPoller
 )

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
@@ -5,5 +5,5 @@ import com.justai.jaicf.channel.jaicp.JaicpBotChannel
 internal data class PollingChannel(
     val url: String,
     val botChannel: JaicpBotChannel,
-    val poller: AbstractRequestPoller
+    val poller: BaseRequestPoller
 )

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPoller.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPoller.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.long
 internal class RequestPoller(
     private val client: HttpClient,
     private val url: String
-) : WithLogger, AbstractRequestPoller() {
+) : WithLogger, BaseRequestPoller() {
 
     private var since: Long = runBlocking {
         client.get<JsonObject>("$url/getTimestamp")["timestamp"]?.long ?: error("Failed to get last message timestamp")
@@ -28,9 +28,9 @@ internal class RequestPoller(
     }
 
     private fun updateSince(requests: List<JaicpBotRequest>) {
-        since = requests.maxBy { it.timestamp?.asSerializedOffsetDateTime() ?: 0 }
-            ?.timestamp?.asSerializedOffsetDateTime()
-            ?: System.currentTimeMillis()
+        since = requests
+            .maxBy { it.timestamp.asSerializedOffsetDateTime() }?.timestamp?.asSerializedOffsetDateTime()
+            ?: since
     }
 }
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPoller.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPoller.kt
@@ -7,6 +7,7 @@ import io.ktor.client.*
 import io.ktor.client.request.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
 
 internal class RequestPoller(
@@ -15,7 +16,8 @@ internal class RequestPoller(
 ) : WithLogger, BaseRequestPoller() {
 
     private var since: Long = runBlocking {
-        client.get<JsonObject>("$url/getTimestamp")["timestamp"]?.long ?: error("Failed to get last message timestamp")
+        client.get<JsonObject>("$url/getTimestamp")["timestamp"]?.jsonPrimitive?.long
+            ?: error("Failed to get last message timestamp")
     }
     private var unprocessed: Boolean = false
 
@@ -29,7 +31,7 @@ internal class RequestPoller(
 
     private fun updateSince(requests: List<JaicpBotRequest>) {
         since = requests
-            .maxBy { it.timestamp.asSerializedOffsetDateTime() }?.timestamp?.asSerializedOffsetDateTime()
+            .maxByOrNull { it.timestamp.asSerializedOffsetDateTime() }?.timestamp?.asSerializedOffsetDateTime()
             ?: since
     }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerFactory.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerFactory.kt
@@ -1,0 +1,37 @@
+package com.justai.jaicf.channel.jaicp.polling
+
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
+import com.justai.jaicf.helpers.logging.WithLogger
+import io.ktor.client.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.isActive
+import kotlin.coroutines.coroutineContext
+
+
+internal abstract class AbstractRequestPoller : WithLogger {
+    suspend fun getUpdates(): Flow<List<JaicpBotRequest>> = flow {
+        while (coroutineContext.isActive) {
+            try {
+                emit(doPoll())
+            } catch (ex: Exception) {
+                delay(500)
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+
+    protected abstract suspend fun doPoll(): List<JaicpBotRequest>
+}
+
+internal object RequestPollerFactory {
+
+    fun getPoller(client: HttpClient, url: String, legacy: Boolean): AbstractRequestPoller {
+        return when (legacy) {
+            true -> RequestPollerLegacy(client, url)
+            false -> RequestPoller(client, url)
+        }
+    }
+}

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerFactory.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerFactory.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.isActive
 import kotlin.coroutines.coroutineContext
 
 
-internal abstract class AbstractRequestPoller : WithLogger {
+internal abstract class BaseRequestPoller : WithLogger {
     suspend fun getUpdates(): Flow<List<JaicpBotRequest>> = flow {
         while (coroutineContext.isActive) {
             try {
@@ -28,7 +28,7 @@ internal abstract class AbstractRequestPoller : WithLogger {
 
 internal object RequestPollerFactory {
 
-    fun getPoller(client: HttpClient, url: String, legacy: Boolean): AbstractRequestPoller {
+    fun getPoller(client: HttpClient, url: String, legacy: Boolean): BaseRequestPoller {
         return when (legacy) {
             true -> RequestPollerLegacy(client, url)
             false -> RequestPoller(client, url)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerLegacy.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerLegacy.kt
@@ -6,6 +6,7 @@ import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.*
 import io.ktor.client.request.*
+import kotlinx.coroutines.delay
 
 @Deprecated("Deprecated long poll api. Will be deleted with all references in further releases.")
 internal class RequestPollerLegacy(
@@ -18,6 +19,7 @@ internal class RequestPollerLegacy(
         return try {
             return listOf(client.get<JaicpPollingRequest>("$url/getUpdates".toUrl()).request)
         } catch (e: Exception) {
+            delay(500L)
             emptyList()
         }
     }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerLegacy.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerLegacy.kt
@@ -12,7 +12,7 @@ internal class RequestPollerLegacy(
     private val client: HttpClient,
     private val url: String
 ) : WithLogger,
-    AbstractRequestPoller() {
+    BaseRequestPoller() {
 
     override suspend fun doPoll(): List<JaicpBotRequest> {
         return try {

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerLegacy.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPollerLegacy.kt
@@ -1,0 +1,24 @@
+package com.justai.jaicf.channel.jaicp.polling
+
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
+import com.justai.jaicf.channel.jaicp.dto.JaicpPollingRequest
+import com.justai.jaicf.helpers.http.toUrl
+import com.justai.jaicf.helpers.logging.WithLogger
+import io.ktor.client.*
+import io.ktor.client.request.*
+
+@Deprecated("Deprecated long poll api. Will be deleted with all references in further releases.")
+internal class RequestPollerLegacy(
+    private val client: HttpClient,
+    private val url: String
+) : WithLogger,
+    AbstractRequestPoller() {
+
+    override suspend fun doPoll(): List<JaicpBotRequest> {
+        return try {
+            return listOf(client.get<JaicpPollingRequest>("$url/getUpdates".toUrl()).request)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+}

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/ResponseSender.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/ResponseSender.kt
@@ -1,19 +1,24 @@
 package com.justai.jaicf.channel.jaicp.polling
 
-
 import com.justai.jaicf.channel.jaicp.deserialized
+import com.justai.jaicf.channel.jaicp.dto.JaicpBotResponse
 import com.justai.jaicf.channel.jaicp.dto.JaicpPollingResponse
 import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.helpers.logging.WithLogger
-import io.ktor.client.HttpClient
-import io.ktor.client.request.post
-import io.ktor.content.TextContent
-import io.ktor.http.ContentType
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import kotlinx.coroutines.Deferred
 
-internal class ResponseSender(private val client: HttpClient) : WithLogger {
-    suspend fun processResponse(url: String, result: JaicpPollingResponse) {
+internal class ResponseSender(private val client: HttpClient, val legacy: Boolean) : WithLogger {
+    suspend fun send(url: String, response: Deferred<JaicpBotResponse?>) {
         try {
-            val text = result.deserialized()
+            val botResponse = response.await() ?: return
+            val text = when (legacy) {
+                true -> JaicpPollingResponse(botResponse.questionId, botResponse).deserialized()
+                false -> botResponse.deserialized()
+            }
             logger.info(text)
             client.post<String>("$url/sendMessage".toUrl()) {
                 body = TextContent(

--- a/core/src/main/kotlin/com/justai/jaicf/context/DialogContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/DialogContext.kt
@@ -8,15 +8,15 @@ import java.util.ArrayDeque
  * Contains all data regarding the current state of the dialogue.
  * Please be careful and edit this class variables values only if you clearly understand what you do.
  */
-class DialogContext: Serializable {
+data class DialogContext(
+    var nextContext: String? = null,
+    var currentContext: String = "/",
+    var nextState: String? = null,
+    var currentState: String = "/",
 
-    var nextContext: String? = null
-    var currentContext: String = "/"
-    var nextState: String? = null
-    var currentState: String = "/"
-
-    val transitions: MutableMap<String, String> = mutableMapOf()
-    val backStateStack = ArrayDeque<String>()
+    val transitions: MutableMap<String, String> = mutableMapOf(),
+    val backStateStack: ArrayDeque<String> = ArrayDeque()
+) : Serializable {
 
     fun nextState(): String? {
         currentState = nextState ?: return null

--- a/core/src/main/kotlin/com/justai/jaicf/context/DialogContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/DialogContext.kt
@@ -8,15 +8,15 @@ import java.util.ArrayDeque
  * Contains all data regarding the current state of the dialogue.
  * Please be careful and edit this class variables values only if you clearly understand what you do.
  */
-data class DialogContext(
-    var nextContext: String? = null,
-    var currentContext: String = "/",
-    var nextState: String? = null,
-    var currentState: String = "/",
+class DialogContext: Serializable {
 
-    val transitions: MutableMap<String, String> = mutableMapOf(),
-    val backStateStack: ArrayDeque<String> = ArrayDeque()
-) : Serializable {
+    var nextContext: String? = null
+    var currentContext: String = "/"
+    var nextState: String? = null
+    var currentState: String = "/"
+
+    val transitions: MutableMap<String, String> = mutableMapOf()
+    val backStateStack = ArrayDeque<String>()
 
     fun nextState(): String? {
         currentState = nextState ?: return null

--- a/core/src/main/kotlin/com/justai/jaicf/context/manager/InMemoryBotContextManager.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/manager/InMemoryBotContextManager.kt
@@ -3,30 +3,31 @@ package com.justai.jaicf.context.manager
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.BotResponse
 import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.DialogContext
 
 /**
  * Simple in-memory [BotContextManager] implementation.
  * Stores every [BotContext] to the internal mutable map with client id as a key.
  */
-object InMemoryBotContextManager: BotContextManager {
+object InMemoryBotContextManager : BotContextManager {
     private val storage = mutableMapOf<String, BotContext>()
 
     /**
      * Fetches a previously stored [BotContext] or creates a new one if it wasn't found.
      *
-     * @param clientId a client identifier
+     * @param request current user's request
      * @return [BotContext] instance
      */
     override fun loadContext(request: BotRequest): BotContext {
-        storage.putIfAbsent(request.clientId, BotContext(request.clientId))
-        return storage[request.clientId]!!
+        val bc = storage.computeIfAbsent(request.clientId) { clientId -> BotContext(clientId) }
+        return bc.copy(dialogContext = bc.dialogContext.copy())
     }
 
     /**
      * Stores a shallow copy [BotContext] to the internal mutable map.
      */
     override fun saveContext(botContext: BotContext, request: BotRequest?, response: BotResponse?) {
-        storage[botContext.clientId] = botContext.copy().apply {
+        storage[botContext.clientId] = botContext.copy(dialogContext = botContext.dialogContext.copy()).apply {
             result = botContext.result
             client.putAll(botContext.client)
             session.putAll(botContext.session)

--- a/core/src/main/kotlin/com/justai/jaicf/test/BotTest.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/test/BotTest.kt
@@ -144,6 +144,7 @@ open class BotTest(private val bot: BotEngine) {
      */
     fun withBackState(path: String) {
         botContext.dialogContext.backStateStack.push(path)
+        saveBotContext()
     }
 
     /**

--- a/examples/jaicp-telephony/src/main/resources/logback.xml
+++ b/examples/jaicp-telephony/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </layout>
+    </appender>
+
+    <root level="ALL">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This PR makes JAICP Polling Connection compatible with new long polling API (since JAICP.Chatadapter 1.10.3 version), also maintaining temporary compatibility for <1.10.2 versions.
Also:
1. Separate thread pools for IO and request executors with configurable thread pool size.
2. Isolation for request processing threads in InMemoryContextManager