### PR TITLE
apply transitions verification to built project

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -63,7 +63,7 @@ class BotEngine(
     private val conversationLoggers: Array<ConversationLogger> = arrayOf(Slf4jConversationLogger())
 ) : BotApi, WithLogger {
 
-    val model = scenario.scenario
+    val model = scenario.scenario.verify()
 
     private val activators = activators.map { it.create(model) }.addBuiltinActivators()
 

--- a/core/src/main/kotlin/com/justai/jaicf/model/ScenarioModelBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/ScenarioModelBuilder.kt
@@ -11,7 +11,6 @@ import com.justai.jaicf.model.scenario.ScenarioModel
 import com.justai.jaicf.model.state.State
 import com.justai.jaicf.model.state.StatePath
 import com.justai.jaicf.model.transition.Transition
-import kotlin.reflect.KClass
 
 internal class ScenarioModelBuilder {
 
@@ -61,13 +60,6 @@ internal class ScenarioModelBuilder {
         val paths = mutableSetOf<String>()
         states.map { it.path.toString() }.forEach {
             check(paths.add(it)) { "Duplicated declaration of state with path '$it'." }
-        }
-        transitions.forEach {
-            val missing = it.fromState.takeIf { it !in paths } ?: it.toState.takeIf { it !in paths }
-            check(missing == null) {
-                "Cannot create transition from '${it.fromState}' to '${it.toState}'" +
-                        " as the state with path '${it.fromState}' doesn't exist."
-            }
         }
         return this
     }

--- a/core/src/main/kotlin/com/justai/jaicf/model/scenario/ScenarioModel.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/scenario/ScenarioModel.kt
@@ -4,7 +4,6 @@ import com.justai.jaicf.hook.BotHook
 import com.justai.jaicf.hook.BotHookListener
 import com.justai.jaicf.model.state.State
 import com.justai.jaicf.model.transition.Transition
-import kotlin.reflect.KClass
 
 /**
  * Represents a model of the dialog scenario.
@@ -18,4 +17,17 @@ data class ScenarioModel(
     val states: Map<String, State> = mapOf(),
     val transitions: List<Transition> = listOf(),
     val hooks: List<BotHookListener<BotHook>> = listOf()
-)
+) {
+
+    fun verify(): ScenarioModel {
+        val paths = states.keys
+        transitions.forEach {
+            val missing = it.fromState.takeIf { it !in paths } ?: it.toState.takeIf { it !in paths }
+            check(missing == null) {
+                "Cannot create transition from '${it.fromState}' to '${it.toState}'" +
+                        " as the state with path '${it.fromState}' doesn't exist."
+            }
+        }
+        return this
+    }
+}


### PR DESCRIPTION
**Bug description:**
We have a verification method to check if all transitions are correct and lead to existing states. The problem is that if we have non-isolated scenarios with cross-dependencies we cannot verify `fromState` transitions as these states are in separate scenario.

**Example scenario with bug:**
```kotlin
val NotIsolatedScenario = Scenario {
    state("second") {
        activators(fromState = "/first") { // fails verification 
            regex("ok")
        }
    }
}
val BugScenario = Scenario(telephony) {
    append(NotIsolatedScenario)
    state("first") {
        activators(fromState = "/second") {
            regex("ok")
        }
    }
}
fun main(args: Array<String>) {
    BotEngine(BugScenario)
}
```

**Solution:**
Execute verification only on complete `ScenarioModel`.