### PR TITLE
add DefaultActionContext typealias

### DIFF
--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/ScenarioFactory.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/ScenarioFactory.kt
@@ -1,15 +1,14 @@
 package com.justai.jaicf.channel.jaicp
 
 import com.justai.jaicf.builder.Scenario
-import com.justai.jaicf.context.ActionContext
-import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.context.DefaultActionContext
 
 object ScenarioFactory {
     fun echo() = Scenario {
         fallback { reactions.say("You said: ${request.input}") }
     }
 
-    fun echoWithAction(block: ActionContext<*, *, *>.() -> Unit) = Scenario {
+    fun echoWithAction(block: DefaultActionContext.() -> Unit) = Scenario {
         fallback {
             block()
         }

--- a/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ActionContext.kt
@@ -97,3 +97,5 @@ open class ActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
     operator fun <A1: A, B1: B, R1: R, T> ContextTypeToken<A1, B1, R1>.invoke(action: ActionContext<A1, B1, R1>.() -> T): T? =
         safeCast(this)?.run(action)
 }
+
+typealias DefaultActionContext = ActionContext<out ActivatorContext, out BotRequest, out Reactions>

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/action/Generic.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/action/Generic.kt
@@ -3,18 +3,19 @@ package com.justai.jaicf.helpers.action
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.ActivatorContext
+import com.justai.jaicf.context.DefaultActionContext
 import com.justai.jaicf.generic.ActivatorTypeToken
 import com.justai.jaicf.generic.ChannelTypeToken
 import com.justai.jaicf.generic.ContextTypeToken
 import com.justai.jaicf.reactions.Reactions
 
-fun ActionContext<*, *, *>.ofType(activatorToken: ActivatorTypeToken<*>): Boolean =
+fun DefaultActionContext.ofType(activatorToken: ActivatorTypeToken<*>): Boolean =
     activatorToken.isInstance(activator)
 
-fun ActionContext<*, *, *>.ofType(channelToken: ChannelTypeToken<*, *>): Boolean =
+fun DefaultActionContext.ofType(channelToken: ChannelTypeToken<*, *>): Boolean =
     channelToken.isInstance(request) && channelToken.isInstance(reactions)
 
-fun ActionContext<*, *, *>.ofType(contextToken: ContextTypeToken<*, *, *>): Boolean =
+fun DefaultActionContext.ofType(contextToken: ContextTypeToken<*, *, *>): Boolean =
     contextToken.isInstance(activator) && contextToken.isInstance(request) && contextToken.isInstance(reactions)
 
 @Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
@@ -1,17 +1,17 @@
 package com.justai.jaicf.helpers.action
 
-import com.justai.jaicf.context.ActionContext
+import com.justai.jaicf.context.DefaultActionContext
 import com.justai.jaicf.test.context.TestActionContext
 import kotlin.random.Random
 
-internal fun random(max: Int, context: ActionContext<*, *, *>): Int {
+internal fun random(max: Int, context: DefaultActionContext): Int {
     return when(context) {
         is TestActionContext -> context.nextRandomInt()
         else -> Random.nextInt(max)
     }
 }
 
-internal fun smartRandom(max: Int, context: ActionContext<*, *, *>): Int {
+internal fun smartRandom(max: Int, context: DefaultActionContext): Int {
     val bc = context.context
     val id = "${bc.dialogContext.currentState}_$max"
     var smartRandom: MutableMap<String, MutableList<Int>>? by bc.session

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/logging/Log.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/logging/Log.kt
@@ -1,9 +1,9 @@
 package com.justai.jaicf.helpers.logging
 
-import com.justai.jaicf.context.ActionContext
+import com.justai.jaicf.context.DefaultActionContext
 import org.slf4j.LoggerFactory
 
-val ActionContext<*, *, *>.logger
+val DefaultActionContext.logger
     get() = LoggerFactory.getLogger(this.context.dialogContext.currentState)
 
-fun ActionContext<*, *, *>.log(msg: String) = logger.info(msg)
+fun DefaultActionContext.log(msg: String) = logger.info(msg)

--- a/core/src/main/kotlin/com/justai/jaicf/test/context/TestActionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/test/context/TestActionContext.kt
@@ -4,7 +4,7 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.ActivatorContext
 import com.justai.jaicf.context.BotContext
-import com.justai.jaicf.context.ProcessContext
+import com.justai.jaicf.context.DefaultActionContext
 import com.justai.jaicf.reactions.Reactions
 
 /**
@@ -34,7 +34,7 @@ data class TestActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
 /**
  * Indicates if scenario is running in test mode
  */
-fun ActionContext<*, *, *>.isTestMode() = this is TestActionContext
+fun DefaultActionContext.isTestMode() = this is TestActionContext
 
 /**
  * Runs this block of code only if the scenario is running in test mode

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
@@ -3,6 +3,7 @@ package com.justai.jaicf.core.test
 import com.justai.jaicf.api.QueryBotRequest
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.DefaultActionContext
 import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.helpers.action.smartRandom
 import com.justai.jaicf.test.reactions.TestReactions
@@ -13,7 +14,7 @@ import java.util.*
 
 class SmartRandomTest {
 
-    private lateinit var context: ActionContext<*, *, *>
+    private lateinit var context: DefaultActionContext
 
     @BeforeEach
     fun createContext() {


### PR DESCRIPTION
Current generic ActionContext is quite hard for users to write extensions.

This adds `DefaultActionContext` typealias to make writing extensions less hard. It will be also reflected in wiki.