### PR TITLE
rename scenario field in Scenario.kt to model, create builders for scenarioModel

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -63,7 +63,7 @@ class BotEngine(
     private val conversationLoggers: Array<ConversationLogger> = arrayOf(Slf4jConversationLogger())
 ) : BotApi, WithLogger {
 
-    val model = scenario.scenario.verify()
+    val model = scenario.model.verify()
 
     private val activators = activators.map { it.create(model) }.addBuiltinActivators()
 

--- a/core/src/main/kotlin/com/justai/jaicf/builder/Scenario.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/Scenario.kt
@@ -4,6 +4,7 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.generic.ChannelTypeToken
 import com.justai.jaicf.model.ScenarioModelBuilder
 import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.model.scenario.ScenarioModel
 import com.justai.jaicf.model.state.State
 import com.justai.jaicf.model.state.StatePath
 import com.justai.jaicf.reactions.Reactions
@@ -14,7 +15,7 @@ fun <B : BotRequest, R : Reactions> Scenario(
     channelToken: ChannelTypeToken<B, R>,
     body: RootBuilder<B, R>.() -> Unit
 ): Scenario = object : Scenario {
-    override val scenario by lazy { RootBuilder(ScenarioModelBuilder(), channelToken).apply(body).buildScenario() }
+    override val model by lazy { RootBuilder(ScenarioModelBuilder(), channelToken).apply(body).buildScenario() }
 }
 
 @ScenarioDsl
@@ -22,8 +23,19 @@ fun Scenario(
     body: RootBuilder<BotRequest, Reactions>.() -> Unit
 ): Scenario = Scenario(ChannelTypeToken.Default, body)
 
+@ScenarioDsl
+fun createModel(
+    body: RootBuilder<BotRequest, Reactions>.() -> Unit
+): ScenarioModel = Scenario(ChannelTypeToken.Default, body).model
+
+@ScenarioDsl
+fun <B : BotRequest, R : Reactions> createModel(
+    channelToken: ChannelTypeToken<B, R>,
+    body: RootBuilder<B, R>.() -> Unit
+): ScenarioModel = Scenario(channelToken, body).model
+
 infix fun Scenario.append(other: Scenario): Scenario = object : Scenario {
-    override val scenario by lazy {
+    override val model by lazy {
         ScenarioModelBuilder().also {
             it.states += State(StatePath.root(), noContext = false, modal = false)
             it.append(StatePath.root(), this@append, ignoreHooks = false, exposeHooks = true, propagateHooks = true)

--- a/core/src/main/kotlin/com/justai/jaicf/builder/Scenario.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/Scenario.kt
@@ -11,28 +11,28 @@ import com.justai.jaicf.reactions.Reactions
 
 
 @ScenarioDsl
-fun <B : BotRequest, R : Reactions> Scenario(
-    channelToken: ChannelTypeToken<B, R>,
-    body: RootBuilder<B, R>.() -> Unit
-): Scenario = object : Scenario {
-    override val model by lazy { RootBuilder(ScenarioModelBuilder(), channelToken).apply(body).buildScenario() }
-}
-
-@ScenarioDsl
 fun Scenario(
     body: RootBuilder<BotRequest, Reactions>.() -> Unit
 ): Scenario = Scenario(ChannelTypeToken.Default, body)
 
 @ScenarioDsl
+fun <B : BotRequest, R : Reactions> Scenario(
+    channelToken: ChannelTypeToken<B, R>,
+    body: RootBuilder<B, R>.() -> Unit
+): Scenario = object : Scenario {
+    override val model by lazy { createModel(channelToken, body) }
+}
+
+@ScenarioDsl
 fun createModel(
     body: RootBuilder<BotRequest, Reactions>.() -> Unit
-): ScenarioModel = Scenario(ChannelTypeToken.Default, body).model
+): ScenarioModel = createModel(ChannelTypeToken.Default, body)
 
 @ScenarioDsl
 fun <B : BotRequest, R : Reactions> createModel(
     channelToken: ChannelTypeToken<B, R>,
     body: RootBuilder<B, R>.() -> Unit
-): ScenarioModel = Scenario(channelToken, body).model
+): ScenarioModel = RootBuilder(ScenarioModelBuilder(), channelToken).apply(body).buildScenario()
 
 infix fun Scenario.append(other: Scenario): Scenario = object : Scenario {
     override val model by lazy {

--- a/core/src/main/kotlin/com/justai/jaicf/model/ScenarioModelBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/ScenarioModelBuilder.kt
@@ -31,7 +31,7 @@ internal class ScenarioModelBuilder {
     }
 
     fun append(path: StatePath, other: Scenario, ignoreHooks: Boolean, exposeHooks: Boolean, propagateHooks: Boolean) {
-        val otherModel = other.scenario.resolve(path)
+        val otherModel = other.model.resolve(path)
         states += otherModel.states.values.filterNot { it.path.toString() == path.toString() }
         transitions += otherModel.transitions
 

--- a/core/src/main/kotlin/com/justai/jaicf/model/scenario/Scenario.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/scenario/Scenario.kt
@@ -2,6 +2,25 @@ package com.justai.jaicf.model.scenario
 
 import kotlin.reflect.KProperty
 
+/**
+ * Main interface for Scenario objects.
+ *
+ * Scenario objects should be generally created by using [com.justai.jaicf.builder.Scenario] function.
+ * Alternative way for creating a scenario is by implementing this interface, see example:
+ * ```kotlin
+ * class MyScenario() : Scenario {
+ *   override val model: ScenarioModel = createModel {
+ *     // your states
+ *     }
+ * }
+ *
+ * ```
+ *
+ * @property model model of scenario
+ *
+ * @see [com.justai.jaicf.builder.Scenario]
+ * @see [com.justai.jaicf.builder.createModel]
+ * */
 interface Scenario {
     val model: ScenarioModel
 }

--- a/core/src/main/kotlin/com/justai/jaicf/model/scenario/Scenario.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/scenario/Scenario.kt
@@ -1,26 +1,9 @@
 package com.justai.jaicf.model.scenario
 
-import com.justai.jaicf.api.BotRequest
-import com.justai.jaicf.builder.RootBuilder
-import com.justai.jaicf.builder.Scenario
-import com.justai.jaicf.builder.ScenarioDsl
-import com.justai.jaicf.generic.ChannelTypeToken
-import com.justai.jaicf.reactions.Reactions
 import kotlin.reflect.KProperty
 
 interface Scenario {
-    val scenario: ScenarioModel
-
-    @ScenarioDsl
-    fun Scenario.createScenario(
-        body: RootBuilder<BotRequest, Reactions>.() -> Unit
-    ): ScenarioModel = Scenario(ChannelTypeToken.Default, body).scenario
-
-    @ScenarioDsl
-    fun <B : BotRequest, R : Reactions> Scenario.createScenario(
-        channelToken: ChannelTypeToken<B, R>,
-        body: RootBuilder<B, R>.() -> Unit
-    ): ScenarioModel = Scenario(channelToken, body).scenario
+    val model: ScenarioModel
 }
 
-operator fun Scenario.getValue(thisRef: Scenario, property: KProperty<*>): ScenarioModel = scenario
+operator fun Scenario.getValue(thisRef: Scenario, property: KProperty<*>): ScenarioModel = model

--- a/core/src/main/kotlin/com/justai/jaicf/model/scenario/ScenarioModel.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/scenario/ScenarioModel.kt
@@ -8,10 +8,11 @@ import com.justai.jaicf.model.transition.Transition
 /**
  * Represents a model of the dialog scenario.
  * Contains a required data that is used by [com.justai.jaicf.api.BotApi] implementation during the user's request processing.
- * This class should not be used directly from your code. You should use [com.justai.jaicf.builder.ScenarioBuilder] instead.
+ * This class should not be used directly from your code. You should use [com.justai.jaicf.builder.Scenario] or [com.justai.jaicf.builder.createModel] instead.
  * Can be concatenated with other models to create a merged [ScenarioModel].
  *
- * @see com.justai.jaicf.builder.ScenarioBuilder
+ * @see com.justai.jaicf.builder.Scenario
+ * @see com.justai.jaicf.builder.createModel
  */
 data class ScenarioModel(
     val states: Map<String, State> = mapOf(),

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GameLoopScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GameLoopScenario.kt
@@ -5,7 +5,7 @@ import com.google.api.services.actions_fulfillment.v2.model.TableCardCell
 import com.google.api.services.actions_fulfillment.v2.model.TableCardColumnProperties
 import com.google.api.services.actions_fulfillment.v2.model.TableCardRow
 import com.justai.jaicf.activator.intent.intent
-import com.justai.jaicf.builder.Scenario
+import com.justai.jaicf.builder.createModel
 import com.justai.jaicf.channel.alexa.AlexaReactions
 import com.justai.jaicf.channel.alexa.alexa
 import com.justai.jaicf.channel.alexa.model.AlexaEvent
@@ -16,7 +16,6 @@ import com.justai.jaicf.examples.gameclock.GameController
 import com.justai.jaicf.examples.gameclock.model.colorLink
 import com.justai.jaicf.helpers.ssml.*
 import com.justai.jaicf.model.scenario.Scenario
-import com.justai.jaicf.model.scenario.getValue
 import kotlin.math.floor
 
 object GameLoopScenario : Scenario {
@@ -26,7 +25,7 @@ object GameLoopScenario : Scenario {
 
     const val play = "/play"
 
-    override val scenario by Scenario {
+    override val model = createModel {
 
         state(play) {
 

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GameSetupScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GameSetupScenario.kt
@@ -1,16 +1,15 @@
 package com.justai.jaicf.examples.gameclock.scenario
 
-import com.justai.jaicf.builder.Scenario
+import com.justai.jaicf.builder.createModel
 import com.justai.jaicf.examples.gameclock.GameController
 import com.justai.jaicf.examples.gameclock.model.supportedColors
 import com.justai.jaicf.model.scenario.Scenario
-import com.justai.jaicf.model.scenario.getValue
 
 object GameSetupScenario : Scenario {
 
     const val state = "/setup"
 
-    override val scenario by Scenario {
+    override val model = createModel {
 
         append(GamersCountScenario(2, supportedColors.size))
         append(GamersColorsScenario)

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersColorsScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersColorsScenario.kt
@@ -1,11 +1,9 @@
 package com.justai.jaicf.examples.gameclock.scenario
 
-import com.justai.jaicf.builder.Scenario
-import com.justai.jaicf.channel.alexa.activator.alexaIntent
+import com.justai.jaicf.builder.createModel
 import com.justai.jaicf.channel.alexa.alexa
 import com.justai.jaicf.channel.alexa.intent
 import com.justai.jaicf.channel.googleactions.actions
-import com.justai.jaicf.channel.googleactions.dialogflow.actionsDialogflow
 import com.justai.jaicf.channel.googleactions.intent
 import com.justai.jaicf.examples.gameclock.GameController
 import com.justai.jaicf.examples.gameclock.model.supportedColors
@@ -14,14 +12,13 @@ import com.justai.jaicf.helpers.ssml.break500ms
 import com.justai.jaicf.helpers.ssml.fast
 import com.justai.jaicf.helpers.ssml.ordinal
 import com.justai.jaicf.model.scenario.Scenario
-import com.justai.jaicf.model.scenario.getValue
 import com.justai.jaicf.test.context.runInTest
 
 object GamersColorsScenario : Scenario {
 
     const val state = "/setup/colors"
 
-    override val scenario by Scenario {
+    override val model = createModel {
         state(state) {
             action {
                 val game = GameController(context)

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersCountScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersCountScenario.kt
@@ -1,15 +1,12 @@
 package com.justai.jaicf.examples.gameclock.scenario
 
-import com.justai.jaicf.builder.Scenario
-import com.justai.jaicf.channel.alexa.activator.alexaIntent
+import com.justai.jaicf.builder.createModel
 import com.justai.jaicf.channel.alexa.alexa
 import com.justai.jaicf.channel.alexa.intent
 import com.justai.jaicf.channel.googleactions.actions
-import com.justai.jaicf.channel.googleactions.dialogflow.actionsDialogflow
 import com.justai.jaicf.channel.googleactions.intent
 import com.justai.jaicf.helpers.ssml.breakMs
 import com.justai.jaicf.model.scenario.Scenario
-import com.justai.jaicf.model.scenario.getValue
 import com.justai.jaicf.test.context.runInTest
 
 class GamersCountScenario(private val min: Int, private val max: Int) : Scenario {
@@ -18,7 +15,7 @@ class GamersCountScenario(private val min: Int, private val max: Int) : Scenario
         const val state = "/setup/gamers"
     }
 
-    override val scenario by Scenario {
+    override val model = createModel {
 
         state(state) {
             action {

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/MainScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/MainScenario.kt
@@ -1,6 +1,6 @@
 package com.justai.jaicf.examples.gameclock.scenario
 
-import com.justai.jaicf.builder.Scenario
+import com.justai.jaicf.builder.createModel
 import com.justai.jaicf.channel.alexa.alexa
 import com.justai.jaicf.channel.alexa.intent
 import com.justai.jaicf.channel.alexa.model.AlexaEvent
@@ -14,11 +14,10 @@ import com.justai.jaicf.helpers.ssml.break300ms
 import com.justai.jaicf.helpers.ssml.break500ms
 import com.justai.jaicf.helpers.ssml.breakMs
 import com.justai.jaicf.model.scenario.Scenario
-import com.justai.jaicf.model.scenario.getValue
 
 object MainScenario : Scenario {
 
-    override val scenario by Scenario {
+    override val model = createModel {
 
         append(GameSetupScenario)
         append(GameLoopScenario)


### PR DESCRIPTION
This renames `scenario` field in `Scenario.kt` interface to `model`, resolves naming conflicts