### PR TITLE
add missing jaicp logs and MDC context

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotResponse.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpBotResponse.kt
@@ -5,11 +5,14 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
+@Serializable
 sealed class JaicpResponse
 
+@Serializable
 object JaicpAsyncResponse : JaicpResponse()
 
-class JaicpErrorResponse(val message: String): JaicpResponse()
+@Serializable
+class JaicpErrorResponse(val message: String) : JaicpResponse()
 
 @Serializable
 data class JaicpBotResponse(
@@ -33,7 +36,7 @@ fun JaicpBotResponse.Companion.fromRequest(
     jaicpBotRequest: JaicpBotRequest,
     rawResponse: JsonElement,
     processingTime: Long = 0,
-    currentState: String = "/"
+    currentState: String = "/",
 ) = JaicpBotResponse(
     data = rawResponse,
     botId = jaicpBotRequest.botId,


### PR DESCRIPTION
Adds logs for JAICP channel request/responses and processing time. 
This will set MDC Context for logging in synchronous channels, if channel implementation has no nested thread pool. For example, processing telephony requests will contain MDC info, while telegram won't.