### PR TITLE
add carousel in Facebook channel

### DIFF
--- a/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaReactions.kt
+++ b/channels/alexa/src/main/kotlin/com/justai/jaicf/channel/alexa/AlexaReactions.kt
@@ -2,17 +2,25 @@ package com.justai.jaicf.channel.alexa
 
 import com.amazon.ask.dispatcher.request.handler.HandlerInput
 import com.amazon.ask.model.interfaces.alexa.presentation.apl.RenderDocumentDirective
-import com.amazon.ask.model.interfaces.audioplayer.*
+import com.amazon.ask.model.interfaces.audioplayer.AudioItem
+import com.amazon.ask.model.interfaces.audioplayer.AudioItemMetadata
+import com.amazon.ask.model.interfaces.audioplayer.PlayBehavior
+import com.amazon.ask.model.interfaces.audioplayer.PlayDirective
+import com.amazon.ask.model.interfaces.audioplayer.Stream
 import com.amazon.ask.model.interfaces.display.Image
 import com.amazon.ask.model.services.DefaultApiConfiguration
-import com.amazon.ask.model.services.directive.*
+import com.amazon.ask.model.services.directive.Directive
+import com.amazon.ask.model.services.directive.DirectiveServiceClient
+import com.amazon.ask.model.services.directive.Header
+import com.amazon.ask.model.services.directive.SendDirectiveRequest
+import com.amazon.ask.model.services.directive.SpeakDirective
 import com.amazon.ask.request.RequestHelper
 import com.amazon.ask.services.ApacheHttpApiClient
 import com.amazon.ask.util.JacksonSerializer
 import com.justai.jaicf.logging.AudioReaction
+import com.justai.jaicf.logging.SayReaction
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.ResponseReactions
-import com.justai.jaicf.logging.SayReaction
 
 val Reactions.alexa
     get() = this as? AlexaReactions

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
@@ -13,8 +13,8 @@ import com.justai.jaicf.channel.facebook.api.FacebookBotRequest
 import com.justai.jaicf.channel.facebook.messenger.Messenger
 import com.justai.jaicf.logging.AudioReaction
 import com.justai.jaicf.logging.ImageReaction
-import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.logging.SayReaction
+import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.jaicp.JaicpCompatibleAsyncReactions
 import java.net.URL
 

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
@@ -6,9 +6,12 @@ import com.github.messenger4j.send.MessagingType
 import com.github.messenger4j.send.Payload
 import com.github.messenger4j.send.message.Message
 import com.github.messenger4j.send.message.RichMediaMessage
+import com.github.messenger4j.send.message.TemplateMessage
 import com.github.messenger4j.send.message.TextMessage
 import com.github.messenger4j.send.message.richmedia.RichMediaAsset
 import com.github.messenger4j.send.message.richmedia.UrlRichMediaAsset
+import com.github.messenger4j.send.message.template.GenericTemplate
+import com.github.messenger4j.send.message.template.common.Element
 import com.justai.jaicf.channel.facebook.api.FacebookBotRequest
 import com.justai.jaicf.channel.facebook.messenger.Messenger
 import com.justai.jaicf.logging.AudioReaction
