### PR TITLE
Use JsonElement instead of JsonObject in responseData

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpResponseData.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpResponseData.kt
@@ -6,7 +6,6 @@ import com.justai.jaicf.channel.jaicp.toJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 @SerialName("responseData")
 @Serializable
@@ -17,7 +16,7 @@ internal class JaicpResponseData private constructor(
     val bargeIn: BargeInProperties? = null,
     val bargeInInterrupt: BargeInResponse? = null,
     val sessionId: String,
-    val responseData: Map<String, JsonObject> = mapOf(),
+    val responseData: Map<String, JsonElement> = mapOf(),
 ) {
     internal constructor(
         replies: List<Reply>,
@@ -25,7 +24,7 @@ internal class JaicpResponseData private constructor(
         bargeInData: BargeInProperties?,
         bargeInInterrupt: BargeInResponse?,
         sessionId: String,
-        responseData: Map<String, JsonObject> = mapOf(),
+        responseData: Map<String, JsonElement> = mapOf(),
     ) : this(
         replies = replies.map { it.serialized().toJson() },
         answer = replies.filterIsInstance<TextReply>().joinToString("\n\n") { it.text },

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatApiReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatApiReactions.kt
@@ -13,7 +13,6 @@ import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.buttons
 import com.justai.jaicf.reactions.jaicp.JaicpCompatibleAsyncReactions
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 val Reactions.chatapi
     get() = this as? ChatApiReactions
@@ -51,7 +50,7 @@ class ChatApiReactions(
 
     fun addResponseData(data: Map<String, JsonElement>) = responseData.putAll(data)
 
-    fun addResponseData(key: String, value: JsonElement) = addResponseData(mapOf(key to value))
+    fun addResponseData(key: String, value: JsonElement) = addResponseData(key to value)
 
-    fun addResponseData(element: Pair<String, JsonElement>) = addResponseData(mapOf(element.first to element.second))
+    fun addResponseData(element: Pair<String, JsonElement>) = addResponseData(mapOf(element))
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatApiReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/ChatApiReactions.kt
@@ -12,6 +12,7 @@ import com.justai.jaicf.logging.ImageReaction
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.buttons
 import com.justai.jaicf.reactions.jaicp.JaicpCompatibleAsyncReactions
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 val Reactions.chatapi
@@ -48,9 +49,9 @@ class ChatApiReactions(
         return AudioReaction.create(url)
     }
 
-    fun addResponseData(data: Map<String, JsonObject>) = responseData.putAll(data)
+    fun addResponseData(data: Map<String, JsonElement>) = responseData.putAll(data)
 
-    fun addResponseData(key: String, value: JsonObject) = addResponseData(mapOf(key to value))
+    fun addResponseData(key: String, value: JsonElement) = addResponseData(mapOf(key to value))
 
-    fun addResponseData(element: Pair<String, JsonObject>) = addResponseData(mapOf(element.first to element.second))
+    fun addResponseData(element: Pair<String, JsonElement>) = addResponseData(mapOf(element.first to element.second))
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
@@ -11,6 +11,7 @@ import com.justai.jaicf.logging.EndSessionReaction
 import com.justai.jaicf.logging.NewSessionReaction
 import com.justai.jaicf.logging.SayReaction
 import com.justai.jaicf.reactions.Reactions
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 
@@ -22,7 +23,7 @@ open class JaicpReactions : Reactions() {
 
     internal val dialer by lazy { JaicpDialerAPI() }
 
-    protected val responseData: MutableMap<String, JsonObject> = mutableMapOf()
+    protected val responseData: MutableMap<String, JsonElement> = mutableMapOf()
 
     internal fun getCurrentState() = botContext.dialogContext.currentState
 


### PR DESCRIPTION
Requiring jsonObject was as a bad decision at it prohibits sending arrays or literals. 
This fixes the issue