### PR TITLE
Implement mapdb context manager using Jackson for serialization

### DIFF
--- a/managers/mapdb/build.gradle.kts
+++ b/managers/mapdb/build.gradle.kts
@@ -12,5 +12,6 @@ plugins {
 
 dependencies {
     core()
+    api(jackson())
     api("org.mapdb:mapdb:3.0.8")
 }

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
@@ -4,21 +4,13 @@ import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.DialogContext
 import java.io.Serializable
 
-internal class BotContextModel private constructor(): Serializable {
-
-    var result: Any? = null
-    lateinit var dialogContext: DialogContext
-    lateinit var client: Map<String, Any?>
-    lateinit var session: Map<String, Any?>
+class BotContextModel(botContext: BotContext): Serializable {
+    val dialogContext = botContext.dialogContext
+    val result: Any? = botContext.result
+    val client = botContext.client.toMap()
+    val session = botContext.session.toMap()
 
     companion object {
         private const val serialVersionUID = -8182528581552214215L
-
-        fun create(botContext: BotContext) = BotContextModel().apply {
-            dialogContext = botContext.dialogContext
-            result = botContext.result
-            client = botContext.client.toMap()
-            session = botContext.session.toMap()
-        }
     }
 }

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
@@ -1,15 +1,24 @@
 package com.justai.jaicf.context.manager.mapdb
 
 import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.DialogContext
 import java.io.Serializable
 
-class BotContextModel(botContext: BotContext): Serializable {
-    val dialogContext = botContext.dialogContext
-    val result: Any? = botContext.result
-    val client = botContext.client.toMap()
-    val session = botContext.session.toMap()
+internal class BotContextModel private constructor(): Serializable {
+
+    var result: Any? = null
+    lateinit var dialogContext: DialogContext
+    lateinit var client: Map<String, Any?>
+    lateinit var session: Map<String, Any?>
 
     companion object {
         private const val serialVersionUID = -8182528581552214215L
+
+        fun create(botContext: BotContext) = BotContextModel().apply {
+            dialogContext = botContext.dialogContext
+            result = botContext.result
+            client = botContext.client.toMap()
+            session = botContext.session.toMap()
+        }
     }
 }

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/BotContextModel.kt
@@ -1,10 +1,9 @@
 package com.justai.jaicf.context.manager.mapdb
 
 import com.justai.jaicf.context.BotContext
-import com.justai.jaicf.context.DialogContext
 import java.io.Serializable
 
-class BotContextModel(botContext: BotContext): Serializable {
+class BotContextModel(botContext: BotContext) : Serializable {
     val dialogContext = botContext.dialogContext
     val result: Any? = botContext.result
     val client = botContext.client.toMap()

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/JacksonMapDbBotContextManager.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/JacksonMapDbBotContextManager.kt
@@ -44,7 +44,7 @@ class JacksonMapDbBotContextManager(dbFilePath: String? = null) : BotContextMana
         response: BotResponse?,
         requestContext: RequestContext
     ) {
-        val model = JacksonBotContextModel.create(botContext)
+        val model = JacksonBotContextModel(botContext)
         map[botContext.clientId] = mapper.writeValueAsString(model)
         db.commit()
     }
@@ -52,18 +52,16 @@ class JacksonMapDbBotContextManager(dbFilePath: String? = null) : BotContextMana
     fun close() = db.close()
 }
 
-private class JacksonBotContextModel {
-    var result: Any? = null
-    lateinit var dialogContext: DialogContext
-    lateinit var client: Map<String, Any?>
-    lateinit var session: Map<String, Any?>
-
-    companion object {
-        fun create(botContext: BotContext) = JacksonBotContextModel().apply {
-            dialogContext = botContext.dialogContext
-            result = botContext.result
-            client = botContext.client.toMap()
-            session = botContext.session.toMap()
-        }
-    }
+private data class JacksonBotContextModel(
+    val result: Any?,
+    val client: Map<String, Any?>,
+    val session: Map<String, Any?>,
+    val dialogContext: DialogContext
+) {
+    constructor(botContext: BotContext) : this(
+        result = botContext.result,
+        client = botContext.client.toMutableMap(),
+        session = botContext.session.toMutableMap(),
+        dialogContext = botContext.dialogContext
+    )
 }

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/MapDbBotContextManager.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/MapDbBotContextManager.kt
@@ -9,7 +9,7 @@ import org.mapdb.DBMaker
 import org.mapdb.Serializer
 
 @Deprecated(
-    "MapDbBotContextManager is deprecated. Use JacksonMapDbBotContextManager with the new dbFilePath instead, because the format of the old base is incompatible with the new"
+    "MapDbBotContextManager is deprecated. Use JacksonMapDbBotContextManager with the new dbFilePath instead, because the database format of this manager is incompatible with JacksonMapDbBotContextManager"
 )
 class MapDbBotContextManager(dbFilePath: String? = null) : BotContextManager {
 

--- a/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/MapDbBotContextManager.kt
+++ b/managers/mapdb/src/main/kotlin/com/justai/jaicf/context/manager/mapdb/MapDbBotContextManager.kt
@@ -9,11 +9,7 @@ import org.mapdb.DBMaker
 import org.mapdb.Serializer
 
 @Deprecated(
-    "MapDbBotContextManager is deprecated. Use JacksonMapDbBotContextManager instead",
-    ReplaceWith(
-        "JacksonMapDbBotContextManager(dbFilePath)",
-        "com.justai.jaicf.context.manager.mapdb.JacksonMapDbBotContextManager"
-    )
+    "MapDbBotContextManager is deprecated. Use JacksonMapDbBotContextManager with the new dbFilePath instead, because the format of the old base is incompatible with the new"
 )
 class MapDbBotContextManager(dbFilePath: String? = null) : BotContextManager {
 
@@ -37,7 +33,7 @@ class MapDbBotContextManager(dbFilePath: String? = null) : BotContextManager {
         response: BotResponse?,
         requestContext: RequestContext
     ) {
-        map[botContext.clientId] = BotContextModel.create(botContext)
+        map[botContext.clientId] = BotContextModel(botContext)
         db.commit()
     }
 

--- a/managers/mapdb/src/test/kotlin/com/justai/jaicf/context/manager/test/JacksonMapDbBotContextManagerTest.kt
+++ b/managers/mapdb/src/test/kotlin/com/justai/jaicf/context/manager/test/JacksonMapDbBotContextManagerTest.kt
@@ -3,15 +3,15 @@ package com.justai.jaicf.context.manager.test
 import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.RequestContext
-import com.justai.jaicf.context.manager.mapdb.MapDbBotContextManager
+import com.justai.jaicf.context.manager.mapdb.JacksonMapDbBotContextManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class MapDbBotContextManagerTest {
+class JacksonMapDbBotContextManagerTest {
 
     @Test
     fun testWithTempFile() {
-        val manager = MapDbBotContextManager()
+        val manager = JacksonMapDbBotContextManager()
         val context = manager.loadContext(EventBotRequest("client1", "event"), RequestContext.DEFAULT)
         context.apply {
             result = "some result"
@@ -30,12 +30,12 @@ class MapDbBotContextManagerTest {
     @Test
     fun testWithFile() {
         val context = BotContext("client1").apply { result = "some result" }
-        MapDbBotContextManager(".mapdb").apply {
+        JacksonMapDbBotContextManager(".mapdb").apply {
             saveContext(context, null, null, RequestContext.DEFAULT)
             close()
         }
 
-        val result = MapDbBotContextManager(".mapdb").run {
+        val result = JacksonMapDbBotContextManager(".mapdb").run {
             loadContext(EventBotRequest(context.clientId, "event"), RequestContext.DEFAULT)
         }
 

--- a/managers/mapdb/src/test/kotlin/com/justai/jaicf/context/manager/test/JacksonMapDbBotContextManagerTest.kt
+++ b/managers/mapdb/src/test/kotlin/com/justai/jaicf/context/manager/test/JacksonMapDbBotContextManagerTest.kt
@@ -4,10 +4,21 @@ import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.RequestContext
 import com.justai.jaicf.context.manager.mapdb.JacksonMapDbBotContextManager
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mapdb.DBMaker
+import java.nio.file.Files
+import java.nio.file.Paths
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JacksonMapDbBotContextManagerTest {
+
+    @AfterAll
+    internal fun shutdown() {
+        Files.deleteIfExists(Paths.get(".mapdb"))
+    }
 
     @Test
     fun testWithTempFile() {
@@ -37,6 +48,7 @@ class JacksonMapDbBotContextManagerTest {
 
         val result = JacksonMapDbBotContextManager(".mapdb").run {
             loadContext(EventBotRequest(context.clientId, "event"), RequestContext.DEFAULT)
+                .also { close() }
         }
 
         assertEquals(context.result, result.result)

--- a/managers/mapdb/src/test/kotlin/com/justai/jaicf/context/manager/test/MapDbBotContextManagerTest.kt
+++ b/managers/mapdb/src/test/kotlin/com/justai/jaicf/context/manager/test/MapDbBotContextManagerTest.kt
@@ -4,10 +4,20 @@ import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.RequestContext
 import com.justai.jaicf.context.manager.mapdb.MapDbBotContextManager
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.nio.file.Files
+import java.nio.file.Paths
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MapDbBotContextManagerTest {
+
+    @AfterAll
+    internal fun shutdown() {
+        Files.deleteIfExists(Paths.get(".mapdb"))
+    }
 
     @Test
     fun testWithTempFile() {
@@ -37,6 +47,7 @@ class MapDbBotContextManagerTest {
 
         val result = MapDbBotContextManager(".mapdb").run {
             loadContext(EventBotRequest(context.clientId, "event"), RequestContext.DEFAULT)
+                .also { close() }
         }
 
         assertEquals(context.result, result.result)


### PR DESCRIPTION
Now MapDbBotContextManager uses the serialization mechanism provided by java.io. This is inconvenient to use because it forces you to implement the Serializable interface for all classes that are stored in BotContext.

This PR adds a BotContextManager that uses MapDb and Jackson for serialization. 
**What's done**: created JacksonMapDbBotContextManager class, deprecated MapDbBotContextManager class, added tests for JacksonMapDbBotContextManager.