@@ -60,5 +63,11 @@ class FacebookReactions(
 
     fun file(url: String) {
         sendUrlRichMediaResponse(url, RichMediaAsset.Type.FILE)
+    }
+
+    fun carousel(vararg elements: Element) {
+        val template = GenericTemplate.create(elements.toList())
+        val message = TemplateMessage.create(template)
+        sendResponse(message)
     }
 }

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookCarousel.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookCarousel.kt
@@ -1,0 +1,42 @@
+package com.justai.jaicf.channel.facebook.api
+
+import com.github.messenger4j.common.WebviewHeightRatio
+import com.github.messenger4j.common.WebviewShareButtonState
+import com.github.messenger4j.messengerprofile.DeleteMessengerSettingsPayload
+import com.github.messenger4j.send.message.template.common.DefaultAction
+import com.github.messenger4j.send.message.template.common.Element
+import java.net.URL
+import java.util.*
+import com.github.messenger4j.send.message.template.button.Button
+
+data class CarouselElement(
+    val title: String,
+    val subtitle: String? = null,
+    val imageUrl: URL? = null,
+    val defaultAction: Action? = null,
+    val buttons: List<Button>? = null
+)
+
+data class Action(
+    val url: URL,
+    val webviewHeightRatio: WebviewHeightRatio? = null,
+    val messengerExtensions: Boolean? = null,
+    val fallbackUrl: URL? = null,
+    val webviewShareButtonState: WebviewShareButtonState? = null
+)
+
+internal fun CarouselElement.toTemplateElement(): Element = Element.create(
+    title,
+    Optional.ofNullable(subtitle),
+    Optional.ofNullable(imageUrl),
+    Optional.ofNullable(defaultAction?.toTemplateAction()),
+    Optional.ofNullable(buttons)
+)
+
+internal fun Action.toTemplateAction() = DefaultAction.create(
+    url,
+    Optional.ofNullable(webviewHeightRatio),
+    Optional.ofNullable(messengerExtensions),
+    Optional.ofNullable(fallbackUrl),
+    Optional.ofNullable(webviewShareButtonState)
+)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -5,13 +5,19 @@ import com.justai.jaicf.activator.event.EventActivatorContext
 import com.justai.jaicf.activator.intent.IntentActivatorContext
 import com.justai.jaicf.activator.regex.RegexActivatorContext
 import com.justai.jaicf.channel.jaicp.JSON
+import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselSlide
 import com.justai.jaicf.channel.jaicp.logging.internal.SessionData
 import com.justai.jaicf.channel.jaicp.toJson
 import com.justai.jaicf.context.ExecutionContext
 import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.exceptions.BotException
 import com.justai.jaicf.exceptions.scenarioCause
-import com.justai.jaicf.logging.*
+import com.justai.jaicf.logging.AudioReaction
+import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.logging.CarouselReaction
+import com.justai.jaicf.logging.ImageReaction
+import com.justai.jaicf.logging.Reaction
+import com.justai.jaicf.logging.SayReaction
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -183,8 +189,22 @@ private fun List<Reaction>.toReplies() = mapNotNull { r ->
         is ImageReaction -> ImageReply(r.imageUrl, state = r.fromState)
         is AudioReaction -> AudioReply(audioUrl = r.audioUrl, state = r.fromState)
         is ButtonsReaction -> ButtonsReply(buttons = r.buttons.map { Button(it) }, state = r.fromState)
+        is CarouselReaction -> r.toReply()
         else -> null
     }
 }.toMutableList()
+
+private fun CarouselReaction.toReply() = CarouselReply(
+    title,
+    slides.map {
+        CarouselSlide(
+            title = it.title,
+            buttonText = it.buttonText,
+            description = it.description,
+            imageUrl = it.imageUrl,
+            sourceUrl = it.sourceUrl
+        )
+    }
+)
 
 private fun BotException.toReply() = ErrorReply(scenarioCause.stackTraceToString(), currentState, "")

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -5,14 +5,19 @@ import com.justai.jaicf.activator.event.EventActivatorContext
 import com.justai.jaicf.activator.intent.IntentActivatorContext
 import com.justai.jaicf.activator.regex.RegexActivatorContext
 import com.justai.jaicf.channel.jaicp.JSON
-import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselSlide
+import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselElement
 import com.justai.jaicf.channel.jaicp.logging.internal.SessionData
 import com.justai.jaicf.channel.jaicp.toJson
 import com.justai.jaicf.context.ExecutionContext
 import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.exceptions.BotException
 import com.justai.jaicf.exceptions.scenarioCause
