### PR TITLE
fix hooks exposure from subscenario to main, release-0.13.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.justai.jaicf"
-    version = "0.13.0"
+    version = "0.13.1"
 
     repositories {
         google()

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -109,7 +109,7 @@ sealed class ScenarioGraphBuilder<B : BotRequest, R : Reactions>(
     @ScenarioDsl
     fun append(other: Scenario) {
         val isRoot = this is RootBuilder
-        doAppend(other, ignoreHooks = true, exposeHooks = isRoot, propagateHooks = true)
+        doAppend(other, ignoreHooks = !isRoot, exposeHooks = isRoot, propagateHooks = true)
     }
 
     /**


### PR DESCRIPTION
This fixes default append logic. On doing append like
```kotlin
val scenario = Scenario {
    append(other)
}
```
ScenarioBuilder should expose subscenario hooks and propagate it's own hooks (we expect JAICP-like behaviour).

This fixes default append logic so it then works like JAICP.