### PR TITLE
Fix type of fallback action block

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -162,13 +162,13 @@ abstract class ScenarioBuilder(
      */
     fun fallback(
         state: String = "fallback",
-        body: ActionContext<CatchAllActivatorContext, BotRequest, Reactions>.() -> Unit
+        body: ActionContext<ActivatorContext, BotRequest, Reactions>.() -> Unit
     ) = state(
         name = state,
         noContext = true,
         body = {
             activators { catchAll() }
-            action { ActivatorTypeToken<CatchAllActivatorContext>().invoke(body) }
+            action(body)
         }
     )
 
@@ -188,13 +188,13 @@ abstract class ScenarioBuilder(
     fun <B: BotRequest, R: Reactions> fallback(
         channelToken: ChannelTypeToken<B, R>,
         state: String = "fallback",
-        body: ActionContext<CatchAllActivatorContext, B, R>.() -> Unit
+        body: ActionContext<ActivatorContext, B, R>.() -> Unit
     ) = state(
         name = state,
         noContext = true,
         body = {
             activators { catchAll() }
-            action { (ActivatorTypeToken<CatchAllActivatorContext>() and channelToken).invoke(body) }
+            action { channelToken.invoke(body) }
         }
     )
 


### PR DESCRIPTION
Previously `fallback` action block had `CatchAllActivatorContext` hardcoded as generic activator type. 
But a user can actually do `reactions.go("fallback")` with the current `ActivatorContext` of any type.
So the error occurred when a `fallback` action block was not executed because of hardcoded `CatchAllActivatorContext`.

This PR fixes this issue by setting base `ActivatorContext` as generic activator type for `fallback`.