### PR TITLE
Add ChannelFactory companion object to all channels

### DIFF
--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentDialogflow.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentDialogflow.kt
@@ -2,6 +2,7 @@ package com.justai.jaicf.channel.googleactions.jaicp
 
 import com.justai.jaicf.api.BotApi
 import com.justai.jaicf.channel.googleactions.ActionsFulfillment
+import com.justai.jaicf.channel.jaicp.JaicpCompatibleBotChannel
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleChannelFactory
 
 class ActionsFulfillmentDialogflow(
@@ -9,4 +10,9 @@ class ActionsFulfillmentDialogflow(
 ) : JaicpCompatibleChannelFactory {
     override val channelType = "dialogflow"
     override fun create(botApi: BotApi) = ActionsFulfillment.dialogflow(botApi, useDataStorage)
+
+    companion object : JaicpCompatibleChannelFactory {
+        override val channelType = "dialogflow"
+        override fun create(botApi: BotApi) = ActionsFulfillmentDialogflow().create(botApi)
+    }
 }

--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentDialogflow.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentDialogflow.kt
@@ -10,8 +10,5 @@ class ActionsFulfillmentDialogflow(
     override val channelType = "dialogflow"
     override fun create(botApi: BotApi) = ActionsFulfillment.dialogflow(botApi, useDataStorage)
 
-    companion object : JaicpCompatibleChannelFactory {
-        override val channelType = "dialogflow"
-        override fun create(botApi: BotApi) = ActionsFulfillmentDialogflow().create(botApi)
-    }
+    companion object : JaicpCompatibleChannelFactory by ActionsFulfillmentDialogflow()
 }

--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentDialogflow.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentDialogflow.kt
@@ -2,7 +2,6 @@ package com.justai.jaicf.channel.googleactions.jaicp
 
 import com.justai.jaicf.api.BotApi
 import com.justai.jaicf.channel.googleactions.ActionsFulfillment
-import com.justai.jaicf.channel.jaicp.JaicpCompatibleBotChannel
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleChannelFactory
 
 class ActionsFulfillmentDialogflow(

--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentSDK.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentSDK.kt
@@ -9,4 +9,9 @@ class ActionsFulfillmentSDK(
 ) : JaicpCompatibleChannelFactory {
     override val channelType = "google"
     override fun create(botApi: BotApi) = ActionsFulfillment.sdk(botApi, useDataStorage)
+
+    companion object : JaicpCompatibleChannelFactory {
+        override val channelType = "google"
+        override fun create(botApi: BotApi) = ActionsFulfillmentSDK().create(botApi)
+    }
 }

--- a/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentSDK.kt
+++ b/channels/google-actions/src/main/kotlin/com/justai/jaicf/channel/googleactions/jaicp/ActionsFulfillmentSDK.kt
@@ -10,8 +10,5 @@ class ActionsFulfillmentSDK(
     override val channelType = "google"
     override fun create(botApi: BotApi) = ActionsFulfillment.sdk(botApi, useDataStorage)
 
-    companion object : JaicpCompatibleChannelFactory {
-        override val channelType = "google"
-        override fun create(botApi: BotApi) = ActionsFulfillmentSDK().create(botApi)
-    }
+    companion object : JaicpCompatibleChannelFactory by ActionsFulfillmentSDK()
 }

--- a/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/ViberChannel.kt
+++ b/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/ViberChannel.kt
@@ -16,14 +16,21 @@ import com.justai.jaicf.channel.viber.sdk.api.ViberApi
 import com.justai.jaicf.channel.viber.sdk.api.ViberHttpClient
 import com.justai.jaicf.channel.viber.sdk.api.ViberKtorClient
 import com.justai.jaicf.channel.viber.sdk.asViberRequest
-import com.justai.jaicf.channel.viber.sdk.event.*
+import com.justai.jaicf.channel.viber.sdk.event.IncomingConversationStartedEvent
+import com.justai.jaicf.channel.viber.sdk.event.IncomingDeliveredEvent
+import com.justai.jaicf.channel.viber.sdk.event.IncomingFailedEvent
+import com.justai.jaicf.channel.viber.sdk.event.IncomingMessageEvent
+import com.justai.jaicf.channel.viber.sdk.event.IncomingSeenEvent
+import com.justai.jaicf.channel.viber.sdk.event.IncomingWebhookEvent
+import com.justai.jaicf.channel.viber.sdk.event.sender
+import com.justai.jaicf.channel.viber.sdk.event.senderId
 import com.justai.jaicf.channel.viber.sdk.profile.BotProfile
 import com.justai.jaicf.channel.viber.sdk.profile.UserProfile
 import com.justai.jaicf.context.RequestContext
+import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
-import java.util.concurrent.Executors
 
 class ViberChannel private constructor(
     override val botApi: BotApi,

--- a/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/ViberChannel.kt
+++ b/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/ViberChannel.kt
@@ -16,21 +16,14 @@ import com.justai.jaicf.channel.viber.sdk.api.ViberApi
 import com.justai.jaicf.channel.viber.sdk.api.ViberHttpClient
 import com.justai.jaicf.channel.viber.sdk.api.ViberKtorClient
 import com.justai.jaicf.channel.viber.sdk.asViberRequest
-import com.justai.jaicf.channel.viber.sdk.event.IncomingConversationStartedEvent
-import com.justai.jaicf.channel.viber.sdk.event.IncomingDeliveredEvent
-import com.justai.jaicf.channel.viber.sdk.event.IncomingFailedEvent
-import com.justai.jaicf.channel.viber.sdk.event.IncomingMessageEvent
-import com.justai.jaicf.channel.viber.sdk.event.IncomingSeenEvent
-import com.justai.jaicf.channel.viber.sdk.event.IncomingWebhookEvent
-import com.justai.jaicf.channel.viber.sdk.event.sender
-import com.justai.jaicf.channel.viber.sdk.event.senderId
+import com.justai.jaicf.channel.viber.sdk.event.*
 import com.justai.jaicf.channel.viber.sdk.profile.BotProfile
 import com.justai.jaicf.channel.viber.sdk.profile.UserProfile
 import com.justai.jaicf.context.RequestContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
-import java.util.concurrent.*
+import java.util.concurrent.Executors
 
 class ViberChannel private constructor(
     override val botApi: BotApi,
@@ -121,8 +114,12 @@ class ViberChannel private constructor(
         }
     }
 
-    companion object {
+    companion object : JaicpCompatibleAsyncChannelFactory {
         private const val REQUEST_TEMPLATE_PATH = "/ViberRequestTemplate.json"
+        override val channelType = "viber"
+
+        override fun create(botApi: BotApi, apiUrl: String, liveChatProvider: JaicpLiveChatProvider) =
+            Factory().create(botApi, apiUrl, liveChatProvider)
     }
 }
 

--- a/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/ViberChannel.kt
+++ b/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/ViberChannel.kt
@@ -121,12 +121,8 @@ class ViberChannel private constructor(
         }
     }
 
-    companion object : JaicpCompatibleAsyncChannelFactory {
+    companion object : JaicpCompatibleAsyncChannelFactory by Factory() {
         private const val REQUEST_TEMPLATE_PATH = "/ViberRequestTemplate.json"
-        override val channelType = "viber"
-
-        override fun create(botApi: BotApi, apiUrl: String, liveChatProvider: JaicpLiveChatProvider) =
-            Factory().create(botApi, apiUrl, liveChatProvider)
     }
 }
 

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
@@ -4,7 +4,6 @@ import com.justai.jaicf.api.BotApi
 import com.justai.jaicf.channel.http.HttpBotRequest
 import com.justai.jaicf.channel.http.HttpBotResponse
 import com.justai.jaicf.channel.http.asJsonHttpBotResponse
-import com.justai.jaicf.channel.jaicp.JaicpCompatibleBotChannel
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleChannelFactory
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleChannelWithApiClient
 import com.justai.jaicf.channel.yandexalice.api.AliceApi

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
@@ -52,10 +52,7 @@ class AliceChannel(
         override fun create(botApi: BotApi) = AliceChannel(botApi, oauthToken = "", useDataStorage = useDataStorage)
     }
 
-    companion object : JaicpCompatibleChannelFactory {
+    companion object : JaicpCompatibleChannelFactory by Factory() {
         private const val DEFAULT_ALICE_API_URL = "https://dialogs.yandex.net/api/v1"
-        override val channelType = "yandex"
-
-        override fun create(botApi: BotApi) = Factory().create(botApi)
     }
 }

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
@@ -4,6 +4,7 @@ import com.justai.jaicf.api.BotApi
 import com.justai.jaicf.channel.http.HttpBotRequest
 import com.justai.jaicf.channel.http.HttpBotResponse
 import com.justai.jaicf.channel.http.asJsonHttpBotResponse
+import com.justai.jaicf.channel.jaicp.JaicpCompatibleBotChannel
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleChannelFactory
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleChannelWithApiClient
 import com.justai.jaicf.channel.yandexalice.api.AliceApi
@@ -18,10 +19,6 @@ class AliceChannel(
     private val oauthToken: String? = null,
     useDataStorage: Boolean = false
 ) : JaicpCompatibleChannelWithApiClient {
-
-    companion object {
-        private const val DEFAULT_ALICE_API_URL = "https://dialogs.yandex.net/api/v1"
-    }
 
     private var aliceApiUrl = DEFAULT_ALICE_API_URL
     private val contextManager = useDataStorage.ifTrue { AliceBotContextManager() }
@@ -54,5 +51,12 @@ class AliceChannel(
     class Factory(private val useDataStorage: Boolean = false) : JaicpCompatibleChannelFactory {
         override val channelType = "yandex"
         override fun create(botApi: BotApi) = AliceChannel(botApi, oauthToken = "", useDataStorage = useDataStorage)
+    }
+
+    companion object : JaicpCompatibleChannelFactory {
+        private const val DEFAULT_ALICE_API_URL = "https://dialogs.yandex.net/api/v1"
+        override val channelType = "yandex"
+
+        override fun create(botApi: BotApi) = Factory().create(botApi)
     }
 }

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/channel/JaicpPoller.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/channel/JaicpPoller.kt
@@ -25,8 +25,8 @@ fun main() {
                 FacebookChannel,
                 AimyboxChannel,
                 AlexaChannel,
-                ViberChannel.Factory(),
-                ActionsFulfillmentDialogflow()
+                ViberChannel,
+                ActionsFulfillmentDialogflow
             )
         ).runBlocking()
     }

--- a/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/channel/JaicpWebhook.kt
+++ b/examples/hello-world/src/main/kotlin/com/justai/jaicf/examples/helloworld/channel/JaicpWebhook.kt
@@ -24,7 +24,7 @@ fun main() {
                 FacebookChannel,
                 AimyboxChannel,
                 AlexaChannel,
-                ActionsFulfillmentDialogflow()
+                ActionsFulfillmentDialogflow
             )
         ).start()
     }

--- a/examples/viber-example/src/main/kotlin/com/justai/jaicf/examples/viber/JaicpPoller.kt
+++ b/examples/viber-example/src/main/kotlin/com/justai/jaicf/examples/viber/JaicpPoller.kt
@@ -13,7 +13,7 @@ fun main() {
             botApi = viberTestBot,
             accessToken = accessToken,
             channels = listOf(
-                ViberChannel.Factory()
+                ViberChannel
             )
         ).runBlocking()
     }


### PR DESCRIPTION
Now when passing in BotEngine some channels (Alice, Viber, Google) need to specify .Factory(), which is different from other channels and causes confusion.
This PR adds companion objects implemented by JaicpChannelFactory to these channels and allows you to pass channels like other