### PR TITLE
 Actualize examples scenarios

### DIFF
--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/GameController.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/GameController.kt
@@ -62,7 +62,7 @@ class GameController(context: BotContext) {
 
     fun record(timeMs: Long) {
         currentTime = timeMs
-        overall = overall?.let { it.plus(timeMs) } ?: timeMs
+        overall = overall?.plus(timeMs) ?: timeMs
 
         currentColor()?.let { color ->
             val time = gamersTime[color] ?: 0

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GameSetupScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GameSetupScenario.kt
@@ -11,10 +11,11 @@ object GameSetupScenario : Scenario {
 
     override val model = createModel {
 
-        append(GamersCountScenario(2, supportedColors.size))
-        append(GamersColorsScenario)
-
         state(state) {
+
+            append(GamersCountScenario(2, supportedColors.size))
+            append(GamersColorsScenario)
+
             action {
                 val game = GameController(context)
 
@@ -33,7 +34,7 @@ object GameSetupScenario : Scenario {
 
                     reactions.run {
                         say("${game.gamers} gamers! Cool! Now you have to choose a color for each of you!")
-                        go(GamersColorsScenario.state, "../complete")
+                        go("../${GamersColorsScenario.state}", "../complete")
                     }
                 }
             }

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersColorsScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersColorsScenario.kt
@@ -16,9 +16,10 @@ import com.justai.jaicf.test.context.runInTest
 
 object GamersColorsScenario : Scenario {
 
-    const val state = "/setup/colors"
+    const val state = "colors"
 
     override val model = createModel {
+
         state(state) {
             action {
                 val game = GameController(context)

--- a/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersCountScenario.kt
+++ b/examples/game-clock/src/main/kotlin/com/justai/jaicf/examples/gameclock/scenario/GamersCountScenario.kt
@@ -12,7 +12,7 @@ import com.justai.jaicf.test.context.runInTest
 class GamersCountScenario(private val min: Int, private val max: Int) : Scenario {
 
     companion object {
-        const val state = "/setup/gamers"
+        const val state = "gamers"
     }
 
     override val model = createModel {

--- a/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
+++ b/examples/jaicp-telephony/src/main/kotlin/com/justai/jaicf/examples/jaicptelephony/TelephonyBotScenario.kt
@@ -2,6 +2,8 @@ package com.justai.jaicf.examples.jaicptelephony
 
 import com.justai.jaicf.builder.Scenario
 import com.justai.jaicf.channel.jaicp.channels.TelephonyEvents
+import com.justai.jaicf.channel.jaicp.dto.AllowedTime
+import com.justai.jaicf.channel.jaicp.dto.LocalTimeInterval
 import com.justai.jaicf.channel.jaicp.telephony
 import com.justai.jaicf.helpers.logging.logger
 import java.time.Instant
@@ -45,10 +47,9 @@ val TelephonyBotScenario = Scenario(telephony) {
             reactions.say("Ok, I will call you back in a minute!")
             reactions.redial(
                 startDateTime = Instant.now().plus(1, ChronoUnit.MINUTES),
-                localTimeFrom = "12:00",
-                localTimeTo = "23:59",
-                retryIntervalInMinutes = 1,
-                maxAttempts = 2
+                allowedTime = AllowedTime(listOf(LocalTimeInterval("12:00", "23:59"))),
+                maxAttempts = 2,
+                retryIntervalInMinutes = 1
             )
             reactions.hangup()
         }


### PR DESCRIPTION
**What's wrong**: The examples do not compile and use outdated reactions.
This PR fixes the examples to use relevant reactions and changes the state tree so the examples run on the current version of jaicf.