### PR TITLE
Fix bug that smartRandom generates values gt max

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
@@ -20,7 +20,7 @@ internal fun smartRandom(max: Int, context: DefaultActionContext): Int {
         smartRandom = mutableMapOf()
     }
 
-    val prev = smartRandom!!.getOrDefault(id, mutableListOf())
+    val prev = smartRandom!!.computeIfAbsent(id) { mutableListOf() }
     val randoms = generateSequence { random(max, context) }.take(max * 5)
 
     val rand = randoms.firstOrNull { it !in prev } ?: 0
@@ -29,8 +29,6 @@ internal fun smartRandom(max: Int, context: DefaultActionContext): Int {
     if (prev.size > max / 2) {
         prev.removeFirst()
     }
-
-    smartRandom!![id] = prev
 
     return rand
 }

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/action/Random.kt
@@ -20,25 +20,17 @@ internal fun smartRandom(max: Int, context: DefaultActionContext): Int {
         smartRandom = mutableMapOf()
     }
 
-    var prev = smartRandom!!.getOrDefault(id, mutableListOf())
+    val prev = smartRandom!!.getOrDefault(id, mutableListOf())
+    val randoms = generateSequence { random(max, context) }.take(max * 5)
 
-    var i = 0
-    var ic = 0
-    while (ic < max * 5) {
-        ic++
-        i = random(ic, context)
-        if (prev.indexOf(i) == -1) {
-            break
-        }
-    }
-
-    prev.add(i)
+    val rand = randoms.firstOrNull { it !in prev } ?: 0
+    prev.add(rand)
 
     if (prev.size > max / 2) {
-        prev = prev.subList(1, prev.size).toMutableList()
+        prev.removeFirst()
     }
 
     smartRandom!![id] = prev
 
-    return i
+    return rand
 }

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
@@ -5,9 +5,8 @@ import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.DefaultActionContext
 import com.justai.jaicf.context.StrictActivatorContext
-import com.justai.jaicf.helpers.action.smartRandom
 import com.justai.jaicf.test.reactions.TestReactions
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import java.util.*
@@ -26,13 +25,20 @@ class SmartRandomTest {
         )
     }
 
-    @RepeatedTest(100)
-    fun testRandom() {
-        val check = mutableListOf<Int>()
-        for (i in 1..5) {
-            val r = smartRandom(10, context)
-            assertFalse(check.contains(r), "Element was found")
-            check.add(r)
-        }
+    @RepeatedTest(100, name = RepeatedTest.LONG_DISPLAY_NAME)
+    fun `Smart random generates no duplicates`() {
+        val (max, count) = 10 to 5
+        val randoms = IntArray(count) { context.random(max) }
+
+        assertTrue(randoms.distinct().size == count) { "Duplicated random value was found" }
+    }
+
+    @RepeatedTest(100, name = RepeatedTest.LONG_DISPLAY_NAME)
+    fun `Smart random generates values within its bounds`() {
+        val (max, count) = 10 to 100
+        val randoms = IntArray(count) { context.random(max) }
+
+        val range = 0 until max
+        randoms.forEach { assertTrue(it in range) { "Expected value in range $range but was $it" } }
     }
 }

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/SmartRandomTest.kt
@@ -6,19 +6,21 @@ import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.DefaultActionContext
 import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.test.reactions.TestReactions
+import org.junit.Rule
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.RepeatedTest
-import java.util.*
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SmartRandomTest {
 
     private lateinit var context: DefaultActionContext
 
-    @BeforeEach
+    @BeforeAll
     fun createContext() {
         context = ActionContext(
-            BotContext(UUID.randomUUID().toString()),
+            BotContext("clientId"),
             StrictActivatorContext(),
             QueryBotRequest("", ""),
             TestReactions()


### PR DESCRIPTION
Smart random did generate values not within bounds because of typo in implementation.
Also, make SmartRandomTest use global action context for all tests as it's better for checking that contracts holds for consecutive invocations of smart random.