### PR TITLE
Change type of FacebookPostBackBotRequest to query

### DIFF
--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookBotRequest.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/api/FacebookBotRequest.kt
@@ -75,7 +75,7 @@ data class FacebookMessageReadBotRequest(
 
 data class FacebookPostBackBotRequest(
     override val event: PostbackEvent
-): FacebookEventBotRequest(event, FacebookEvent.POST_BACK)
+): FacebookBotRequest, QueryBotRequest(clientId = event.senderId(), input = event.title())
 
 data class FacebookReferralBotRequest(
     override val event: ReferralEvent


### PR DESCRIPTION
This PR changes the behavior of Facebook reactions so that a request to click a button can be treated as a query request