### PR TITLE
add logging in facebook messenger

### DIFF
--- a/channels/facebook/src/main/java/com/justai/jaicf/channel/facebook/messenger/Messenger.java
+++ b/channels/facebook/src/main/java/com/justai/jaicf/channel/facebook/messenger/Messenger.java
@@ -234,7 +234,7 @@ public final class Messenger {
           throw MessengerApiExceptionFactory.create(responseJsonObject);
         }
       } catch (Exception e) {
-        log.error("Http response status: {}, body: {}", httpResponse.statusCode(), httpResponse.body());
+        log.error("Unexpected HTTP response with status: {}, and body: {}", httpResponse.statusCode(), httpResponse.body());
         throw e;
       }
     } catch (IOException e) {


### PR DESCRIPTION
Add logging in facebook messenger, so that framework users can understand what happens if the proxy returns an error.