### PR TITLE
Fix/blocking calls on ktor server coroutine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.0.2-SNAPSHOT"
+    version = "1.0.2"
 
     repositories {
         google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.0.1"
+    version = "1.0.2-SNAPSHOT"
 
     repositories {
         google()

--- a/core/src/main/kotlin/com/justai/jaicf/channel/http/Ktor.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/channel/http/Ktor.kt
@@ -40,7 +40,9 @@ fun Routing.httpBotRouting(vararg channels: Pair<String, HttpBotChannel>) {
                 )
             }
 
-            val response = channel.second.process(request)
+            val response = withContext(Dispatchers.Default) {
+                channel.second.process(request)
+            }
             response?.headers?.forEach { call.response.headers.append(it.key, it.value, false) }
 
             when (response) {


### PR DESCRIPTION
Ktor server does not allow blocking calls on server coroutines dispatcher. This fixes blocking calls by moving them to separate dispatcher.