### PR TITLE
improve Slf4jConversationLogger.kt format

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/logging/Slf4jConversationLogger.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/Slf4jConversationLogger.kt
@@ -24,12 +24,15 @@ class Slf4jConversationLogger(
      * @param loggingContext current request's [LoggingContext] with obfuscated input and reactions
      * */
     override fun doLog(loggingContext: LoggingContext) {
-        logger.debug(
+        val replies = loggingContext.reactions.joinToString(separator = "\n\t\t", prefix = "\n\t\t") {
+            it.toString().replace("\n", "\\n")
+        }
+        logger.info(
             """
             |
-            |Processing ${loggingContext.request::class.simpleName} with input "${loggingContext.input}" finished
-            |SelectedActivator: ${loggingContext.activationContext?.activator?.name} with state ${loggingContext.activationContext?.activation?.state}
-            |Reactions: ${loggingContext.reactions}""".trimMargin()
+            |  Processing ${loggingContext.request::class.simpleName} with input "${loggingContext.input}"
+            |  SelectedActivator: ${loggingContext.activationContext?.activator?.name} with state ${loggingContext.activationContext?.activation?.state}
+            |  Reactions: $replies""".trimMargin()
         )
     }
 }


### PR DESCRIPTION
Simple improvement of Slf4jConversationLogger format

old: 
```
09:53:17.515 [pool-1-thread-2] DEBUG c.j.j.l.Slf4jConversationLogger - 
Processing ChatWidgetBotRequest with input "/start" finished
SelectedActivator: regexActivator with state /start
Reactions: [reply "Hello! Please say something to test speech recognition." from state /start, reply "this is fine" from state /start, buttons [this is very bad, anotherbutton] from state /start, transition from state /start to state /bye, reply "Bye-bye!" from state /bye]
```

new: 
```
09:53:17.515 [pool-1-thread-2] INFO c.j.j.l.Slf4jConversationLogger - 
  Processing ChatWidgetBotRequest with input "/start"
  SelectedActivator: regexActivator with state /start
  Reactions: 
		reply "Hello! Please say something to test speech recognition." from state /start
		reply "this is fine. \nNewLine\n\nNewLineAgain" from state /start
		buttons [this is very bad, anotherbutton] from state /start
		transition from state /start to state /bye
		reply "Bye-bye!" from state /bye
```