### PR TITLE
Add allowedTime field in RedialData

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
@@ -160,6 +160,7 @@ class JaicpDialerAPI {
  */
 @Serializable
 data class AllowedTime(
+    val default: List<LocalTimeInterval>? = null,
     val mon: List<LocalTimeInterval>? = null,
     val tue: List<LocalTimeInterval>? = null,
     val wed: List<LocalTimeInterval>? = null,
@@ -167,7 +168,6 @@ data class AllowedTime(
     val fri: List<LocalTimeInterval>? = null,
     val sat: List<LocalTimeInterval>? = null,
     val sun: List<LocalTimeInterval>? = null,
-    val default: List<LocalTimeInterval>? = null
 ) {
     internal val intervals = listOf(mon, tue, wed, thu, fri, sat, sun, default)
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
@@ -179,10 +179,11 @@ data class AllowedTime(
     val thu: List<LocalTimeInterval>? = null,
     val fri: List<LocalTimeInterval>? = null,
     val sat: List<LocalTimeInterval>? = null,
-    val sun: List<LocalTimeInterval>? = null,
-) {
-    internal val intervals = listOf(mon, tue, wed, thu, fri, sat, sun, default)
-}
+    val sun: List<LocalTimeInterval>? = null
+)
+
+internal val AllowedTime.intervals
+    get() = listOf(default, mon, tue, wed, thu, fri, sat, sun)
 
 
 /**
@@ -225,7 +226,7 @@ private fun checkLocalTime(data: JaicpDialerAPI.RedialData) {
     val end = data.localTimeTo?.let { LocalTime.parse(it, formatter) }
     if (start != null && end != null) {
         require(start.isBefore(end)) {
-            "localTimeFrom cannot be higher then localTimeTo"
+            "localTimeFrom must be before localTimeTo"
         }
     }
 }
@@ -240,7 +241,7 @@ private fun checkAllowedTime(data: JaicpDialerAPI.RedialData) {
             val end = interval.localTimeTo.let { LocalTime.parse(it, formatter) }
 
             require(start.isBefore(end)) {
-                "localTimeFrom cannot be higher then localTimeTo of allowedTime"
+                "localTimeFrom must be before localTimeTo"
             }
         }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
@@ -43,16 +43,16 @@ class JaicpDialerAPI {
         val startDateTime: Long? = null,
         val finishDateTime: Long? = null,
         val allowedDays: List<String> = emptyList(),
-        @Deprecated("Field localTimeFrom are deprecated, use allowedTime instead")
+        @Deprecated("Field 'localTimeFrom' are deprecated, use 'allowedTime' instead")
         val localTimeFrom: String? = null,
-        @Deprecated("Field localTimeTo are deprecated, use allowedTime instead")
+        @Deprecated("Field 'localTimeTo' are deprecated, use 'allowedTime' instead")
         val localTimeTo: String? = null,
         val maxAttempts: Int? = null,
         val retryIntervalInMinutes: Int? = null,
         val allowedTime: AllowedTime? = null,
     ) {
         companion object {
-            @Deprecated("Parameters localTimeFrom and localTimeTo are deprecated, use create method that accepts allowedTime")
+            @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'create' method that accepts allowedTime")
             fun create(
                 startDateTime: Instant?,
                 finishDateTime: Instant?,
@@ -89,7 +89,7 @@ class JaicpDialerAPI {
         }
     }
 
-    @Deprecated("Parameters localTimeFrom and localTimeTo are deprecated, use redial method that accepts allowedTime")
+    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime")
     internal fun redial(
         startDateTime: Instant?,
         finishDateTime: Instant?,
@@ -145,6 +145,45 @@ class JaicpDialerAPI {
         callResultPayload = resultPayload
     }
 }
+
+/**
+ * Contains local time intervals by day of a week.
+ *
+ * @param mon list of time intervals on Monday
+ * @param tue list of time intervals on Tuesday
+ * @param wed list of time intervals on Wednesday
+ * @param thu list of time intervals on Thursday
+ * @param fri list of time intervals on Friday
+ * @param sat list of time intervals on Saturday
+ * @param sun list of time intervals on Sunday
+ * @param default will be used if no interval is specified for the current day of the week
+ */
+@Serializable
+data class AllowedTime(
+    val mon: List<LocalTimeInterval>? = null,
+    val tue: List<LocalTimeInterval>? = null,
+    val wed: List<LocalTimeInterval>? = null,
+    val thu: List<LocalTimeInterval>? = null,
+    val fri: List<LocalTimeInterval>? = null,
+    val sat: List<LocalTimeInterval>? = null,
+    val sun: List<LocalTimeInterval>? = null,
+    val default: List<LocalTimeInterval>? = null
+) {
+    internal val intervals = listOf(mon, tue, wed, thu, fri, sat, sun, default)
+}
+
+
+/**
+ * Local time interval attempting to redial
+ *
+ * @param localTimeFrom local time interval start attempting to redial. E.g. 16:20
+ * @param localTimeTo local time interval end attempting to redial. E.g. 23:59
+ * */
+@Serializable
+data class LocalTimeInterval(
+    val localTimeFrom: String,
+    val localTimeTo: String
+)
 
 private fun List<DayOfWeek>.mapToDialerDays(): List<String> = map {
     when (it) {
@@ -206,42 +245,3 @@ private fun checkRetryAndInterval(data: JaicpDialerAPI.RedialData) {
         }
     }
 }
-
-/**
- * Contains local time intervals by day of a week.
- *
- * @param mon list of time intervals on Monday
- * @param tue list of time intervals on Tuesday
- * @param wed list of time intervals on Wednesday
- * @param thu list of time intervals on Thursday
- * @param fri list of time intervals on Friday
- * @param sat list of time intervals on Saturday
- * @param sun list of time intervals on Sunday
- * @param default will be used if no interval is specified for the current day of the week
- */
-@Serializable
-data class AllowedTime(
-    val mon: List<LocalTimeInterval>? = null,
-    val tue: List<LocalTimeInterval>? = null,
-    val wed: List<LocalTimeInterval>? = null,
-    val thu: List<LocalTimeInterval>? = null,
-    val fri: List<LocalTimeInterval>? = null,
-    val sat: List<LocalTimeInterval>? = null,
-    val sun: List<LocalTimeInterval>? = null,
-    val default: List<LocalTimeInterval>? = null
-) {
-    internal val intervals = listOf(mon, tue, wed, thu, fri, sat, sun, default)
-}
-
-
-/**
- * Local time interval attempting to redial
- *
- * @param localTimeFrom local time interval start attempting to redial. E.g. 16:20
- * @param localTimeTo local time interval end attempting to redial. E.g. 23:59
- * */
-@Serializable
-data class LocalTimeInterval(
-    val localTimeFrom: String,
-    val localTimeTo: String
-)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
@@ -34,8 +34,8 @@ class JaicpDialerAPI {
      * @property allowedDays list of [DayOfWeek] allowed days
      * @property localTimeFrom local time interval start attempting to redial. E.g. 16:20
      * @property localTimeTo local time interval end attempting to redial. E.g. 23:59
-     * @property retryIntervalInMinutes interval between redial attempts
      * @property maxAttempts max number of attempts to call client
+     * @property retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      * */
     @Serializable
     data class RedialData internal constructor(
@@ -45,7 +45,7 @@ class JaicpDialerAPI {
         val localTimeFrom: String? = null,
         val localTimeTo: String? = null,
         val maxAttempts: Int? = null,
-        val retryIntervalInMinutes: Int? = null
+        val retryIntervalInMinutes: Int? = null,
     ) {
         companion object {
             fun create(
@@ -55,7 +55,7 @@ class JaicpDialerAPI {
                 localTimeFrom: String? = null,
                 localTimeTo: String? = null,
                 maxAttempts: Int? = null,
-                retryIntervalInMinutes: Int? = null
+                retryIntervalInMinutes: Int? = null,
             ) = RedialData(
                 startDateTime = startDateTime?.toEpochMilli(),
                 finishDateTime = finishDateTime?.toEpochMilli(),
@@ -75,7 +75,7 @@ class JaicpDialerAPI {
         localTimeFrom: String? = null,
         localTimeTo: String? = null,
         maxAttempts: Int? = null,
-        retryIntervalInMinutes: Int? = null
+        retryIntervalInMinutes: Int? = null,
     ) = redial(
         RedialData(
             startDateTime = startDateTime?.toEpochMilli(),

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
@@ -52,7 +52,13 @@ class JaicpDialerAPI {
         val allowedTime: AllowedTime? = null,
     ) {
         companion object {
-            @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'create' method that accepts allowedTime")
+            @Deprecated(
+                "Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'create' method that accepts allowedTime",
+                ReplaceWith(
+                    "create(startDateTime, finishDateTime, allowedDays, AllowedTime(listOf(LocalTimeInterval(localTimeFrom, localTimeTo))), maxAttempts, retryIntervalInMinutes)",
+                    "com.justai.jaicf.channel.jaicp.dto.*"
+                )
+            )
             fun create(
                 startDateTime: Instant?,
                 finishDateTime: Instant?,
@@ -89,7 +95,13 @@ class JaicpDialerAPI {
         }
     }
 
-    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime")
+    @Deprecated(
+        "Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
+        ReplaceWith(
+            "redial(startDateTime, finishDateTime, allowedDays, AllowedTime(listOf(LocalTimeInterval(localTimeFrom, localTimeTo))), maxAttempts, retryIntervalInMinutes)",
+            "com.justai.jaicf.channel.jaicp.dto.*"
+        )
+    )
     internal fun redial(
         startDateTime: Instant?,
         finishDateTime: Instant?,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
@@ -6,6 +6,7 @@ import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.api.QueryBotRequest
 import com.justai.jaicf.channel.jaicp.JSON
 import com.justai.jaicf.channel.jaicp.dto.bargein.BargeInRequest
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
@@ -39,17 +40,19 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
      * Returns the call campaign schedule that was set during the campaign creation.
      * Returned object has two properties, allowedDays and allowedTime
      */
-    val campaignSchedule: JsonObject?
+    val campaignSchedule: Schedule?
         get() = jaicp.rawRequest.jsonObject["originateData"]?.jsonObject?.get("callScenarioData")
             ?.jsonObject?.get("schedule")?.jsonObject?.get("campaignSchedule")?.jsonObject
+            ?.let(JSON::decodeFromJsonElement)
 
     /**
-     * Returns the current phone number dial schedule. Returned object has two properties, allowedDays and allowedTime.
+     * Returns the dial schedule of current phone number. Returned object has two properties, allowedDays and allowedTime.
      * Works only when the call was created using the Calls API with a custom schedule of allowed call time intervals.
      */
-    val dialSchedule: JsonObject?
+    val dialSchedule: Schedule?
         get() = jaicp.rawRequest.jsonObject["originateData"]?.jsonObject?.get("callScenarioData")
             ?.jsonObject?.get("schedule")?.jsonObject?.get("dialSchedule")?.jsonObject
+            ?.let(JSON::decodeFromJsonElement)
 
     /**
      * Returns a token for downloading call recordings made in the current project.
@@ -84,7 +87,7 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
      */
     fun getCallRecordingFullUrl(sessionId: String): String? =
         jaicp.data?.jsonObject?.get("resterisk")?.jsonObject?.get("callRecordsDownloadData")
-                ?.jsonObject?.get("downloadUrl")?.jsonPrimitive?.content?.replace("{sessionId}", sessionId)
+            ?.jsonObject?.get("downloadUrl")?.jsonPrimitive?.content?.replace("{sessionId}", sessionId)
 
 
     companion object {
@@ -97,6 +100,12 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
         }
     }
 }
+
+@Serializable
+data class Schedule(
+    val allowedDays: List<String>? = null,
+    val allowedTime: AllowedTime? = null,
+)
 
 data class TelephonyQueryRequest(
     override val jaicp: JaicpBotRequest,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -131,7 +131,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param localTimeFrom local time interval start attempting to redial. E.g. 16:20
      * @param localTimeTo local time interval end attempting to redial. E.g. 23:59
      * @param maxAttempts max number of attempts to call client
-     * @param retryIntervalInMinutes interval between redial attempts
+     * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      * */
     fun redial(
         startDateTime: Instant? = null,
@@ -140,15 +140,15 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
         localTimeFrom: String? = null,
         localTimeTo: String? = null,
         maxAttempts: Int? = null,
-        retryIntervalInMinutes: Int? = null
+        retryIntervalInMinutes: Int? = null,
     ) = dialer.redial(
-        startDateTime,
-        finishDateTime,
-        allowedDays,
-        localTimeFrom,
-        localTimeTo,
-        maxAttempts,
-        retryIntervalInMinutes
+        startDateTime = startDateTime,
+        finishDateTime = finishDateTime,
+        allowedDays = allowedDays,
+        localTimeFrom = localTimeFrom,
+        localTimeTo = localTimeTo,
+        retryIntervalInMinutes = retryIntervalInMinutes,
+        maxAttempts = maxAttempts
     )
 
     /**
@@ -167,7 +167,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param localTimeFrom local time interval start attempting to redial. E.g. 16:20
      * @param localTimeTo local time interval end attempting to redial. E.g. 23:59
      * @param maxAttempts max number of attempts to call client
-     * @param retryIntervalInMinutes interval between redial attempts
+     * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      */
     fun redial(
         startRedialAfter: Duration,
@@ -176,17 +176,17 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
         localTimeFrom: String? = null,
         localTimeTo: String? = null,
         maxAttempts: Int? = null,
-        retryIntervalInMinutes: Int? = null
+        retryIntervalInMinutes: Int? = null,
     ) {
         val currentTime = Instant.now()
         redial(
-            currentTime.plus(startRedialAfter),
-            currentTime.plus(finishRedialAfter),
-            allowedDays,
-            localTimeFrom,
-            localTimeTo,
-            maxAttempts,
-            retryIntervalInMinutes
+            startDateTime = currentTime.plus(startRedialAfter),
+            finishDateTime = currentTime.plus(finishRedialAfter),
+            allowedDays = allowedDays,
+            localTimeFrom = localTimeFrom,
+            localTimeTo = localTimeTo,
+            maxAttempts = maxAttempts,
+            retryIntervalInMinutes = retryIntervalInMinutes
         )
     }
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -133,7 +133,12 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      * */
-    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime")
+    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
+        ReplaceWith(
+            "redial(startDateTime, finishDateTime, allowedDays, AllowedTime(listOf(LocalTimeInterval(localTimeFrom, localTimeTo))), maxAttempts, retryIntervalInMinutes)",
+            "com.justai.jaicf.channel.jaicp.dto.*"
+        )
+    )
     fun redial(
         startDateTime: Instant? = null,
         finishDateTime: Instant? = null,
@@ -211,7 +216,12 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      */
-    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime")
+    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
+        ReplaceWith(
+            "redial(startRedialAfter, finishRedialAfter, allowedDays, AllowedTime(listOf(LocalTimeInterval(localTimeFrom, localTimeTo))), maxAttempts, retryIntervalInMinutes)",
+            "com.justai.jaicf.channel.jaicp.dto.*"
+        )
+    )
     fun redial(
         startRedialAfter: Duration,
         finishRedialAfter: Duration,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -133,7 +133,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      * */
-    @Deprecated("Parameters localTimeFrom and localTimeTo are deprecated, use redial method that accepts allowedTime")
+    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime")
     fun redial(
         startDateTime: Instant? = null,
         finishDateTime: Instant? = null,
@@ -211,7 +211,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      */
-    @Deprecated("Parameters localTimeFrom and localTimeTo are deprecated, use redial method that accepts allowedTime")
+    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime")
     fun redial(
         startRedialAfter: Duration,
         finishRedialAfter: Duration,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -133,6 +133,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      * */
+    @Deprecated("Parameters localTimeFrom and localTimeTo are deprecated, use redial method that accepts allowedTime")
     fun redial(
         startDateTime: Instant? = null,
         finishDateTime: Instant? = null,
@@ -149,6 +150,47 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
         localTimeTo = localTimeTo,
         retryIntervalInMinutes = retryIntervalInMinutes,
         maxAttempts = maxAttempts
+    )
+
+    /**
+     * Schedules a redial in outbound call campaign.
+     *
+     * example usage:
+     * ```
+     * state("redial") {
+     *    activators {
+     *        regex("call me back")
+     *    }
+     *    action {
+     *        reactions.say("Ok, I will call you in an hour.")
+     *        reactions.telephony?.redial(
+     *            startDateTime = Instant.now().plusSeconds(3600),
+     *            maxAttempts = 2
+     *        )
+     *    }
+     * }
+     * ```
+     * @param startDateTime unix timestamp (UTC-0 epoch milliseconds) to start attempting to redial a client
+     * @param finishDateTime unix timestamp (UTC-0 epoch milliseconds) to end attempting to redial a client
+     * @param allowedDays list of [DayOfWeek] allowed days to call a client
+     * @param allowedTime local time intervals by day of a week
+     * @param maxAttempts max number of attempts to call client
+     * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
+     * */
+    fun redial(
+        startDateTime: Instant? = null,
+        finishDateTime: Instant? = null,
+        allowedDays: List<DayOfWeek> = emptyList(),
+        allowedTime: AllowedTime? = null,
+        maxAttempts: Int? = null,
+        retryIntervalInMinutes: Int? = null
+    ) = dialer.redial(
+        startDateTime,
+        finishDateTime,
+        allowedDays,
+        allowedTime,
+        maxAttempts,
+        retryIntervalInMinutes
     )
 
     /**
@@ -169,6 +211,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      */
+    @Deprecated("Parameters localTimeFrom and localTimeTo are deprecated, use redial method that accepts allowedTime")
     fun redial(
         startRedialAfter: Duration,
         finishRedialAfter: Duration,
@@ -187,6 +230,35 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
             localTimeTo = localTimeTo,
             maxAttempts = maxAttempts,
             retryIntervalInMinutes = retryIntervalInMinutes
+        )
+    }
+
+    /**
+     * Schedules a redial in outbound call campaign
+     *
+     * @param startRedialAfter a [Duration] amount after which redial will start
+     * @param finishRedialAfter a [Duration] after which redial will finish
+     * @param allowedDays list of [DayOfWeek] allowed days to call a client
+     * @param allowedTime local time intervals by day of a week
+     * @param maxAttempts max number of attempts to call client
+     * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
+     */
+    fun redial(
+        startRedialAfter: Duration,
+        finishRedialAfter: Duration,
+        allowedDays: List<DayOfWeek> = emptyList(),
+        allowedTime: AllowedTime? = null,
+        maxAttempts: Int? = null,
+        retryIntervalInMinutes: Int? = null
+    ) {
+        val currentTime = Instant.now()
+        redial(
+            currentTime.plus(startRedialAfter),
+            currentTime.plus(finishRedialAfter),
+            allowedDays,
+            allowedTime,
+            maxAttempts,
+            retryIntervalInMinutes
         )
     }
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -133,7 +133,8 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      * */
-    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
+    @Deprecated(
+        "Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
         ReplaceWith(
             "redial(startDateTime, finishDateTime, allowedDays, AllowedTime(listOf(LocalTimeInterval(localTimeFrom, localTimeTo))), maxAttempts, retryIntervalInMinutes)",
             "com.justai.jaicf.channel.jaicp.dto.*"
@@ -216,7 +217,8 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * @param maxAttempts max number of attempts to call client
      * @param retryIntervalInMinutes interval between redial attempts. Must not be less than 1
      */
-    @Deprecated("Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
+    @Deprecated(
+        "Parameters 'localTimeFrom' and 'localTimeTo' are deprecated, use 'redial' method that accepts allowedTime",
         ReplaceWith(
             "redial(startRedialAfter, finishRedialAfter, allowedDays, AllowedTime(listOf(LocalTimeInterval(localTimeFrom, localTimeTo))), maxAttempts, retryIntervalInMinutes)",
             "com.justai.jaicf.channel.jaicp.dto.*"

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/dialer/JaicpDialerAPITests.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/dialer/JaicpDialerAPITests.kt
@@ -4,6 +4,8 @@ import com.justai.jaicf.channel.jaicp.JaicpBaseTest
 import com.justai.jaicf.channel.jaicp.JaicpTestChannel
 import com.justai.jaicf.channel.jaicp.ScenarioFactory.echoWithAction
 import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
+import com.justai.jaicf.channel.jaicp.dto.AllowedTime
+import com.justai.jaicf.channel.jaicp.dto.LocalTimeInterval
 import com.justai.jaicf.channel.jaicp.reactions.telephony
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -15,9 +17,9 @@ import kotlin.test.assertEquals
 internal class JaicpDialerAPITests : JaicpBaseTest() {
 
     @Test
-    fun `001 dialer should answer with redial`() {
+    fun `001 dialer should answer with deprecated redial`() {
         val scenario = echoWithAction {
-            val startRedialTime = Instant.ofEpochMilli(1605189536000);
+            val startRedialTime = Instant.ofEpochMilli(1605189536000)
             reactions.telephony?.redial(
                 startDateTime = startRedialTime,
                 finishDateTime = startRedialTime.plusSeconds(60),
@@ -36,7 +38,30 @@ internal class JaicpDialerAPITests : JaicpBaseTest() {
     }
 
     @Test
-    fun `002 dialer should report property from call`() {
+    fun `002 dialer should answer with redial accepting allowedTime argument`() {
+        val scenario = echoWithAction {
+            val startRedialTime = Instant.ofEpochMilli(1605189536000)
+            reactions.telephony?.redial(
+                startDateTime = startRedialTime,
+                finishDateTime = startRedialTime.plusSeconds(60),
+                allowedDays = listOf(DayOfWeek.MONDAY, DayOfWeek.THURSDAY, DayOfWeek.WEDNESDAY),
+                allowedTime = AllowedTime(
+                    default = listOf(LocalTimeInterval("12:00", "12:30")),
+                    wed = listOf(LocalTimeInterval("14:00", "15:30"))
+                ),
+                maxAttempts = 5,
+                retryIntervalInMinutes = 5
+            )
+            reactions.say("You said: ${request.input}")
+        }
+
+        val channel = JaicpTestChannel(scenario, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        assertEquals(responseFromResources, response.jaicp)
+    }
+
+    @Test
+    fun `003 dialer should report property from call`() {
         val scenario = echoWithAction {
             reactions.telephony?.report("propname", "propvalue")
             reactions.say("You said: ${request.input}")
@@ -48,7 +73,7 @@ internal class JaicpDialerAPITests : JaicpBaseTest() {
     }
 
     @Test
-    fun `003 dialer should set call result`() {
+    fun `004 dialer should set call result`() {
         val scenario = echoWithAction {
             reactions.telephony?.setResult(
                 callResult = "call ended",
@@ -65,9 +90,9 @@ internal class JaicpDialerAPITests : JaicpBaseTest() {
     }
 
     @Test
-    fun `004 dialer should set merge all methods`() {
+    fun `005 dialer should set merge all methods`() {
         val scenario = echoWithAction {
-            val startRedialTime = Instant.ofEpochMilli(1605189536000);
+            val startRedialTime = Instant.ofEpochMilli(1605189536000)
             reactions.telephony?.redial(startRedialTime, null, maxAttempts = 5)
             reactions.telephony?.report("smoking", "i love it")
             reactions.telephony?.setResult(

--- a/channels/jaicp/src/test/resources/dialer/002/resp.json
+++ b/channels/jaicp/src/test/resources/dialer/002/resp.json
@@ -1,10 +1,21 @@
 {
   "data": {
     "dialer": {
-      "reportData": {
-        "propname": {
-          "value": "propvalue",
-          "order": null
+      "redial": {
+        "startDateTime": 1605189536000,
+        "finishDateTime": 1605189596000,
+        "allowedDays": ["mon", "thu", "wed"],
+        "maxAttempts": 5,
+        "retryIntervalInMinutes": 5,
+        "allowedTime": {
+          "default": [{
+            "localTimeFrom": "12:00",
+            "localTimeTo": "12:30"
+          }],
+          "wed": [{
+            "localTimeFrom": "14:00",
+            "localTimeTo": "15:30"
+          }]
         }
       }
     },

--- a/channels/jaicp/src/test/resources/dialer/003/resp.json
+++ b/channels/jaicp/src/test/resources/dialer/003/resp.json
@@ -1,8 +1,12 @@
 {
   "data": {
     "dialer": {
-      "callResult": "call ended",
-      "callResultPayload": "{\"result\":\"Ok\"}"
+      "reportData": {
+        "propname": {
+          "value": "propvalue",
+          "order": null
+        }
+      }
     },
     "replies": [
       {

--- a/channels/jaicp/src/test/resources/dialer/005/req.json
+++ b/channels/jaicp/src/test/resources/dialer/005/req.json
@@ -1,33 +1,27 @@
 {
   "data": {
-    "dialer": {
-      "callResult": "call ended",
-      "callResultPayload": "{\"result\":\"Ok\"}"
-    },
-    "replies": [
-      {
-        "type": "text",
-        "text": "You said: /start"
-      }
-    ],
-    "answer": "You said: /start"
+    "livechatStatus": {
+      "enabled": false
+    }
   },
+  "version": 1,
   "botId": "mva_jaicf_project-263-XQt",
-  "accountId": "mva_jaicf_project-263-XQt",
   "channelType": "resterisk",
   "channelBotId": "mva_jaicf_project-263-XQt",
   "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
   "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
   "query": "/start",
-  "timestamp": 0,
-  "currentState": "/fallback",
-  "processingTime": 0,
-  "requestData": {
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
     "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
     "clientId": "test",
     "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
     "query": "/start",
     "timestamp": "2020-03-09T15:25:19.497",
     "userId": "test"
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
   }
 }

--- a/channels/jaicp/src/test/resources/dialer/005/resp.json
+++ b/channels/jaicp/src/test/resources/dialer/005/resp.json
@@ -2,7 +2,17 @@
   "data": {
     "dialer": {
       "callResult": "call ended",
-      "callResultPayload": "{\"result\":\"Ok\"}"
+      "callResultPayload": "{\"result\":\"Ok\"}",
+      "reportData": {
+        "smoking": {
+          "value": "i love it",
+          "order": null
+        }
+      },
+      "redial": {
+        "startDateTime": 1605189536000,
+        "maxAttempts": 5
+      }
     },
     "replies": [
       {


### PR DESCRIPTION
The localTimeFrom and localTimeTo fields in RedialData are deprecated. This PR adds a new field allowedTime and deprecates  the usages of the old format.