### PR TITLE
Wrap HttpBotRequest#stream to BufferedInputStream.

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/channel/http/HttpBotRequest.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/channel/http/HttpBotRequest.kt
@@ -25,6 +25,9 @@ class HttpBotRequest(
     fun firstHeader(name: String) = headers[name]?.first()
 
     fun firstParameter(name: String) = parameters[name]?.first()
+
+    override fun toString() =
+        "HttpBotRequest(stream=$stream, headers=$headers, parameters=$parameters, requestMetadata=$requestMetadata"
 }
 
 fun <R> InputStream.runAndReset(action: InputStream.() -> R): R {

--- a/core/src/main/kotlin/com/justai/jaicf/channel/http/HttpBotRequest.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/channel/http/HttpBotRequest.kt
@@ -12,18 +12,24 @@ import java.nio.charset.Charset
  * @property parameters HTTP query parameters
  * @property requestMetadata optional metadata for request processing
  */
-data class HttpBotRequest(
-    val stream: InputStream,
+class HttpBotRequest(
+    stream: InputStream,
     val headers: Map<String, List<String>> = mapOf(),
     val parameters: Map<String, List<String>> = mapOf(),
     val requestMetadata: String? = null
 ) {
+    val stream = stream.buffered()
 
-    fun receiveText(charset: Charset = Charset.forName("UTF-8")) = stream.bufferedReader(charset).readText()
+    fun receiveText(charset: Charset = Charset.forName("UTF-8")) = stream.runAndReset { bufferedReader(charset).readText() }
 
     fun firstHeader(name: String) = headers[name]?.first()
 
     fun firstParameter(name: String) = parameters[name]?.first()
+}
+
+fun <R> InputStream.runAndReset(action: InputStream.() -> R): R {
+    mark(0)
+    return action().also { reset() }
 }
 
 fun String.asHttpBotRequest(requestMetadata: String? = null) = HttpBotRequest(


### PR DESCRIPTION
Wrap `HttpBotRequest#stream` to `BufferedInputStream` as it supports `mark` and `reset`, allowing us to read request data multiple times

Wrap `receiveText()` to `mark` + `reset` to automatically reset stream for further readings

Closes #175 