### PR TITLE
Add serialVersionUID to all java.io.Serializable classes

### DIFF
--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivatorContext.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivatorContext.kt
@@ -18,6 +18,10 @@ data class CailaIntentActivatorContext(
     var slots = intentData.slots?.map { it.name to it.value }?.toMap() ?: emptyMap()
 
     val entities = result.entitiesLookup.entities
+
+    companion object {
+        private const val serialVersionUID = 4934755046273038374L
+    }
 }
 
 val ActivatorContext.caila

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaAnalyzeResponseData.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaAnalyzeResponseData.kt
@@ -7,20 +7,32 @@ data class CailaAnalyzeResponseData(
     val markup: CailaMarkupData,
     val entitiesLookup: CailaPhraseMarkupData,
     val inference: CailaInferenceResultsData
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -7944621135486361310L
+    }
+}
 
 @Serializable
 data class CailaInferenceResultsData(
     val phrase: CailaPhraseMarkupData,
     val variants: List<CailaInferenceResultData>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -8632267852430180094L
+    }
+}
 
 @Serializable
 data class CailaMarkupData(
     val source: String,
     val correctedText: String,
     val words: List<CailaWordData>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -2819797379889298421L
+    }
+}
 
 @Serializable
 data class CailaWordData(
@@ -29,4 +41,8 @@ data class CailaWordData(
     val source: String,
     val word: String,
     val punctuation: Boolean
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -5443803721832092446L
+    }
+}

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaEntitiesLookupResults.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaEntitiesLookupResults.kt
@@ -6,7 +6,11 @@ import kotlinx.serialization.Serializable
 data class CailaEntitiesLookupResults(
     val text: String,
     val entities: List<CailaEntityMarkupData>
-): java.io.Serializable
+): java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -4754223571735534961L
+    }
+}
 
 @Serializable
 data class CailaEntityMarkupData(
@@ -19,4 +23,8 @@ data class CailaEntityMarkupData(
     val default: Boolean?,
     val system: Boolean?,
     val entityId: Long?
-): java.io.Serializable
+): java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -6523969273872886292L
+    }
+}

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceRequestData.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceRequestData.kt
@@ -6,7 +6,11 @@ import kotlinx.serialization.Serializable
 data class CailaAnalyzeRequestData(
     val data: CailaInferenceRequestData,
     val showAll: Boolean
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 9073984233860769077L
+    }
+}
 
 @Serializable
 data class CailaInferenceRequestData(
@@ -14,10 +18,18 @@ data class CailaInferenceRequestData(
     val knownSlots: List<CailaKnownSlotData>,
     val nBest: Int,
     val showDebugInfo: Boolean = false
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 5610919149644712850L
+    }
+}
 
 @Serializable
 data class CailaPhraseMarkupData(
     val text: String,
     val entities: MutableList<CailaEntityMarkupData>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = -6194136165197848082L
+    }
+}

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceResultData.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceResultData.kt
@@ -10,7 +10,11 @@ data class CailaInferenceResultData(
     val confidence: Double,
     val slots: List<CailaKnownSlotData>?,
     val debug: JsonObject?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 1698636910227622116L
+    }
+}
 
 @Serializable
 data class CailaIntentData(
@@ -21,6 +25,10 @@ data class CailaIntentData(
     val slots: List<CailaSlotData>?
 )  : java.io.Serializable{
     val name = path.substring(path.lastIndexOf('/') + 1)
+
+    companion object {
+        private const val serialVersionUID = -8682982605253378239L
+    }
 }
 
 @Serializable
@@ -30,11 +38,19 @@ data class CailaSlotData(
     val required: Boolean,
     val prompts: List<String>?,
     val array: Boolean?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 8993441993535699579L
+    }
+}
 
 @Serializable
 data class CailaKnownSlotData(
     val name: String,
     val value: String,
     val array: Boolean?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 1467148388316177817L
+    }
+}

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingContext.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingContext.kt
@@ -34,5 +34,7 @@ internal data class CailaSlotFillingContext(
                 maxRetries = maxRetries
             )
         }
+
+        private const val serialVersionUID = 6691290642221965774L
     }
 }

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivatorContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivatorContext.kt
@@ -13,7 +13,11 @@ import java.io.Serializable
 open class IntentActivatorContext(
     override val confidence: Float,
     open val intent: String
-): ActivatorContext, Serializable
+): ActivatorContext, Serializable {
+    companion object {
+        private const val serialVersionUID = 5641269141466602296L
+    }
+}
 
 val ActivatorContext.intent
     get() = this as? IntentActivatorContext

--- a/core/src/main/kotlin/com/justai/jaicf/context/DialogContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/DialogContext.kt
@@ -37,4 +37,8 @@ class DialogContext: Serializable {
 
         return currentContext
     }
+
+    companion object {
+        private const val serialVersionUID = -9180292787182200322L
+    }
 }

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
@@ -8,4 +8,8 @@ class BotContextModel(botContext: BotContext): Serializable {
     val result: Any? = botContext.result
     val client = botContext.client.toMap()
     val session = botContext.session.toMap()
+
+    companion object {
+        private const val serialVersionUID = -8182528581552214215L
+    }
 }


### PR DESCRIPTION
All UIDs were generated by serialver jdk tool. The compiled classes were used as of the latest release.
Considering that there have been no changes in affected classes since 0.10.0, this fix should not break compatibility with any newer versions of JAICF.
Correctness of the DialogContext's UID was double-checked.