### PR TITLE
add isNewUser propagation to SessionManager.kt, fix tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.1.0"
+    version = "1.1.2.1-SNAPSHOT"
 
     repositories {
         google()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.1.2.1-SNAPSHOT"
+    version = "1.1.1-SNAPSHOT"
 
     repositories {
         google()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -43,6 +43,7 @@ internal data class JaicpLogModel private constructor(
     val channelType: String,
     val sessionId: String,
     val isNewSession: Boolean,
+    val isNewUser: Boolean,
     val channelData: JsonObject?,
     val exception: String? = null
 ) {
@@ -175,6 +176,7 @@ internal data class JaicpLogModel private constructor(
                 user = user,
                 sessionId = session.sessionId,
                 isNewSession = session.isNewSession,
+                isNewUser = executionContext.isNewUser,
                 channelData = jaicpBotRequest.channelData,
                 exception = executionContext.scenarioException?.scenarioCause?.stackTraceToString()
             )

--- a/channels/jaicp/src/test/resources/logging/002/logModel.json
+++ b/channels/jaicp/src/test/resources/logging/002/logModel.json
@@ -51,5 +51,6 @@
   "channelType": "resterisk",
   "sessionId": "chatapi-mva_jaicf_project-263-XQt-testc2325f96-ec3a-4e63-ba05-5f582c4ad521",
   "isNewSession": true,
+  "isNewUser": true,
   "channelData": null
 }

--- a/channels/jaicp/src/test/resources/logging/006/logModel.json
+++ b/channels/jaicp/src/test/resources/logging/006/logModel.json
@@ -55,6 +55,7 @@
   "channelType": "resterisk",
   "sessionId": "006-d29b3a8b-9b09-4cea-8d3f-0d3b7b95a648",
   "isNewSession": true,
+  "isNewUser": true,
   "channelData": {
     "@type": "resterisk",
     "callRecording": "250311145/2021-02-16/11636330465/471177/10-24-33.198-nkOp2",

--- a/core/src/main/kotlin/com/justai/jaicf/context/BotContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/BotContext.kt
@@ -41,8 +41,14 @@ package com.justai.jaicf.context
  */
 data class BotContext(
     val clientId: String,
-    val dialogContext: DialogContext = DialogContext()
+    val dialogContext: DialogContext
 ) {
+
+    // TODO: Change BotContextManager API in further major releases, get rid of this dirty fix.
+    constructor(clientId: String) : this(clientId, DialogContext()) {
+        temp[BotContextKeys.IS_NEW_USER_KEY] = true
+    }
+
     val client = mutableMapOf<String, Any?>().withDefault { null }
     val session = mutableMapOf<String, Any?>().withDefault { null }
     val temp = mutableMapOf<String, Any?>().withDefault { null }
@@ -64,4 +70,8 @@ data class BotContext(
     fun cleanTempData() {
         temp.clear()
     }
+}
+
+internal object BotContextKeys {
+    const val IS_NEW_USER_KEY = "com/justai/jaicf/core/context/isNewUser"
 }

--- a/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
@@ -20,5 +20,6 @@ data class ExecutionContext(
     val firstState: String = botContext.dialogContext.currentState,
     val reactions: MutableList<Reaction> = mutableListOf(),
     val input: String = request.input,
-    var scenarioException: BotException? = null
+    var scenarioException: BotException? = null,
+    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false
 )

--- a/core/src/main/kotlin/com/justai/jaicf/context/manager/InMemoryBotContextManager.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/manager/InMemoryBotContextManager.kt
@@ -3,6 +3,7 @@ package com.justai.jaicf.context.manager
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.BotResponse
 import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.BotContextKeys
 import com.justai.jaicf.context.DialogContext
 import com.justai.jaicf.context.RequestContext
 
@@ -25,6 +26,9 @@ object InMemoryBotContextManager : BotContextManager {
             result = bc.result
             client.putAll(bc.client)
             session.putAll(bc.session)
+            if (bc.temp[BotContextKeys.IS_NEW_USER_KEY] == true) {
+                temp[BotContextKeys.IS_NEW_USER_KEY] = true
+            }
         }
     }
 


### PR DESCRIPTION
This adds isNewUser property to LogModel. This property is required by Analytics API. 

The right way to define is user is new is to know if we create new `BotContext` for this user. But I'm hesitant to change public API for `BotContextManager#loadContext`, and a number of IF-statemens in `SessionManager` generally solve the problem, so be it. 