### PR TITLE
Fix state path parsing and state name verification

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -305,7 +305,7 @@ class StateBuilder<B : BotRequest, R : Reactions> internal constructor(
     internal override fun build(): State = verify().run { State(path, noContext, modal, action?.let(::ActionAdapter)) }
 
     private fun verify(): StateBuilder<B, R> {
-        if (this.parent.isRoot && !name.matches(Regex("/?[^/]+")))
+        if (this.parent.isRoot && !name.matches(Regex("/?[^/]*")))
             logger.warn(
                 """
                     Slashes are not allowed in the name of top-level state. Your state path: "$path"
@@ -314,7 +314,7 @@ class StateBuilder<B : BotRequest, R : Reactions> internal constructor(
                     """.trimIndent()
             )
 
-        if (!this.parent.isRoot && !name.matches(Regex("[^/]+")))
+        if (!this.parent.isRoot && !name.matches(Regex("[^/]*")))
             logger.warn(
                 """
                     Slashes are not allowed in names of inner states. Your state path: "$path"
@@ -323,7 +323,7 @@ class StateBuilder<B : BotRequest, R : Reactions> internal constructor(
                     """.trimIndent()
             )
 
-        if (name.matches(Regex("/*")))
+        if (name.matches(Regex("/?")))
             logger.warn("State name must not be empty. Your state path: $path")
 
         return this

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -313,7 +313,7 @@ class StateBuilder<B : BotRequest, R : Reactions> internal constructor(
                 "Slashes are not allowed in name of inner states. State path $path"
             }
 
-        check(name.matches(Regex("/?"))) {
+        check(name.matches(Regex("/?[^/]+"))) {
             "State name must not be empty. State path $path"
         }
 

--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -47,6 +47,7 @@ sealed class ScenarioGraphBuilder<B : BotRequest, R : Reactions>(
         modal: Boolean = false,
         body: StateBuilder<B, R>.() -> Unit
     ) {
+        verifyStateName(name)
         val state = StateBuilder(scenarioModelBuilder, channelToken, path, name, noContext, modal)
             .apply(body).build()
         scenarioModelBuilder.states.add(state)
@@ -145,6 +146,17 @@ sealed class ScenarioGraphBuilder<B : BotRequest, R : Reactions>(
         scenarioModelBuilder.append(path, other, ignoreHooks, exposeHooks, propagateHooks)
 
     internal open fun build(): State = State(path, noContext, modal)
+
+    private fun verifyStateName(name: String) {
+        if (this is RootBuilder)
+            check(name.matches(Regex("/?[^/]+"))) {
+                "Only single leading slash is allowed in name of for top-level state. State path $path/$name"
+            }
+        else
+            check(name.matches(Regex("[^/]+"))) {
+                "Slashes are not allowed in name of inner states. State path $path/$name"
+            }
+    }
 }
 
 class RootBuilder<B : BotRequest, R : Reactions> internal constructor(

--- a/core/src/main/kotlin/com/justai/jaicf/model/state/StatePath.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/state/StatePath.kt
@@ -66,12 +66,12 @@ class StatePath {
     private fun normalized(): StatePath {
         val normalizedPath = mutableListOf<String>()
 
-        for (item in this.path.withIndex()) {
+        for ((index, item) in this.path.withIndex()) {
             when {
-                item.value == "" && item.index != 0 -> continue
-                item.value == CUR -> continue
-                item.value == UP -> normalizedPath.removeLastOrNull() ?: normalizedPath.add(item.value)
-                else -> normalizedPath.add(item.value)
+                item == "" && index != 0 -> continue
+                item == CUR -> continue
+                item == UP -> normalizedPath.removeLastOrNull()
+                else -> normalizedPath.add(item)
             }
         }
         return StatePath(normalizedPath)


### PR DESCRIPTION
This PR fixes parsing of multiple slashes in go, changeState and other reactions. 
It also prohibits slashes in state names (except for one leading slash in top-level states).