### PR TITLE
Implement buttons reactions in the Facebook channel

### DIFF
--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
@@ -8,7 +8,6 @@ import com.github.messenger4j.send.message.Message
 import com.github.messenger4j.send.message.RichMediaMessage
 import com.github.messenger4j.send.message.TemplateMessage
 import com.github.messenger4j.send.message.TextMessage
-import com.github.messenger4j.send.message.quickreply.QuickReply
 import com.github.messenger4j.send.message.quickreply.TextQuickReply
 import com.github.messenger4j.send.message.richmedia.RichMediaAsset
 import com.github.messenger4j.send.message.richmedia.UrlRichMediaAsset
@@ -70,11 +69,11 @@ class FacebookReactions(
         sendResponse(
             TemplateMessage.create(
                 ButtonTemplate.create(text, inlineButtons.asList())
-            ).also {
-                SayReaction.create(text)
-                ButtonsReaction.create(inlineButtons.map { it.toReactionButton().text })
-            }
-        )
+            )
+        ).also {
+            SayReaction.create(text)
+            ButtonsReaction.create(inlineButtons.map { it.toReactionButton().text })
+        }
     }
 
     fun buttons(title: String, buttons: List<String>): ButtonsReaction {

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookReactions.kt
@@ -79,7 +79,7 @@ class FacebookReactions(
 
     fun buttons(title: String, buttons: List<String>): ButtonsReaction {
         val replies = buttons.map { TextQuickReply.create(it, it) }
-        sendResponse(TextMessage.create(title, Optional.of(replies), Optional.ofNullable(null)))
+        sendResponse(TextMessage.create(title, Optional.of(replies), Optional.empty()))
         return ButtonsReaction.create(buttons)
     }
 

--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookCarousel.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookCarousel.kt
@@ -25,7 +25,7 @@ data class Action(
     val webviewShareButtonState: WebviewShareButtonState? = null
 )
 
-internal fun CarouselElement.toTemplateElement(): Element = Element.create(
+internal fun CarouselElement.toTemplateElement() = Element.create(
     title,
     Optional.ofNullable(subtitle),
     Optional.ofNullable(imageUrl),


### PR DESCRIPTION
This PR brings new reactions in the Facebook channel:
Reactions signatures:
1. say(text: String, vararg inlineButtons: String)
2. say(text: String, vararg inlineButtons: Button)
3. buttons(title: String, buttons: List<String>)