### PR TITLE
Add bot id to jaicp mdc, make logging dependencies transitive

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "ZB-11352-SNAPSHOT"
+    version = "1.0.0"
 
     repositories {
         google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.0.0"
+    version = "ZB-11352-SNAPSHOT"
 
     repositories {
         google()

--- a/channels/jaicp/build.gradle.kts
+++ b/channels/jaicp/build.gradle.kts
@@ -16,9 +16,8 @@ dependencies {
 
     implementation(`tomcat-servlet`())
 
-    implementation("de.appelgriepsch.logback:logback-gelf-appender" version { logbackGelfAppender })
-    implementation(kotlinx("kotlinx-coroutines-slf4j") version { coroutinesCore })
-
+    api("de.appelgriepsch.logback:logback-gelf-appender" version { logbackGelfAppender })
+    api(kotlinx("kotlinx-coroutines-slf4j") version { coroutinesCore })
     api(`coroutines-core`())
 
     api(ktor("ktor-client-cio"))

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpMDC.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpMDC.kt
@@ -7,6 +7,7 @@ object JaicpMDC {
     fun setFromRequest(request: JaicpBotRequest) {
         MDC.put("requestId", request.questionId)
         MDC.put("channelId", request.channelBotId)
+        MDC.put("bot", request.channelBotId)
         MDC.put("accountId", request.channelBotId.split("-").first())
     }
 }


### PR DESCRIPTION
This fixes error when JAICP Application Console cannot show logs in JAICP Cloud.