### PR TITLE
Fix JaicpConversationLoggerTest.kt

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
@@ -83,6 +83,29 @@ class JaicpAnalyticsAPI internal constructor() {
         this.sessionResult = result
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as JaicpAnalyticsAPI
+
+        if (sessionResult != other.sessionResult) return false
+        if (comment != other.comment) return false
+        if (sessionData != other.sessionData) return false
+        if (sessionLabel != other.sessionLabel) return false
+        if (messageLabel != other.messageLabel) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = sessionResult?.hashCode() ?: 0
+        result = 31 * result + (comment?.hashCode() ?: 0)
+        result = 31 * result + sessionData.hashCode()
+        result = 31 * result + sessionLabel.hashCode()
+        result = 31 * result + messageLabel.hashCode()
+        return result
+    }
+
     @Serializable
     data class MessageLabel(
         val labelName: String,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpAnalyticsAPI.kt
@@ -20,13 +20,13 @@ internal val BotContext.analyticsApi: JaicpAnalyticsAPI
 private const val ANALYTICS_BOT_CONTEXT_KEY = "com/justai/jaicf/jaicp/jaicpAnalyticsApi"
 
 @Serializable
-class JaicpAnalyticsAPI internal constructor() {
-    private var sessionResult: String? = null
-    private var comment: String? = null
-    private val sessionData: MutableMap<String, String> = mutableMapOf();
-    private val sessionLabel: MutableList<String> = mutableListOf()
-    private val messageLabel: MutableList<MessageLabel> = mutableListOf()
-
+data class JaicpAnalyticsAPI internal constructor(
+    private var sessionResult: String? = null,
+    private var comment: String? = null,
+    private val sessionData: MutableMap<String, String> = mutableMapOf(),
+    private val sessionLabel: MutableList<String> = mutableListOf(),
+    private val messageLabel: MutableList<MessageLabel> = mutableListOf(),
+) {
     /**
      * Adds columns with arbitrary data in the session result report.
      *
@@ -83,32 +83,9 @@ class JaicpAnalyticsAPI internal constructor() {
         this.sessionResult = result
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        other as JaicpAnalyticsAPI
-
-        if (sessionResult != other.sessionResult) return false
-        if (comment != other.comment) return false
-        if (sessionData != other.sessionData) return false
-        if (sessionLabel != other.sessionLabel) return false
-        if (messageLabel != other.messageLabel) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = sessionResult?.hashCode() ?: 0
-        result = 31 * result + (comment?.hashCode() ?: 0)
-        result = 31 * result + sessionData.hashCode()
-        result = 31 * result + sessionLabel.hashCode()
-        result = 31 * result + messageLabel.hashCode()
-        return result
-    }
-
     @Serializable
     data class MessageLabel(
         val labelName: String,
-        val groupName: String
+        val groupName: String,
     )
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpLogModel.kt
@@ -178,7 +178,7 @@ internal data class JaicpLogModel private constructor(
                 response = Response(response),
                 user = user,
                 sessionId = session.sessionId,
-                isNewSession = false,
+                isNewSession = session.isNewSession,
                 isNewUser = executionContext.isNewUser,
                 channelData = jaicpBotRequest.channelData,
                 exception = executionContext.scenarioException?.scenarioCause?.stackTraceToString()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/ChatAdapterConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/http/ChatAdapterConnector.kt
@@ -30,7 +30,7 @@ internal class ChatAdapterConnector(
         }
     }
 
-    suspend fun processLogAsync(logModel: JaicpLogModel) {
+    suspend fun sendLogAsync(logModel: JaicpLogModel) {
         try {
             httpClient.post<String>("$baseUrl/processLogs") {
                 contentType(ContentType.Application.Json)

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/logging/JaicpConversationLoggerTest.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/logging/JaicpConversationLoggerTest.kt
@@ -15,10 +15,9 @@ import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
 import com.justai.jaicf.channel.jaicp.dto.JaicpBotRequest
 import com.justai.jaicf.channel.jaicp.dto.JaicpLogModel
 import com.justai.jaicf.channel.jaicp.logging.internal.SessionData
-import com.justai.jaicf.channel.jaicp.reactions.chatapi
+import com.justai.jaicf.channel.jaicp.reactions.jaicp
 import com.justai.jaicf.context.ExecutionContext
-import io.mockk.spyk
-import io.mockk.verify
+import kotlinx.serialization.encodeToString
 import org.junit.jupiter.api.Test
 import kotlin.properties.Delegates
 import kotlin.test.assertEquals
@@ -26,8 +25,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-
-private const val DEFAULT_VERIFY_TIMEOUT = 1000L
 
 internal class JaicpConversationLoggerTest : JaicpBaseTest() {
     private var actLog: JaicpLogModel by Delegates.notNull()
@@ -38,25 +35,29 @@ internal class JaicpConversationLoggerTest : JaicpBaseTest() {
         override fun createLog(
             req: JaicpBotRequest,
             ctx: ExecutionContext,
-            session: SessionData
-        ): JaicpLogModel = super.createLog(req, ctx, session).also { actLog = it }
+            session: SessionData,
+        ): JaicpLogModel = super.createLog(req, ctx, session).also {
+            actLog = it
+        }
     }
-    private val spyLogger = spyk(conversationLogger)
-    private val echoBot = BotEngine(ScenarioFactory.echo(), conversationLoggers = arrayOf(spyLogger))
+    private val echoBot = BotEngine(ScenarioFactory.echo(), conversationLoggers = arrayOf(conversationLogger))
 
     @Test
     fun `001 logging should set log model with session id for new user`() {
         JaicpTestChannel(echoBot, ChatApiChannel).process(requestFromResources.withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
 
         assertNotNull(actLog.sessionId)
+        assertEquals(actLog.sessionId, actLog.response.responseData.sessionId)
+        assertTrue(actLog.isNewUser)
         assertTrue(actLog.isNewSession)
     }
 
     @Test
     fun `002 logging should create correct log model`() {
         JaicpTestChannel(echoBot, ChatApiChannel).process(requestFromResources.withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
+
+        println(JSON.encodeToString(actLog))
+        println(JSON.encodeToString(expLog))
 
         assertEquals(
             expLog.withInvalidatedTime().withInvalidatedSessionId().withUserId(testNumber),
@@ -66,13 +67,13 @@ internal class JaicpConversationLoggerTest : JaicpBaseTest() {
 
     @Test
     fun `003 logging should maintain sessionId between calls from one client`() {
-        JaicpTestChannel(echoBot, ChatApiChannel).process(requestFromResources.withQuery("Hello!").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
+        val channel = JaicpTestChannel(echoBot, ChatApiChannel)
+        channel.process(requestFromResources.withQuery("Hello!").withClientId(testNumber))
         val sessionBefore = actLog.sessionId
         assertTrue(actLog.isNewSession)
 
-        JaicpTestChannel(echoBot, ChatApiChannel).process(requestFromResources.withQuery("test session id").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
+        channel.process(requestFromResources.withQuery("test session id")
+            .withClientId(testNumber))
         val sessionAfter = actLog.sessionId
 
         assertEquals(sessionBefore, sessionAfter)
@@ -85,29 +86,30 @@ internal class JaicpConversationLoggerTest : JaicpBaseTest() {
 
             state("sid") {
                 activators { regex("start session") }
-                action { reactions.chatapi?.startNewSession() }
+                action {
+                    reactions.jaicp?.startNewSession()
+                }
             }
 
             fallback { reactions.say("You said: ${request.input}") }
         }
         val bot =
-            BotEngine(scenario, conversationLoggers = arrayOf(spyLogger), activators = arrayOf(RegexActivator))
+            BotEngine(scenario, conversationLoggers = arrayOf(conversationLogger), activators = arrayOf(RegexActivator))
         val channel = JaicpTestChannel(bot, ChatApiChannel)
 
         channel.process(requestFromResources.withQuery("Hello!").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
         val sessionBefore = actLog.sessionId
         assertTrue(actLog.isNewSession)
+        println(sessionBefore)
 
         channel.process(requestFromResources.withQuery("start session").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
         val sessionAfter = actLog.sessionId
+        println(sessionAfter)
 
         assertNotEquals(sessionBefore, sessionAfter)
         assertTrue(actLog.isNewSession)
 
         channel.process(requestFromResources.withQuery("Hello again!").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
 
         assertNotEquals(sessionBefore, sessionAfter)
         assertFalse(actLog.isNewSession)
@@ -119,29 +121,26 @@ internal class JaicpConversationLoggerTest : JaicpBaseTest() {
 
             state("sid") {
                 activators { regex("end session") }
-                action { reactions.chatapi?.endSession() }
+                action { reactions.jaicp?.endSession() }
             }
 
             fallback { reactions.say("You said: ${request.input}") }
         }
         val bot =
-            BotEngine(scenario, conversationLoggers = arrayOf(spyLogger), activators = arrayOf(RegexActivator))
+            BotEngine(scenario, conversationLoggers = arrayOf(conversationLogger), activators = arrayOf(RegexActivator))
         val channel = JaicpTestChannel(bot, ChatApiChannel)
 
         channel.process(requestFromResources.withQuery("Hello!").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
         val sessionInitial = actLog.sessionId
         assertTrue(actLog.isNewSession)
 
         channel.process(requestFromResources.withQuery("end session").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
         val sessionAfterEndReaction = actLog.sessionId
 
         assertFalse(actLog.isNewSession)
         assertEquals(sessionInitial, sessionAfterEndReaction)
 
         channel.process(requestFromResources.withQuery("Hello again!").withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
         val sessionAfterNewRequest = actLog.sessionId
 
         assertTrue(actLog.isNewSession)
@@ -151,7 +150,6 @@ internal class JaicpConversationLoggerTest : JaicpBaseTest() {
     @Test
     fun `006 logging should create log model with channel data for telephony channel`() {
         JaicpTestChannel(echoBot, TelephonyChannel).process(requestFromResources.withClientId(testNumber))
-        verify(timeout = DEFAULT_VERIFY_TIMEOUT) { spyLogger.createLog(any(), any(), any()) }
 
         assertEquals(
             expLog.withInvalidatedTime().withInvalidatedSessionId().withUserId(testNumber),
@@ -162,7 +160,10 @@ internal class JaicpConversationLoggerTest : JaicpBaseTest() {
 
 private fun JaicpLogModel.withInvalidatedTime() = copy(timestamp = 0, processingTime = 0)
 
-private fun JaicpLogModel.withInvalidatedSessionId() = copy(sessionId = "sessionId")
+private fun JaicpLogModel.withInvalidatedSessionId(): JaicpLogModel {
+    val responseData = response.responseData.copy(sessionId = "sessionId")
+    return copy(sessionId = "sessionId", response = response.copy(responseData))
+}
 
 private fun JaicpLogModel.withUserId(uid: String) = copy(userId = uid)
 

--- a/channels/jaicp/src/test/resources/logging/002/logModel.json
+++ b/channels/jaicp/src/test/resources/logging/002/logModel.json
@@ -39,6 +39,7 @@
           "state": "/fallback"
         }
       ],
+      "analytics": {},
       "answer": "reply \"You said: /start\" from state /fallback",
       "sessionId": null
     }

--- a/channels/jaicp/src/test/resources/logging/006/logModel.json
+++ b/channels/jaicp/src/test/resources/logging/006/logModel.json
@@ -43,6 +43,7 @@
           "state": "/fallback"
         }
       ],
+      "analytics": {},
       "answer": "reply \"You said: сел\" from state /fallback",
       "sessionId": null
     }


### PR DESCRIPTION
This fixes `JaicpConversationLogger` tests. 
Removes spyk usage from mockk library, simplify test logic.