### PR TITLE
JAICP Analytics API Support

### DIFF
--- a/channels/jaicp/README.md
+++ b/channels/jaicp/README.md
@@ -339,10 +339,65 @@ state("NewGame") {
     action {
         reactions.jaicp?.startNewSession()
         reactions.say("Hello there! Let's play a game of numbers!")
-        reacions.say("I've picked a number from 1 to 100 and it's time for you to guess it right")
+        reactions.say("I've picked a number from 1 to 100 and it's time for you to guess it right")
     }
 }
 ```
 
 In this case whenever a new game starts we create a new dialogue session. This will afterwards allow us, for example, to
 generate some statistics like how many steps it takes for a client to guess a number. 
+
+### JAICP Analytics API
+JAICP also provides a number of methods to mark client messages and conversations. For example, 
+you can define a result of conversation with `jaicpAnalytics.setSessionResult`. 
+This result will be shown in analytic charts in JAICP Application Console.
+
+#### Usage in scenario:
+```kotlin
+state("Are you happy with our bot?") {
+  activators {
+    intent("Yes")
+  }
+  action {
+    reactions.say("Nice!")
+    jaicpAnalytics.setSessionResult("")
+  }
+  
+  state("Are you happy with our bot?") {
+    activators {
+      intent("Yes")
+    }
+    action { 
+      reactions.say("Nice!")
+      jaicpAnalytics.setSessionResult("Client is happy. Developer should get a raise.")
+    }
+  }
+  
+  state("Are you happy with our bot?") {
+    activators {
+      intent("No")
+    }
+    action {
+      reactions.say("That's truly awful.")
+      jaicpAnalytics.setSessionResult("Client is sad. Developer should keep on improving.")
+    }
+  }
+}
+```
+
+> See more about analytics api [JAICP Help Portal](https://help.just-ai.com/#/docs/ru/JS_API/built_in_services/analytics/analytics) and [In source code](https://help.just-ai.com/#/docs/ru/JS_API/built_in_services/analytics/analytics)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
@@ -1,7 +1,7 @@
 package com.justai.jaicf.channel.jaicp.dto
 
+import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.DefaultActionContext
-import com.justai.jaicf.context.ExecutionContext
 import kotlinx.serialization.Serializable
 
 /**
@@ -10,17 +10,17 @@ import kotlinx.serialization.Serializable
  * @see JaicpAnalyticsAPI
  * */
 val DefaultActionContext.jaicpAnalytics: JaicpAnalyticsAPI
-    get() = reactions.executionContext.analyticsApi
+    get() = reactions.botContext.analyticsApi
 
-internal val ExecutionContext.analyticsApi: JaicpAnalyticsAPI
-    get() = (channelContext[ANALYTICS_BOT_CONTEXT_KEY] as? JaicpAnalyticsAPI ?: JaicpAnalyticsAPI()).also {
-        channelContext[ANALYTICS_BOT_CONTEXT_KEY] = it
+internal val BotContext.analyticsApi: JaicpAnalyticsAPI
+    get() = (temp[ANALYTICS_BOT_CONTEXT_KEY] as? JaicpAnalyticsAPI ?: JaicpAnalyticsAPI()).also {
+        temp[ANALYTICS_BOT_CONTEXT_KEY] = it
     }
 
 private const val ANALYTICS_BOT_CONTEXT_KEY = "com/justai/jaicf/jaicp/jaicpAnalyticsApi"
 
 @Serializable
-class JaicpAnalyticsAPI {
+class JaicpAnalyticsAPI internal constructor() {
     private var sessionResult: String? = null
     private var comment: String? = null
     private val sessionData: MutableMap<String, String> = mutableMapOf();

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
@@ -1,0 +1,91 @@
+package com.justai.jaicf.channel.jaicp.dto
+
+import com.justai.jaicf.context.DefaultActionContext
+import com.justai.jaicf.context.ExecutionContext
+import kotlinx.serialization.Serializable
+
+/**
+ * Provides JAICP Analytics API for scenarios
+ *
+ * @see JaicpAnalyticsAPI
+ * */
+val DefaultActionContext.jaicpAnalytics: JaicpAnalyticsAPI
+    get() = reactions.executionContext.analyticsApi
+
+internal val ExecutionContext.analyticsApi: JaicpAnalyticsAPI
+    get() = (channelContext[ANALYTICS_BOT_CONTEXT_KEY] as? JaicpAnalyticsAPI ?: JaicpAnalyticsAPI()).also {
+        channelContext[ANALYTICS_BOT_CONTEXT_KEY] = it
+    }
+
+private const val ANALYTICS_BOT_CONTEXT_KEY = "com/justai/jaicf/jaicp/jaicpAnalyticsApi"
+
+@Serializable
+class JaicpAnalyticsAPI {
+    private var sessionResult: String? = null
+    private var comment: String? = null
+    private val sessionData: MutableMap<String, String> = mutableMapOf();
+    private val sessionLabel: MutableList<String> = mutableListOf()
+    private val messageLabel: MutableList<MessageLabel> = mutableListOf()
+
+    /**
+     * Adds columns with arbitrary data in the session result report.
+     *
+     * @param header of column
+     * @param value any stringified value
+     * */
+    fun setSessionData(header: String, value: String) {
+        this.sessionData[header] = value
+    }
+
+    /**
+     * Sets comments to client phrases (input).
+     *
+     * @param comment for client phrase.
+     * */
+    fun setComment(comment: String) {
+        this.comment = comment
+    }
+
+    /**
+     * Sets labels to dialogs.
+     *
+     * @param label displayed in Analytics section in JAICP Application Console and xls report
+     * */
+    fun setSessionLabel(vararg label: String) {
+        this.sessionLabel.addAll(label)
+    }
+
+    /**
+     * Sets labels to client phrases (input).
+     *
+     * @param labelName the label name in a group
+     * @param groupName the name of labels group
+     * */
+    fun setMessageLabel(labelName: String, groupName: String) {
+        setMessageLabel(MessageLabel(labelName, groupName))
+    }
+
+    /**
+     * Sets labels to client phrases (input).
+     *
+     * @param labels
+     * */
+    fun setMessageLabel(vararg labels: MessageLabel) {
+        messageLabel.addAll(labels)
+    }
+
+    /**
+     * Sets the conversation result.
+     *
+     * @param result displayed in Analytics section in JAICP Application Console and xls report.
+     * */
+    fun setSessionResult(result: String) {
+        this.sessionResult = result
+    }
+
+    @Serializable
+    data class MessageLabel(
+        val labelName: String,
+        val groupName: String
+    )
+}

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -126,7 +126,7 @@ internal data class JaicpLogModel private constructor(
             fun create(executionContext: ExecutionContext, session: SessionData): ResponseData {
                 val nlpInfo = NlpInfo.create(executionContext)
                 val replies = buildReplies(executionContext.reactions)
-                val analytics = executionContext.analyticsApi
+                val analytics = executionContext.botContext.analyticsApi
 
                 executionContext.scenarioException?.toReply()?.let {
                     replies.add(JSON.encodeToJsonElement(ErrorReply.serializer(), it))

--- a/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
@@ -16,7 +16,6 @@ import com.justai.jaicf.logging.Reaction
  * @param reactions current channel provided reactions
  * @param input client's input
  * @param scenarioException an exception thrown from scenario
- * @param channelContext a storage for any context needed for channel or channel wrapper
  *
  * @see ConversationLogger
  * @see Reaction
@@ -30,6 +29,5 @@ data class ExecutionContext(
     val reactions: MutableList<Reaction> = mutableListOf(),
     val input: String = request.input,
     var scenarioException: BotException? = null,
-    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false,
-    val channelContext: MutableMap<String, Any> = mutableMapOf()
+    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false
 )

--- a/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
@@ -9,6 +9,15 @@ import com.justai.jaicf.logging.Reaction
 /**
  * This class will accumulate all execution information obtained during processing request.
  *
+ * @param requestContext current channel request's context
+ * @param activationContext selected activation context
+ * @param botContext current client's bot context
+ * @param request current client's request
+ * @param reactions current channel provided reactions
+ * @param input client's input
+ * @param scenarioException an exception thrown from scenario
+ * @param channelContext a storage for any context needed for channel or channel wrapper
+ *
  * @see ConversationLogger
  * @see Reaction
  * */
@@ -22,4 +31,5 @@ data class ExecutionContext(
     val input: String = request.input,
     var scenarioException: BotException? = null,
     val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false
+    val channelContext: MutableMap<String, Any> = mutableMapOf()
 )

--- a/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
@@ -30,6 +30,6 @@ data class ExecutionContext(
     val reactions: MutableList<Reaction> = mutableListOf(),
     val input: String = request.input,
     var scenarioException: BotException? = null,
-    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false
+    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false,
     val channelContext: MutableMap<String, Any> = mutableMapOf()
 )


### PR DESCRIPTION
This PR adds support for JAICF equivalent of [JAICP Analytics API](https://help.just-ai.com/#/docs/ru/JS_API/built_in_services/analytics/analytics)


Changeset: 
1. Add jaicpAnalytics extension property to DefaultActionContext
2. Add JaicpAnalyticsAPI serialization and propagation to JaicpLogModel.kt
3. Fix minor issues with missing sessionId for log record
4. Add readme for analytics

