### PR TITLE
polling: add stopPolling method, allow using provided executor, unify threads for http and execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.2.1"
+    version = "1.2.2-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpConnector.kt
@@ -33,8 +33,17 @@ abstract class JaicpConnector(
     val accessToken: String,
     val url: String,
     httpClient: HttpClient,
-    executor: Executor
+    executor: Executor,
 ) : WithLogger {
+
+    constructor(
+        botApi: BotApi,
+        channels: List<JaicpChannelFactory>,
+        accessToken: String,
+        url: String,
+        httpClient: HttpClient,
+        executorThreadPoolSize: Int,
+    ) : this(botApi, channels, accessToken, url, httpClient, Executors.newFixedThreadPool(executorThreadPoolSize))
 
     val jaicpExecutor = JaicpRequestExecutor(executor)
     private val chatAdapterConnector = ChatAdapterConnector(accessToken, url, httpClient)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpPollingConnector.kt
@@ -9,6 +9,7 @@ import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.*
 import io.ktor.client.features.logging.*
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 /**
  * This class is used to create polling coroutines for each channel, polls requests and sends responses.
@@ -37,6 +38,24 @@ open class JaicpPollingConnector(
     executor: Executor = DEFAULT_EXECUTOR,
 ) : JaicpConnector(botApi, channels, accessToken, url, httpClient, executor),
     WithLogger {
+
+    constructor(
+        botApi: BotApi,
+        accessToken: String,
+        url: String = DEFAULT_PROXY_URL,
+        channels: List<JaicpChannelFactory>,
+        logLevel: LogLevel = LogLevel.INFO,
+        httpClient: HttpClient = HttpClientFactory.create(logLevel),
+        executorThreadPoolSize: Int
+    ) : this(
+        botApi,
+        accessToken,
+        url,
+        channels,
+        logLevel,
+        httpClient,
+        Executors.newFixedThreadPool(executorThreadPoolSize)
+    )
 
     private val dispatcher = Dispatcher(httpClient, jaicpExecutor)
     protected val channelMap = mutableMapOf<String, JaicpBotChannel>()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
@@ -18,6 +18,7 @@ import com.justai.jaicf.channel.jaicp.http.HttpClientFactory
 import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.*
 import io.ktor.client.features.logging.*
+import java.util.concurrent.Executor
 
 
 /**
@@ -58,11 +59,11 @@ open class JaicpWebhookConnector(
     url: String = DEFAULT_PROXY_URL,
     channels: List<JaicpChannelFactory>,
     logLevel: LogLevel = LogLevel.INFO,
-    httpClient: HttpClient = null ?: HttpClientFactory.create(logLevel),
-    threadPoolSize: Int = DEFAULT_REQUEST_EXECUTOR_THREAD_POOL_SIZE
+    httpClient: HttpClient = HttpClientFactory.create(logLevel),
+    executor: Executor = DEFAULT_EXECUTOR
 ) : WithLogger,
     HttpBotChannel,
-    JaicpConnector(botApi, channels, accessToken, url, httpClient, threadPoolSize) {
+    JaicpConnector(botApi, channels, accessToken, url, httpClient, executor) {
 
     protected val channelMap = mutableMapOf<String, JaicpBotChannel>()
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/JaicpWebhookConnector.kt
@@ -19,6 +19,7 @@ import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.*
 import io.ktor.client.features.logging.*
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 
 /**
@@ -64,6 +65,24 @@ open class JaicpWebhookConnector(
 ) : WithLogger,
     HttpBotChannel,
     JaicpConnector(botApi, channels, accessToken, url, httpClient, executor) {
+
+    constructor(
+        botApi: BotApi,
+        accessToken: String,
+        url: String = DEFAULT_PROXY_URL,
+        channels: List<JaicpChannelFactory>,
+        logLevel: LogLevel = LogLevel.INFO,
+        httpClient: HttpClient = HttpClientFactory.create(logLevel),
+        executorThreadPoolSize: Int
+    ) : this(
+        botApi,
+        accessToken,
+        url,
+        channels,
+        logLevel,
+        httpClient,
+        Executors.newFixedThreadPool(executorThreadPoolSize)
+    )
 
     protected val channelMap = mutableMapOf<String, JaicpBotChannel>()
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/execution/JaicpRequestExecutor.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/execution/JaicpRequestExecutor.kt
@@ -28,13 +28,11 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
-import java.util.concurrent.Executors
+import java.util.concurrent.Executor
 import kotlin.coroutines.CoroutineContext
 
-class ThreadPoolRequestExecutor(nThreads: Int) : CoroutineScope, WithLogger {
-
-    override val coroutineContext: CoroutineContext =
-        Executors.newFixedThreadPool(nThreads).asCoroutineDispatcher()
+class JaicpRequestExecutor(val executorImpl: Executor) : CoroutineScope, WithLogger {
+    override val coroutineContext: CoroutineContext = executorImpl.asCoroutineDispatcher()
 
     fun executeAsync(request: JaicpBotRequest, channel: BotChannel) = async(coroutineContext + MDCContext()) {
         execute(request, channel)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
@@ -2,49 +2,65 @@ package com.justai.jaicf.channel.jaicp.polling
 
 import com.justai.jaicf.channel.jaicp.JaicpBotChannel
 import com.justai.jaicf.channel.jaicp.dto.JaicpResponse
-import com.justai.jaicf.channel.jaicp.execution.ThreadPoolRequestExecutor
+import com.justai.jaicf.channel.jaicp.execution.JaicpRequestExecutor
 import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.slf4j.MDCContext
-import kotlin.coroutines.CoroutineContext
 
 
 internal class Dispatcher(
     private val client: HttpClient,
-    private val executor: ThreadPoolRequestExecutor
-) : WithLogger, CoroutineScope {
+    private val jaicpExecutor: JaicpRequestExecutor,
+) : WithLogger {
 
-    private val supervisor = SupervisorJob()
-    override val coroutineContext: CoroutineContext = supervisor + MDCContext()
     private val pollingChannels = mutableListOf<PollingChannel>()
     private val sender = ResponseSender(client)
 
     fun registerPolling(channel: JaicpBotChannel, proxyUrl: String) = pollingChannels
-        .add(PollingChannel(proxyUrl, channel, RequestPoller(client, proxyUrl)))
+        .add(PollingChannel(
+            url = proxyUrl,
+            botChannel = channel,
+            poller = RequestPoller(client, proxyUrl, jaicpExecutor.coroutineContext)
+        ))
         .also { logger.info("Registered polling for channel $channel") }
 
     fun startPollingBlocking() = runBlocking {
-        pollingChannels.map { channel ->
-            launch(MDCContext()) {
-                logger.info("Starting polling coroutine for channel ${channel.botChannel}")
-                runPolling(channel)
-            }
-        }.joinAll()
+        logger.info("Start blocking polling for ${pollingChannels.size} channels")
+        startPolling().joinAll()
     }
 
-    private suspend fun runPolling(channel: PollingChannel) {
-        channel.poller.getUpdates().collect { reqs ->
-            reqs.forEach { req ->
-                sendResponse(executor.executeAsync(req, channel.botChannel), channel.url)
-            }
+    fun stopPolling() {
+        logger.info("Stop polling for ${pollingChannels.size} channels")
+        pollingChannels.forEach { it.stopPolling() }
+    }
+
+    private suspend fun PollingChannel.registerUpdatesCollector() = poller.getUpdates().collect { reqs ->
+        reqs.forEach { req ->
+            sendResponse(jaicpExecutor.executeAsync(req, botChannel), url)
         }
     }
 
     private fun sendResponse(botResponse: Deferred<JaicpResponse>, url: String) {
-        launch(Dispatchers.IO) {
+        CoroutineScope(jaicpExecutor.coroutineContext).launch {
             sender.send(url, botResponse)
+        }
+    }
+
+    fun startPolling(): List<Job> {
+        logger.info("Start polling for ${pollingChannels.size} channels")
+        return pollingChannels.map { channel ->
+            CoroutineScope(jaicpExecutor.coroutineContext + MDCContext()).launch {
+                logger.info("Starting polling coroutine for channel ${channel.botChannel}")
+                channel.startPolling()
+                channel.registerUpdatesCollector()
+            }
         }
     }
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/Dispatcher.kt
@@ -38,7 +38,7 @@ internal class Dispatcher(
 
     fun stopPolling() {
         logger.info("Stop polling for ${pollingChannels.size} channels")
-        pollingChannels.forEach { it.stopPolling() }
+        pollingChannels.forEach { it.poller.stopPolling() }
     }
 
     private suspend fun PollingChannel.registerUpdatesCollector() = poller.getUpdates().collect { reqs ->
@@ -58,7 +58,7 @@ internal class Dispatcher(
         return pollingChannels.map { channel ->
             CoroutineScope(jaicpExecutor.coroutineContext + MDCContext()).launch {
                 logger.info("Starting polling coroutine for channel ${channel.botChannel}")
-                channel.startPolling()
+                channel.poller.startPolling()
                 channel.registerUpdatesCollector()
             }
         }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
@@ -5,5 +5,18 @@ import com.justai.jaicf.channel.jaicp.JaicpBotChannel
 internal data class PollingChannel(
     val url: String,
     val botChannel: JaicpBotChannel,
-    val poller: RequestPoller
-)
+    val poller: RequestPoller,
+) {
+    var isActive: Boolean = false
+        private set
+
+    fun startPolling() {
+        isActive = true
+        poller.startPolling()
+    }
+
+    fun stopPolling() {
+        isActive = false
+        poller.stopPolling()
+    }
+}

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/PollingChannel.kt
@@ -6,17 +6,4 @@ internal data class PollingChannel(
     val url: String,
     val botChannel: JaicpBotChannel,
     val poller: RequestPoller,
-) {
-    var isActive: Boolean = false
-        private set
-
-    fun startPolling() {
-        isActive = true
-        poller.startPolling()
-    }
-
-    fun stopPolling() {
-        isActive = false
-        poller.stopPolling()
-    }
-}
+)

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPoller.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/polling/RequestPoller.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.CoroutineContext
 
 internal class RequestPoller(
@@ -27,10 +28,10 @@ internal class RequestPoller(
     }
 
     private var unprocessed: Boolean = false
-    private var isActive: Boolean = false
+    private val isActive: AtomicBoolean = AtomicBoolean(false)
 
     suspend fun getUpdates(): Flow<List<JaicpBotRequest>> = flow {
-        while (isActive) {
+        while (isActive.get()) {
             try {
                 emit(doPoll())
             } catch (ex: Exception) {
@@ -48,11 +49,11 @@ internal class RequestPoller(
     }
 
     fun stopPolling() {
-        isActive = false
+        isActive.set(false)
     }
 
     fun startPolling() {
-        isActive = true
+        isActive.set(true)
     }
 
     private fun updateSince(requests: List<JaicpBotRequest>) {


### PR DESCRIPTION
There was no way to implement graceful shutdown with long polling and previous thread distribution made it easy to create a bottleneck in `ThreadPoolRequestExecutor`, as separate coroutines filled pool with requests and never ensured pool capacity.

Changes:
1. Creates jaicpConnector.stop() method to stop polling coroutines.
2. Allows providing Executor to run requests on.
3. Unifies thread pool for HTTP calls and request processing