### PR TITLE
persist temp data for conversation loggers

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -118,8 +118,8 @@ class BotEngine(
                 tryHandleWithHook(AnyErrorHook(botContext, request, reactions, exception), executionContext, false)
             }
 
-            botContext.cleanTempData()
             conversationLoggers.forEach { it.obfuscateAndLog(executionContext) }
+            botContext.cleanTempData()
             saveContext(manager, botContext, request, reactions, requestContext)
         } catch (e: Exception) {
             logger.error("", e)


### PR DESCRIPTION
This will allow conversationLoggers to see and use BotContext.temp data