-import com.justai.jaicf.logging.*
+import com.justai.jaicf.logging.AudioReaction
+import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.logging.CarouselReaction
+import com.justai.jaicf.logging.ImageReaction
+import com.justai.jaicf.logging.Reaction
+import com.justai.jaicf.logging.SayReaction
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -192,7 +197,7 @@ private fun List<Reaction>.toReplies() = mapNotNull { r ->
 private fun CarouselReaction.toReply() = CarouselReply(
     title,
     elements.map {
-        CarouselSlide(
+        CarouselElement(
             title = it.title,
             buttonText = it.buttons.firstOrNull() ?: "",
             description = it.description,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -5,7 +5,6 @@ import com.justai.jaicf.activator.event.EventActivatorContext
 import com.justai.jaicf.activator.intent.IntentActivatorContext
 import com.justai.jaicf.activator.regex.RegexActivatorContext
 import com.justai.jaicf.channel.jaicp.JSON
-import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselElement
 import com.justai.jaicf.channel.jaicp.logging.internal.SessionData
 import com.justai.jaicf.channel.jaicp.toJson
 import com.justai.jaicf.context.ExecutionContext
@@ -197,12 +196,12 @@ private fun List<Reaction>.toReplies() = mapNotNull { r ->
 private fun CarouselReaction.toReply() = CarouselReply(
     title,
     elements.map {
-        CarouselElement(
+        CarouselReply.Element(
             title = it.title,
-            buttonText = it.buttons.firstOrNull() ?: "",
+            buttonText = it.buttons.firstOrNull()?.text ?: "",
             description = it.description,
             imageUrl = it.imageUrl,
-            buttonRedirectUrl = it.buttonRedirectUrl
+            buttonRedirectUrl = it.buttons.firstOrNull()?.url
         )
     }
 )

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -198,7 +198,7 @@ private fun CarouselReaction.toReply() = CarouselReply(
     elements.map {
         CarouselReply.Element(
             title = it.title,
-            buttonText = it.buttons.firstOrNull()?.text ?: "",
+            button = it.buttons.firstOrNull()?.text ?: "",
             description = it.description,
             imageUrl = it.imageUrl,
             buttonRedirectUrl = it.buttons.firstOrNull()?.url

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -12,12 +12,7 @@ import com.justai.jaicf.context.ExecutionContext
 import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.exceptions.BotException
 import com.justai.jaicf.exceptions.scenarioCause
-import com.justai.jaicf.logging.AudioReaction
-import com.justai.jaicf.logging.ButtonsReaction
-import com.justai.jaicf.logging.CarouselReaction
-import com.justai.jaicf.logging.ImageReaction
-import com.justai.jaicf.logging.Reaction
-import com.justai.jaicf.logging.SayReaction
+import com.justai.jaicf.logging.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -196,13 +191,13 @@ private fun List<Reaction>.toReplies() = mapNotNull { r ->
 
 private fun CarouselReaction.toReply() = CarouselReply(
     title,
-    slides.map {
+    elements.map {
         CarouselSlide(
             title = it.title,
-            buttonText = it.buttonText,
+            buttonText = it.buttons.firstOrNull() ?: "",
             description = it.description,
             imageUrl = it.imageUrl,
-            sourceUrl = it.sourceUrl
+            buttonRedirectUrl = it.buttonRedirectUrl
         )
     }
 )

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -61,11 +61,11 @@ data class CarouselReply(
     @SerialName("text")
     val title: String,
     @SerialName("content")
-    val slides: List<CarouselSlide>
+    val elements: List<CarouselElement>
 ) : Reply("carousel") {
 
     @Serializable
-    data class CarouselSlide(
+    data class CarouselElement(
         val title: String,
         @SerialName("btnText")
         val buttonText: String,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -67,7 +67,7 @@ data class CarouselReply(
     data class Element(
         val title: String,
         @SerialName("btnText")
-        val buttonText: String,
+        val button: String,
         val description: String? = null,
         @SerialName("image")
         val imageUrl: String? = null,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -61,11 +61,10 @@ data class CarouselReply(
     @SerialName("text")
     val title: String,
     @SerialName("content")
-    val elements: List<CarouselElement>
+    val elements: List<Element>
 ) : Reply("carousel") {
-
     @Serializable
-    data class CarouselElement(
+    data class Element(
         val title: String,
         @SerialName("btnText")
         val buttonText: String,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -73,7 +73,7 @@ data class CarouselReply(
         @SerialName("image")
         val imageUrl: String? = null,
         @SerialName("url")
-        val sourceUrl: String? = null
+        val buttonRedirectUrl: String? = null
     )
 
     override fun serialized() = JSON.encodeToString(serializer(), this)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -57,6 +57,29 @@ data class AudioReply(
 }
 
 @Serializable
+data class CarouselReply(
+    @SerialName("text")
+    val title: String,
+    @SerialName("content")
+    val slides: List<CarouselSlide>
+) : Reply("carousel") {
+
+    @Serializable
+    data class CarouselSlide(
+        val title: String,
+        @SerialName("btnText")
+        val buttonText: String,
+        val description: String? = null,
+        @SerialName("image")
+        val imageUrl: String? = null,
+        @SerialName("url")
+        val sourceUrl: String? = null
+    )
+
+    override fun serialized() = JSON.encodeToString(serializer(), this)
+}
+
+@Serializable
 class HangupReply(val state: String? = null) : Reply("hangup") {
     override fun serialized() = JSON.encodeToString(serializer(), this)
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -43,13 +43,14 @@ class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
         return CarouselReaction.create(text, slides.toReactionSlides())
     }
 
+    // TODO: Move from class body
     private fun Array<out CarouselSlide>.toReactionSlides() = map {
-        CarouselReaction.CarouselSlide(
+        CarouselReaction.Element(
             title = it.title,
-            buttonText = it.buttonText,
+            buttons = listOf(it.buttonText),
             description = it.description,
             imageUrl = it.imageUrl,
-            sourceUrl = it.sourceUrl
+            buttonRedirectUrl = it.buttonRedirectUrl
         )
     }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -3,7 +3,7 @@ package com.justai.jaicf.channel.jaicp.reactions
 import com.justai.jaicf.channel.jaicp.dto.Button
 import com.justai.jaicf.channel.jaicp.dto.ButtonsReply
 import com.justai.jaicf.channel.jaicp.dto.CarouselReply
-import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselSlide
+import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselElement
 import com.justai.jaicf.channel.jaicp.dto.ImageReply
 import com.justai.jaicf.logging.ButtonsReaction
 import com.justai.jaicf.logging.CarouselReaction
@@ -16,6 +16,7 @@ val Reactions.chatwidget
     get() = this as? ChatWidgetReactions
 
 class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
+
     override fun image(url: String): ImageReaction {
         return image(imageUrl = url, caption = null)
     }
@@ -37,20 +38,18 @@ class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
         return ButtonsReaction.create(buttons)
     }
 
-    fun carousel(text: String, vararg slides: CarouselSlide): CarouselReaction {
-        replies.add(CarouselReply(text, slides.asList()))
-
-        return CarouselReaction.create(text, slides.toReactionSlides())
+    fun carousel(text: String, vararg elements: CarouselElement): CarouselReaction {
+        replies.add(CarouselReply(text, elements.asList()))
+        return CarouselReaction.create(text, elements.toReactionElements())
     }
+}
 
-    // TODO: Move from class body
-    private fun Array<out CarouselSlide>.toReactionSlides() = map {
-        CarouselReaction.Element(
-            title = it.title,
-            buttons = listOf(it.buttonText),
-            description = it.description,
-            imageUrl = it.imageUrl,
-            buttonRedirectUrl = it.buttonRedirectUrl
-        )
-    }
+private fun Array<out CarouselElement>.toReactionElements() = map {
+    CarouselReaction.Element(
+        title = it.title,
+        buttons = listOf(it.buttonText),
+        description = it.description,
+        imageUrl = it.imageUrl,
+        buttonRedirectUrl = it.buttonRedirectUrl
+    )
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -3,8 +3,10 @@ package com.justai.jaicf.channel.jaicp.reactions
 import com.justai.jaicf.channel.jaicp.dto.Button
 import com.justai.jaicf.channel.jaicp.dto.ButtonsReply
 import com.justai.jaicf.channel.jaicp.dto.CarouselReply
+import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselSlide
 import com.justai.jaicf.channel.jaicp.dto.ImageReply
 import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.logging.CarouselReaction
 import com.justai.jaicf.logging.ImageReaction
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.buttons
@@ -35,7 +37,19 @@ class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
         return ButtonsReaction.create(buttons)
     }
 
-    fun carousel(text: String, vararg slides: CarouselReply.CarouselSlide) {
+    fun carousel(text: String, vararg slides: CarouselSlide): CarouselReaction {
         replies.add(CarouselReply(text, slides.asList()))
+
+        return CarouselReaction.create(text, slides.toReactionSlides())
+    }
+
+    private fun Array<out CarouselSlide>.toReactionSlides() = map {
+        CarouselReaction.CarouselSlide(
+            title = it.title,
+            buttonText = it.buttonText,
+            description = it.description,
+            imageUrl = it.imageUrl,
+            sourceUrl = it.sourceUrl
+        )
     }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -2,6 +2,7 @@ package com.justai.jaicf.channel.jaicp.reactions
 
 import com.justai.jaicf.channel.jaicp.dto.Button
 import com.justai.jaicf.channel.jaicp.dto.ButtonsReply
+import com.justai.jaicf.channel.jaicp.dto.CarouselReply
 import com.justai.jaicf.channel.jaicp.dto.ImageReply
 import com.justai.jaicf.logging.ButtonsReaction
 import com.justai.jaicf.logging.ImageReaction
@@ -32,5 +33,9 @@ class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
     fun buttons(buttons: List<String>): ButtonsReaction {
         replies.add(ButtonsReply(buttons.map { Button(it) }))
         return ButtonsReaction.create(buttons)
+    }
+
+    fun carousel(text: String, vararg slides: CarouselReply.CarouselSlide) {
+        replies.add(CarouselReply(text, slides.asList()))
     }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -3,7 +3,6 @@ package com.justai.jaicf.channel.jaicp.reactions
 import com.justai.jaicf.channel.jaicp.dto.Button
 import com.justai.jaicf.channel.jaicp.dto.ButtonsReply
 import com.justai.jaicf.channel.jaicp.dto.CarouselReply
-import com.justai.jaicf.channel.jaicp.dto.CarouselReply.CarouselElement
 import com.justai.jaicf.channel.jaicp.dto.ImageReply
 import com.justai.jaicf.logging.ButtonsReaction
 import com.justai.jaicf.logging.CarouselReaction
@@ -38,18 +37,17 @@ class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
         return ButtonsReaction.create(buttons)
     }
 
-    fun carousel(text: String, vararg elements: CarouselElement): CarouselReaction {
+    fun carousel(text: String, vararg elements: CarouselReply.Element): CarouselReaction {
         replies.add(CarouselReply(text, elements.asList()))
-        return CarouselReaction.create(text, elements.toReactionElements())
+        return CarouselReaction.create(text, elements.toCarouselReactionElements())
     }
 }
 
-private fun Array<out CarouselElement>.toReactionElements() = map {
+private fun Array<out CarouselReply.Element>.toCarouselReactionElements() = map {
     CarouselReaction.Element(
         title = it.title,
-        buttons = listOf(it.buttonText),
+        buttons = listOf(CarouselReaction.Button(it.buttonText, it.buttonRedirectUrl)),
         description = it.description,
-        imageUrl = it.imageUrl,
-        buttonRedirectUrl = it.buttonRedirectUrl
+        imageUrl = it.imageUrl
     )
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatWidgetReactions.kt
@@ -46,7 +46,7 @@ class ChatWidgetReactions : JaicpReactions(), JaicpCompatibleAsyncReactions {
 private fun Array<out CarouselReply.Element>.toCarouselReactionElements() = map {
     CarouselReaction.Element(
         title = it.title,
-        buttons = listOf(CarouselReaction.Button(it.buttonText, it.buttonRedirectUrl)),
+        buttons = listOf(CarouselReaction.Button(it.button, it.buttonRedirectUrl)),
         description = it.description,
         imageUrl = it.imageUrl
     )

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceReactions.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceReactions.kt
@@ -9,6 +9,8 @@ import com.justai.jaicf.channel.yandexalice.api.model.ImageGallery
 import com.justai.jaicf.channel.yandexalice.api.model.ItemsList
 import com.justai.jaicf.logging.AudioReaction
 import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.logging.CarouselReaction
+import com.justai.jaicf.logging.CarouselReaction.CarouselSlide
 import com.justai.jaicf.logging.ImageReaction
 import com.justai.jaicf.logging.SayReaction
 import com.justai.jaicf.reactions.Reactions
@@ -70,8 +72,21 @@ class AliceReactions(
     fun itemsList(header: String? = null, footer: ItemsList.Footer? = null) =
         ItemsList(ItemsList.Header(header), footer).also { builder.card = it }
 
-    fun imageGallery(first: Image, vararg images: Image) =
-        ImageGallery(listOf(first) + images.toList()).also { builder.card = it }
+    fun imageGallery(first: Image, vararg images: Image): CarouselReaction {
+        val imageList = listOf(first) + images.toList()
+        builder.card = ImageGallery(imageList)
+        return CarouselReaction.create("", imageList.toSlides())
+    }
+
+    private fun List<Image>.toSlides() = map {
+        CarouselSlide(
+            title = it.title ?: "",
+            buttonText = it.button?.title ?: "",
+            description = it.description,
+            imageUrl = api?.getImageUrl(it.imageId),
+            sourceUrl = it.button?.url
+        )
+    }
 
     override fun audio(id: String): AudioReaction {
         builder.tts += " <speaker audio='dialogs-upload/$skillId/$id.opus'>"

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceReactions.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceReactions.kt
@@ -7,12 +7,8 @@ import com.justai.jaicf.channel.yandexalice.api.model.Button
 import com.justai.jaicf.channel.yandexalice.api.model.Image
 import com.justai.jaicf.channel.yandexalice.api.model.ImageGallery
 import com.justai.jaicf.channel.yandexalice.api.model.ItemsList
-import com.justai.jaicf.logging.AudioReaction
-import com.justai.jaicf.logging.ButtonsReaction
-import com.justai.jaicf.logging.CarouselReaction
-import com.justai.jaicf.logging.CarouselReaction.CarouselSlide
-import com.justai.jaicf.logging.ImageReaction
-import com.justai.jaicf.logging.SayReaction
+import com.justai.jaicf.logging.*
+import com.justai.jaicf.logging.CarouselReaction.Element
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.ResponseReactions
 import kotlinx.serialization.json.JsonElement
@@ -75,17 +71,7 @@ class AliceReactions(
     fun imageGallery(first: Image, vararg images: Image): CarouselReaction {
         val imageList = listOf(first) + images.toList()
         builder.card = ImageGallery(imageList)
-        return CarouselReaction.create("", imageList.toSlides())
-    }
-
-    private fun List<Image>.toSlides() = map {
-        CarouselSlide(
-            title = it.title ?: "",
-            buttonText = it.button?.title ?: "",
-            description = it.description,
-            imageUrl = api?.getImageUrl(it.imageId),
-            sourceUrl = it.button?.url
-        )
+        return CarouselReaction.create("", mapImagesToReactions(imageList))
     }
 
     override fun audio(id: String): AudioReaction {
@@ -113,4 +99,14 @@ class AliceReactions(
     fun deleteFromUserState(key: String) {
         response.userStateUpdate[key] = null
     }
+}
+
+private fun AliceReactions.mapImagesToReactions(imageList: List<Image>) = imageList.map {
+    Element(
+        title = it.title ?: "",
+        buttons = listOf(it.button?.title ?: ""),
+        description = it.description,
+        imageUrl = api?.getImageUrl(it.imageId),
+        buttonRedirectUrl = it.button?.url
+    )
 }

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceReactions.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceReactions.kt
@@ -8,7 +8,6 @@ import com.justai.jaicf.channel.yandexalice.api.model.Image
 import com.justai.jaicf.channel.yandexalice.api.model.ImageGallery
 import com.justai.jaicf.channel.yandexalice.api.model.ItemsList
 import com.justai.jaicf.logging.*
-import com.justai.jaicf.logging.CarouselReaction.Element
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.ResponseReactions
 import kotlinx.serialization.json.JsonElement
@@ -65,13 +64,25 @@ class AliceReactions(
         button: Button? = null
     ) = image(Image(requireNotNull(api).getImageId(url), title, description, button))
 
+    /**
+     * Sends a message with a list of images and optionaly [Header] and [Footer].
+     * A list must contain from 1 to 5 images. [Image.button] is ignored.
+     *
+     * @see <a href="https://yandex.ru/dev/dialogs/alice/doc/protocol.html#ariaid-title3">yandex-protocol</a>
+     */
     fun itemsList(header: String? = null, footer: ItemsList.Footer? = null) =
         ItemsList(ItemsList.Header(header), footer).also { builder.card = it }
 
+    /**
+     * Sends a message with a carousel of images.
+     * A carousel must contain from 1 to 7 images. [Image.button] is ignored.
+     *
+     * @see <a href="https://yandex.ru/dev/dialogs/alice/doc/protocol.html#ariaid-title3">yandex-protocol</a>
+     */
     fun imageGallery(first: Image, vararg images: Image): CarouselReaction {
         val imageList = listOf(first) + images.toList()
         builder.card = ImageGallery(imageList)
-        return CarouselReaction.create("", mapImagesToReactions(imageList))
+        return CarouselReaction.create("", mapImagesToCarouselReactionElements(imageList))
     }
 
     override fun audio(id: String): AudioReaction {
@@ -101,12 +112,11 @@ class AliceReactions(
     }
 }
 
-private fun AliceReactions.mapImagesToReactions(imageList: List<Image>) = imageList.map {
-    Element(
+private fun AliceReactions.mapImagesToCarouselReactionElements(imageList: List<Image>) = imageList.map {
+    CarouselReaction.Element(
         title = it.title ?: "",
-        buttons = listOf(it.button?.title ?: ""),
+        buttons = emptyList(),
         description = it.description,
-        imageUrl = api?.getImageUrl(it.imageId),
-        buttonRedirectUrl = it.button?.url
+        imageUrl = api?.getImageUrl(it.imageId)
     )
 }

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/api/AliceApi.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/api/AliceApi.kt
@@ -53,9 +53,9 @@ class AliceApi(
 
     fun getImageId(url: String) = images.getOrPut(url) { uploadImage(url).id }
 
-    fun getImageUrl(id: String) = images.entries.find { id == it.value }?.key
+    internal fun getImageUrl(id: String) = images.entries.find { id == it.value }?.key
 
-    private fun uploadImage(url: String): Image = runBlocking {
+    fun uploadImage(url: String): Image = runBlocking {
         client.post<UploadedImage>("$apiUrl/skills/$skillId/images") {
             contentType(ContentType.Application.Json)
             body = JsonObject(mapOf("url" to JsonPrimitive(url)))
@@ -64,7 +64,7 @@ class AliceApi(
         imageStorage[skillId]?.put(image.origUrl, image.id)
     }
 
-    private fun listImages(): List<Image> = runBlocking {
+    fun listImages(): List<Image> = runBlocking {
         client.get<Images>("$apiUrl/skills/$skillId/images").images
     }
 }

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/api/AliceApi.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/api/AliceApi.kt
@@ -53,7 +53,9 @@ class AliceApi(
 
     fun getImageId(url: String) = images.getOrPut(url) { uploadImage(url).id }
 
-    fun uploadImage(url: String): Image = runBlocking {
+    fun getImageUrl(id: String) = images.entries.find { id == it.value }?.key
+
+    private fun uploadImage(url: String): Image = runBlocking {
         client.post<UploadedImage>("$apiUrl/skills/$skillId/images") {
             contentType(ContentType.Application.Json)
             body = JsonObject(mapOf("url" to JsonPrimitive(url)))
@@ -62,7 +64,7 @@ class AliceApi(
         imageStorage[skillId]?.put(image.origUrl, image.id)
     }
 
-    fun listImages(): List<Image> = runBlocking {
+    private fun listImages(): List<Image> = runBlocking {
         client.get<Images>("$apiUrl/skills/$skillId/images").images
     }
 }

--- a/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
@@ -118,16 +118,19 @@ data class CarouselReaction internal constructor(
     override val fromState: String
 ) : Reaction(fromState) {
 
-    // TODO выделить кнопку в отдельный класс
     data class Element(
         val title: String,
-        val buttons: List<String>,
+        val buttons: List<Button>,
         val description: String? = null,
-        val imageUrl: String? = null,
-        val buttonRedirectUrl: String? = null
+        val imageUrl: String? = null
     )
 
-    override fun toString(): String = """carousel with title "$title" from state $fromState"""
+    data class Button(
+        val text: String,
+        val url: String? = null
+    )
+
+    override fun toString(): String = """carousel with title "$title" containing $elements from state $fromState"""
 
     companion object
 }

--- a/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
@@ -114,16 +114,16 @@ data class AudioReaction internal constructor(
  * */
 data class CarouselReaction internal constructor(
     val title: String,
-    val slides: List<CarouselSlide>,
+    val elements: List<Element>,
     override val fromState: String
 ) : Reaction(fromState) {
 
-    data class CarouselSlide(
+    data class Element(
         val title: String,
-        val buttonText: String,
+        val buttons: List<String>,
         val description: String? = null,
         val imageUrl: String? = null,
-        val sourceUrl: String? = null
+        val buttonRedirectUrl: String? = null
     )
 
     override fun toString(): String = """carousel with title "$title" from state $fromState"""

--- a/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
@@ -118,6 +118,7 @@ data class CarouselReaction internal constructor(
     override val fromState: String
 ) : Reaction(fromState) {
 
+    // TODO выделить кнопку в отдельный класс
     data class Element(
         val title: String,
         val buttons: List<String>,

--- a/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/Reaction.kt
@@ -105,3 +105,28 @@ data class AudioReaction internal constructor(
 
     companion object
 }
+
+/**
+ * Reaction that is displayed as a carousel to store in [ExecutionContext]. May not be supported in some channels.
+ *
+ * @see [ExecutionContext]
+ * @see [com.justai.jaicf.logging.ConversationLogger]
+ * */
+data class CarouselReaction internal constructor(
+    val title: String,
+    val slides: List<CarouselSlide>,
+    override val fromState: String
+) : Reaction(fromState) {
+
+    data class CarouselSlide(
+        val title: String,
+        val buttonText: String,
+        val description: String? = null,
+        val imageUrl: String? = null,
+        val sourceUrl: String? = null
+    )
+
+    override fun toString(): String = """carousel with title "$title" from state $fromState"""
+
+    companion object
+}

--- a/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
@@ -29,8 +29,8 @@ interface ReactionRegistrar {
     fun ButtonsReaction.Companion.create(buttons: List<String>) =
         ButtonsReaction(buttons, currentState).register()
 
-    fun CarouselReaction.Companion.create(text: String, slides: List<Element>) =
-        CarouselReaction(text, slides, currentState).register()
+    fun CarouselReaction.Companion.create(text: String, elements: List<Element>) =
+        CarouselReaction(text, elements, currentState).register()
 
     fun GoReaction.Companion.create(path: String) =
         GoReaction(path, currentState).register()

--- a/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
@@ -2,6 +2,7 @@ package com.justai.jaicf.logging
 
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.ExecutionContext
+import com.justai.jaicf.logging.CarouselReaction.CarouselSlide
 
 /**
  * Reactions logging methods holder.
@@ -27,6 +28,9 @@ interface ReactionRegistrar {
 
     fun ButtonsReaction.Companion.create(buttons: List<String>) =
         ButtonsReaction(buttons, currentState).register()
+
+    fun CarouselReaction.Companion.create(text: String, slides: List<CarouselSlide>) =
+        CarouselReaction(text, slides, currentState).register()
 
     fun GoReaction.Companion.create(path: String) =
         GoReaction(path, currentState).register()

--- a/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
@@ -2,7 +2,7 @@ package com.justai.jaicf.logging
 
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.ExecutionContext
-import com.justai.jaicf.logging.CarouselReaction.CarouselSlide
+import com.justai.jaicf.logging.CarouselReaction.Element
 
 /**
  * Reactions logging methods holder.
@@ -29,7 +29,7 @@ interface ReactionRegistrar {
     fun ButtonsReaction.Companion.create(buttons: List<String>) =
         ButtonsReaction(buttons, currentState).register()
 
-    fun CarouselReaction.Companion.create(text: String, slides: List<CarouselSlide>) =
+    fun CarouselReaction.Companion.create(text: String, slides: List<Element>) =
         CarouselReaction(text, slides, currentState).register()
 
     fun GoReaction.Companion.create(path: String) =

--- a/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/logging/ReactionRegistrar.kt
@@ -2,7 +2,6 @@ package com.justai.jaicf.logging
 
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.ExecutionContext
-import com.justai.jaicf.logging.CarouselReaction.Element
 
 /**
  * Reactions logging methods holder.
@@ -29,7 +28,7 @@ interface ReactionRegistrar {
     fun ButtonsReaction.Companion.create(buttons: List<String>) =
         ButtonsReaction(buttons, currentState).register()
 
-    fun CarouselReaction.Companion.create(text: String, elements: List<Element>) =
+    fun CarouselReaction.Companion.create(text: String, elements: List<CarouselReaction.Element>) =
         CarouselReaction(text, elements, currentState).register()
 
     fun GoReaction.Companion.create(path: String) =


### PR DESCRIPTION
Implement carousel functionality in FacebookChannel and add a general CarouselReaction to the core that is used in FacebookChannel, ChatWidgetChannel and AliceChannel.
JAICF-67