### PR TITLE
Implement delegated properties on BotContext

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/helpers/context/BotContextProperty.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/context/BotContextProperty.kt
@@ -1,0 +1,185 @@
+package com.justai.jaicf.helpers.context
+
+import com.justai.jaicf.context.BotContext
+import kotlin.properties.ReadOnlyProperty
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * An alias for a property delegate of type [V] backed by [BotContext]
+ */
+typealias BotContextProperty<V> = MapBackedProperty<BotContext, V>
+
+/**
+ * Creates a property delegate of type [V] backed by [BotContext.client].
+ *
+ * Definition example:
+ * ```kotlin
+ *
+ * var BotContext.username by clientProperty<String>()
+ * var BotContext.isUserBlocked by clientProperty("blockStatus") { false }
+ * var BotContext.order by clientProperty<Order?>(removeOnNull = true) { null }
+ * val BotContext.userInfo by clientProperty<UserInfo>(saveDefault = true) { getUserInfo(it.clientId) }
+ *
+ * ```
+ *
+ * Usage example:
+ * ```kotlin
+ *
+ * action {
+ *   if (context.isUserBlocked) return@action
+ *   reactions.say("Hello, ${context.username}!")
+ * }
+ *
+ * ```
+ *
+ * @param key the key of the entry where to store the property value, if `null` property name is used
+ * @param saveDefault whether to save generated [default] value in the [BotContext.client], `false` by default
+ * @param removeOnNull whether to remove entry from [BotContext.client] on null set, `false` by default
+ * @param default provider of a default value for the entry, [NoSuchElementException] will be thrown by default
+ */
+fun <V> clientProperty(
+    key: String? = null,
+    saveDefault: Boolean = false,
+    removeOnNull: Boolean = false,
+    default: (BotContext) -> V = { throw NoSuchElementException("No value found for the key specified") }
+): BotContextProperty<V> = MapBackedProperty(BotContext::client, key, saveDefault, removeOnNull, default)
+
+/**
+ * Creates a property delegate of type [V] backed by [BotContext.session].
+ *
+ * @param key the key of the entry where to store the property value, if `null` property name is used
+ * @param saveDefault whether to save generated [default] value in the [BotContext.session], `false` by default
+ * @param removeOnNull whether to remove entry from [BotContext.session] on null set, `false` by default
+ * @param default provider of a default value for the entry, [NoSuchElementException] will be thrown by default
+ *
+ * @see clientProperty for examples
+ */
+fun <V> sessionProperty(
+    key: String? = null,
+    saveDefault: Boolean = false,
+    removeOnNull: Boolean = false,
+    default: (BotContext) -> V = { throw NoSuchElementException("No value found for the key specified") }
+): BotContextProperty<V> = MapBackedProperty(BotContext::session, key, saveDefault, removeOnNull, default)
+
+/**
+ * Creates a property delegate of type [V] backed by [BotContext.temp].
+ *
+ * @param key the key of the entry where to store the property value, if `null` property name is used
+ * @param saveDefault whether to save generated [default] value in the [BotContext.temp], `false` by default
+ * @param removeOnNull whether to remove entry from [BotContext.temp] on null set, `false` by default
+ * @param default provider of a default value for the entry, [NoSuchElementException] will be thrown by default
+ *
+ * @see clientProperty for examples
+ */
+fun <V> tempProperty(
+    key: String? = null,
+    saveDefault: Boolean = false,
+    removeOnNull: Boolean = false,
+    default: (BotContext) -> V = { throw NoSuchElementException("No value found for the key specified") }
+): BotContextProperty<V> = MapBackedProperty(BotContext::temp, key, saveDefault, removeOnNull, default)
+
+/**
+ * Allows to bind [ReadWriteProperty] defined on [BotContext] to a receiver of any type [T]
+ * by providing [BotContext] selector function.
+ *
+ * Example:
+ * ```kotlin
+ * val DefaultActionContext.userName by clientProperty<String?>() withContext { context }
+ * ```
+ *
+ * @param context provider of a [BotContext] for type [T]
+ *
+ * @return delegated property on a type [T] backed by the given [ReadWriteProperty]
+ */
+infix fun <T, V> ReadWriteProperty<BotContext, V>.withContext(context: T.() -> BotContext): ReadWriteProperty<T, V> =
+    object : ReadWriteProperty<T, V> {
+        override fun getValue(thisRef: T, property: KProperty<*>): V {
+            return this@withContext.getValue(thisRef.context(), property)
+        }
+
+        override fun setValue(thisRef: T, property: KProperty<*>, value: V) {
+            this@withContext.setValue(thisRef.context(), property, value)
+        }
+    }
+
+/**
+ * Allows to bind [ReadOnlyProperty] defined on [BotContext] to a receiver of any type [T]
+ * by providing [BotContext] selector function.
+ *
+ * @param context provider of a [BotContext] for type [T]
+ *
+ * @return delegated peroperty on a type [T] backed by the given [ReadOnlyProperty]
+ */
+infix fun <T, V> ReadOnlyProperty<BotContext, V>.withContext(context: T.() -> BotContext): ReadOnlyProperty<T, V> =
+    ReadOnlyProperty<T, V> { thisRef, property -> this@withContext.getValue(thisRef.context(), property) }
+
+/**
+ * Allows to bind [MapBackedProperty] defined on [BotContext] to a receiver of any type [T]
+ * by providing [BotContext] selector function.
+ *
+ * Also allows to override default value with [T] as a receiver.
+ *
+ * Example:
+ * ```kotlin
+ * val DefaultActionContext.userName by clientProperty<String>(saveDefault = true).with({ context }) { request.getUserName() }
+ * ```
+ *
+ * @param context provider of a [BotContext] for type [T]
+ * @param default new overriding default value
+ *
+ * @return delegated property on a receiver of type [T] backed by the given [MapBackedProperty]
+ */
+fun <T, V> MapBackedProperty<BotContext, V>.with(
+    context: T.() -> BotContext,
+    default: T.() -> V = { this@with.default(context()) }
+): MapBackedProperty<T, V> = MapBackedProperty({ mapSelector(it.context()) }, key, saveDefault, removeOnNull, default)
+
+/**
+ * An implementation of [ReadWriteProperty] backed by some [MutableMap].
+ *
+ * @param T receiver type
+ * @param V property type
+ * @param mapSelector selector of the underlying [MutableMap]
+ * @param key the key of the entry where to store the property value, if `null` property name is used
+ * @param saveDefault whether to save generated [default] value in the map, `false` by default
+ * @param removeOnNull whether to remove entry from the map on null set, `false` by default
+ * @param default provider of a default value for the entry, [NoSuchElementException] will be thrown by default
+ */
+class MapBackedProperty<T, V>(
+    internal val mapSelector: (T) -> MutableMap<String, Any?>,
+    internal val key: String?,
+    internal val saveDefault: Boolean,
+    internal val removeOnNull: Boolean,
+    internal val default: (T) -> V,
+) : ReadWriteProperty<T, V> {
+
+    override fun getValue(thisRef: T, property: KProperty<*>): V {
+        val map = mapSelector(thisRef)
+        val key = key ?: property.name
+
+        val value = if (map.containsKey(key)) {
+            map[key]
+        } else {
+            val default = default(thisRef)
+            if (saveDefault) {
+                map[key] = default
+            }
+            default
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return value as V
+    }
+
+    override fun setValue(thisRef: T, property: KProperty<*>, value: V) {
+        val map = mapSelector(thisRef)
+        val key = key ?: property.name
+
+        if (value == null && removeOnNull) {
+            map.remove(key)
+        } else {
+            map[key] = value
+        }
+    }
+}

--- a/core/src/testFixtures/kotlin/com/justai/jaicf/core/test/managers/BotContextBaseTest.kt
+++ b/core/src/testFixtures/kotlin/com/justai/jaicf/core/test/managers/BotContextBaseTest.kt
@@ -1,0 +1,92 @@
+package com.justai.jaicf.core.test.managers
+
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.manager.BotContextManager
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.Serializable
+
+open class BotContextBaseTest(override val manager: BotContextManager) : BotContextManagerTest {
+    @Test
+    fun `Saves simple value`() {
+        val context = BotContext("client1").apply {
+            result = "some result"
+            session["key1"] = "some value"
+            client["key1"] = "some value"
+        }
+
+        val result = manager.exchangeContext(context)
+
+        Assertions.assertNotNull(result)
+        Assertions.assertEquals(context.result, result.result)
+        Assertions.assertEquals(context.session, result.session)
+        Assertions.assertEquals(context.client, result.client)
+    }
+
+    @Test
+    fun `Saves custom bean`() {
+        val context = BotContext("client2").apply {
+            result = CustomValue(1)
+            session["value"] = CustomValue(CustomValue(2))
+            client["value"] = CustomValue(CustomValue(2))
+        }
+
+        val result = manager.exchangeContext(context)
+
+        Assertions.assertNotNull(result)
+        Assertions.assertTrue(result.result is CustomValue)
+        Assertions.assertTrue(result.session["value"] is CustomValue)
+        Assertions.assertTrue(result.client["value"] is CustomValue)
+    }
+
+    @Test
+    fun `Saves transition history`() {
+        var context = BotContext("client3")
+        Assertions.assertEquals(listOf("/"), context.dialogContext.transitionHistory.toList())
+
+        context.dialogContext.saveToTransitionHistory("/a")
+
+        context = manager.exchangeContext(context)
+        Assertions.assertEquals(listOf("/", "/a"), context.dialogContext.transitionHistory.toList())
+
+        context.dialogContext.saveToTransitionHistory("/a/b")
+
+        context = manager.exchangeContext(context)
+        Assertions.assertEquals(listOf("/", "/a", "/a/b"), context.dialogContext.transitionHistory.toList())
+    }
+
+    @Test
+    fun `Saves back states stack`() {
+        var context = BotContext("client3")
+        Assertions.assertEquals(emptyList<String>(), context.dialogContext.backStateStack.toList())
+
+        context.dialogContext.backStateStack.add("/a")
+
+        context = manager.exchangeContext(context)
+        Assertions.assertEquals(listOf("/a"), context.dialogContext.backStateStack.toList())
+
+        context.dialogContext.backStateStack.add("/a/b")
+
+        context = manager.exchangeContext(context)
+        Assertions.assertEquals(listOf("/a", "/a/b"), context.dialogContext.backStateStack.toList())
+    }
+
+    @Test
+    fun `Saves transitions`() {
+        var context = BotContext("client3")
+        Assertions.assertEquals(emptyMap<String, String>(), context.dialogContext.transitions)
+
+        context.dialogContext.transitions.put("a", "/a")
+
+        context = manager.exchangeContext(context)
+        Assertions.assertEquals(mutableMapOf("a" to "/a"), context.dialogContext.transitions)
+
+        context.dialogContext.transitions.put("b", "/b")
+
+        context = manager.exchangeContext(context)
+        Assertions.assertEquals(mutableMapOf("a" to "/a", "b" to "/b"), context.dialogContext.transitions)
+    }
+
+    data class CustomValue(val value: Any) : Serializable
+}

--- a/core/src/testFixtures/kotlin/com/justai/jaicf/core/test/managers/BotContextDelegatesTest.kt
+++ b/core/src/testFixtures/kotlin/com/justai/jaicf/core/test/managers/BotContextDelegatesTest.kt
@@ -1,0 +1,189 @@
+package com.justai.jaicf.core.test.managers
+
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.manager.BotContextManager
+import com.justai.jaicf.helpers.context.clientProperty
+import com.justai.jaicf.helpers.context.with
+import com.justai.jaicf.helpers.context.withContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+open class BotContextDelegatesTest(override val manager: BotContextManager) : BotContextManagerTest {
+    // @formatter:off
+    var BotContextHolder.generatedNameSaveFalseRemoveFalse by clientProperty<String?> { "value" } withContext { context }
+    var BotContextHolder.generatedNameSaveFalseRemoveTrue by clientProperty<String?>(saveDefault = false, removeOnNull = true) { "value" } withContext { context }
+    var BotContextHolder.generatedNameSaveTrueRemoveFalse by clientProperty<String?>(saveDefault = true, removeOnNull = false) { "value" } withContext { context }
+    var BotContextHolder.generatedNameSaveTrueRemoveTrue by clientProperty<String?>(saveDefault = true, removeOnNull = true) { "value" } withContext { context }
+    var BotContextHolder.customNameWithoutDefaultSaveFalseRemoveFalse by clientProperty<String?>(key = "name") withContext { context }
+    var BotContextHolder.customNameWithoutDefaultSaveFalseRemoveTrue by clientProperty<String?>(key = "name", saveDefault = false, removeOnNull = true) withContext { context }
+    var BotContextHolder.customNameWithoutDefaultSaveTrueRemoveFalse by clientProperty<String?>(key = "name", saveDefault = true, removeOnNull = false) withContext { context }
+    var BotContextHolder.customNameWithoutDefaultSaveTrueRemoveTrue by clientProperty<String?>(key = "name", saveDefault = true, removeOnNull = true) withContext { context }
+    var BotContextHolder.customNameWithCustomDefaultSaveFalseRemoveFalse by clientProperty<String?>(key = "name").with({ context }) { customData }
+    var BotContextHolder.customNameWithCustomDefaultSaveFalseRemoveTrue by clientProperty<String?>(key = "name", saveDefault = false, removeOnNull = true).with({ context }) { customData }
+    var BotContextHolder.customNameWithCustomDefaultSaveTrueRemoveFalse by clientProperty<String?>(key = "name", saveDefault = true, removeOnNull = false).with({ context }) { customData }
+    var BotContextHolder.customNameWithCustomDefaultSaveTrueRemoveTrue by clientProperty<String?>(key = "name", saveDefault = true, removeOnNull = true).with({ context }) { customData }
+    // @formatter:on
+
+    @Test
+    fun generatedNameSaveFalseRemoveFalse() = testDelegateProperty(
+        { generatedNameSaveFalseRemoveFalse },
+        { generatedNameSaveFalseRemoveFalse = it },
+        expectedName = "generatedNameSaveFalseRemoveFalse",
+        hasDefault = true,
+        saveDefault = false,
+        removeOnNull = false
+    )
+
+    @Test
+    fun generatedNameSaveFalseRemoveTrue() = testDelegateProperty(
+        { generatedNameSaveFalseRemoveTrue },
+        { generatedNameSaveFalseRemoveTrue = it },
+        expectedName = "generatedNameSaveFalseRemoveTrue",
+        hasDefault = true,
+        saveDefault = false,
+        removeOnNull = true
+    )
+
+    @Test
+    fun generatedNameSaveTrueRemoveFalse() = testDelegateProperty(
+        { generatedNameSaveTrueRemoveFalse },
+        { generatedNameSaveTrueRemoveFalse = it },
+        expectedName = "generatedNameSaveTrueRemoveFalse",
+        hasDefault = true,
+        saveDefault = true,
+        removeOnNull = false
+    )
+
+    @Test
+    fun generatedNameSaveTrueRemoveTrue() = testDelegateProperty(
+        { generatedNameSaveTrueRemoveTrue },
+        { generatedNameSaveTrueRemoveTrue = it },
+        expectedName = "generatedNameSaveTrueRemoveTrue",
+        hasDefault = true,
+        saveDefault = true,
+        removeOnNull = true
+    )
+
+    @Test
+    fun customNameWithoutDefaultSaveFalseRemoveFalse() = testDelegateProperty(
+        { customNameWithoutDefaultSaveFalseRemoveFalse },
+        { customNameWithoutDefaultSaveFalseRemoveFalse = it },
+        expectedName = "name",
+        hasDefault = false,
+        saveDefault = false,
+        removeOnNull = false
+    )
+
+    @Test
+    fun customNameWithoutDefaultSaveFalseRemoveTrue() = testDelegateProperty(
+        { customNameWithoutDefaultSaveFalseRemoveTrue },
+        { customNameWithoutDefaultSaveFalseRemoveTrue = it },
+        expectedName = "name",
+        hasDefault = false,
+        saveDefault = false,
+        removeOnNull = true
+    )
+
+    @Test
+    fun customNameWithoutDefaultSaveTrueRemoveFalse() = testDelegateProperty(
+        { customNameWithoutDefaultSaveTrueRemoveFalse },
+        { customNameWithoutDefaultSaveTrueRemoveFalse = it },
+        expectedName = "name",
+        hasDefault = false,
+        saveDefault = true,
+        removeOnNull = false
+    )
+
+    @Test
+    fun customNameWithoutDefaultSaveTrueRemoveTrue() = testDelegateProperty(
+        { customNameWithoutDefaultSaveTrueRemoveTrue },
+        { customNameWithoutDefaultSaveTrueRemoveTrue = it },
+        expectedName = "name",
+        hasDefault = false,
+        saveDefault = true,
+        removeOnNull = true
+    )
+
+    @Test
+    fun customNameWithCustomDefaultSaveFalseRemoveFalse() = testDelegateProperty(
+        { customNameWithCustomDefaultSaveFalseRemoveFalse },
+        { customNameWithCustomDefaultSaveFalseRemoveFalse = it },
+        expectedName = "name",
+        hasDefault = true,
+        isCustomDefault = true,
+        saveDefault = false,
+        removeOnNull = false
+    )
+
+    @Test
+    fun customNameWithCustomDefaultSaveFalseRemoveTrue() = testDelegateProperty(
+        { customNameWithCustomDefaultSaveFalseRemoveTrue },
+        { customNameWithCustomDefaultSaveFalseRemoveTrue = it },
+        expectedName = "name",
+        hasDefault = true,
+        isCustomDefault = true,
+        saveDefault = false,
+        removeOnNull = true
+    )
+
+    @Test
+    fun customNameWithCustomDefaultSaveTrueRemoveFalse() = testDelegateProperty(
+        { customNameWithCustomDefaultSaveTrueRemoveFalse },
+        { customNameWithCustomDefaultSaveTrueRemoveFalse = it },
+        expectedName = "name",
+        hasDefault = true,
+        isCustomDefault = true,
+        saveDefault = true,
+        removeOnNull = false
+    )
+
+    @Test
+    fun customNameWithCustomDefaultSaveTrueRemoveTrue() = testDelegateProperty(
+        { customNameWithCustomDefaultSaveTrueRemoveTrue },
+        { customNameWithCustomDefaultSaveTrueRemoveTrue = it },
+        expectedName = "name",
+        hasDefault = true,
+        isCustomDefault = true,
+        saveDefault = true,
+        removeOnNull = true
+    )
+
+    fun testDelegateProperty(
+        getProp: BotContextHolder.() -> String?,
+        setProp: BotContextHolder.(String?) -> Unit,
+        expectedName: String,
+        hasDefault: Boolean,
+        isCustomDefault: Boolean = false,
+        saveDefault: Boolean,
+        removeOnNull: Boolean
+    ) {
+        val context = manager.loadContext()
+        val holder = BotContextHolder(context, "customData")
+        assertFalse(context.client.containsKey(expectedName))
+
+        if (hasDefault) {
+            val actual = holder.getProp()
+            val expected = if (isCustomDefault) holder.customData else "value"
+            assertEquals(saveDefault, context.client.containsKey(expectedName))
+            assertEquals(expected, actual)
+            if (saveDefault) {
+                assertEquals(expected, context.client[expectedName])
+            }
+        } else {
+            assertThrows<NoSuchElementException> { holder.getProp() }
+            assertFalse(context.client.containsKey(expectedName))
+        }
+
+        holder.setProp("new value")
+        val value = holder.getProp()
+        assertEquals("new value", context.client[expectedName])
+        assertEquals("new value", value)
+
+        holder.setProp(null)
+        assertEquals(!removeOnNull, context.client.containsKey(expectedName))
+    }
+
+    class BotContextHolder(val context: BotContext, val customData: String)
+}

--- a/core/src/testFixtures/kotlin/com/justai/jaicf/core/test/managers/BotContextManagerBaseTest.kt
+++ b/core/src/testFixtures/kotlin/com/justai/jaicf/core/test/managers/BotContextManagerBaseTest.kt
@@ -4,106 +4,32 @@ import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.context.BotContext
 import com.justai.jaicf.context.RequestContext
 import com.justai.jaicf.context.manager.BotContextManager
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestInstance
-import java.io.Serializable
+import java.util.*
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-abstract class BotContextManagerBaseTest {
-    abstract val manager: BotContextManager
+interface BotContextManagerTest {
+    val manager: BotContextManager
 
-    @Test
-    fun `Saves simple value`() {
-        val context = BotContext("client1").apply {
-            result = "some result"
-            session["key1"] = "some value"
-            client["key1"] = "some value"
-        }
+    fun BotContextManager.saveContext(context: BotContext) = saveContext(context, null, null, RequestContext.DEFAULT)
 
-        val result = manager.exchangeContext(context)
+    fun BotContextManager.loadContext(clientId: String = UUID.randomUUID().toString()) =
+        loadContext(EventBotRequest(clientId, "event"), RequestContext.DEFAULT)
 
-        assertNotNull(result)
-        assertEquals(context.result, result.result)
-        assertEquals(context.session, result.session)
-        assertEquals(context.client, result.client)
-    }
-
-    @Test
-    fun `Saves custom bean`() {
-        val context = BotContext("client2").apply {
-            result = CustomValue(1)
-            session["value"] = CustomValue(CustomValue(2))
-            client["value"] = CustomValue(CustomValue(2))
-        }
-
-        val result = manager.exchangeContext(context)
-
-        assertNotNull(result)
-        assertTrue(result.result is CustomValue)
-        assertTrue(result.session["value"] is CustomValue)
-        assertTrue(result.client["value"] is CustomValue)
-    }
-
-    @Test
-    fun `Saves transition history`() {
-        var context = BotContext("client3")
-        assertEquals(listOf("/"), context.dialogContext.transitionHistory.toList())
-
-        context.dialogContext.saveToTransitionHistory("/a")
-
-        context = manager.exchangeContext(context)
-        assertEquals(listOf("/", "/a"), context.dialogContext.transitionHistory.toList())
-
-        context.dialogContext.saveToTransitionHistory("/a/b")
-
-        context = manager.exchangeContext(context)
-        assertEquals(listOf("/", "/a", "/a/b"), context.dialogContext.transitionHistory.toList())
-    }
-
-    @Test
-    fun `Saves back states stack`() {
-        var context = BotContext("client3")
-        assertEquals(emptyList<String>(), context.dialogContext.backStateStack.toList())
-
-        context.dialogContext.backStateStack.add("/a")
-
-        context = manager.exchangeContext(context)
-        assertEquals(listOf("/a"), context.dialogContext.backStateStack.toList())
-
-        context.dialogContext.backStateStack.add("/a/b")
-
-        context = manager.exchangeContext(context)
-        assertEquals(listOf("/a", "/a/b"), context.dialogContext.backStateStack.toList())
-    }
-
-    @Test
-    fun `Saves transitions`() {
-        var context = BotContext("client3")
-        assertEquals(emptyMap<String, String>(), context.dialogContext.transitions)
-
-        context.dialogContext.transitions.put("a", "/a")
-
-        context = manager.exchangeContext(context)
-        assertEquals(mutableMapOf("a" to "/a"), context.dialogContext.transitions)
-
-        context.dialogContext.transitions.put("b", "/b")
-
-        context = manager.exchangeContext(context)
-        assertEquals(mutableMapOf("a" to "/a", "b" to "/b"), context.dialogContext.transitions)
-    }
-
-    protected fun BotContextManager.saveContext(context: BotContext) = saveContext(context, null, null, RequestContext.DEFAULT)
-
-    protected fun BotContextManager.loadContext(clientId: String) = loadContext(EventBotRequest(clientId, "event"), RequestContext.DEFAULT)
-
-    protected fun BotContextManager.exchangeContext(context: BotContext): BotContext {
+    fun BotContextManager.exchangeContext(context: BotContext): BotContext {
         val clientId = context.clientId
         saveContext(context)
         return loadContext(clientId)
     }
+}
 
-    data class CustomValue(val value: Any) : Serializable
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class BotContextManagerBaseTest : BotContextManagerTest {
+
+    @Nested
+    inner class BotContextBase : BotContextBaseTest(manager)
+
+    @Nested
+    inner class BotContextDelegates : BotContextDelegatesTest(manager)
+
 }

--- a/docs/pages/features/BotContext-Delegates.md
+++ b/docs/pages/features/BotContext-Delegates.md
@@ -1,0 +1,131 @@
+---
+layout: default
+title: BotContext delegates
+permalink: BotContext-Delegates
+parent: Features
+---
+
+[BotContext](context) allows to store data associated with user in a form of key-value pairs either on `client`, `session` or `temp` levels.
+Manipulating such a data in a raw key-value form may be quite complicated and uncomfortable. So Kotlin [delegated properties](https://kotlinlang.org/docs/delegated-properties.html) comes to rescue.
+
+JAICF provides helper functions that can be used in order to create delegated extension properties on `BotContext` encapsulating accesses to underlying key-value data storage.
+This functions are `clientProperty`, `sessionProperty` and `tempProperty` built on top of respective key-value maps. Source code can be found [here](https://github.com/just-ai/jaicf-kotlin/blob/master/core/src/main/kotlin/com/justai/jaicf/helpers/context/BotContextProperty.kt).
+
+```kotlin
+var BotContext.userName by clientProperty<String>()
+```
+This code creates read-write extension property `userName` on `BotContext` of type `String`. 
+
+Accesses to this property will be reflected to accesses to property with key `userName` stored in `BotContext.client`.
+```kotlin
+action {
+    context.userName = "John" // associates key "userName" with value "John" in BotContext.client
+    val name = context.userName // reads the value associated with the key "userName" in BotContext.client
+}
+```
+
+### default
+The property defined above will throw an exception in case it is read before its value was set. 
+But often it's useful to return some default value if the property value is not set yet or if the property is considered to be read-only. 
+One can achieve that by providing default value inside a lambda expression:
+```kotlin
+var BotContext.isUserBlocked by clientProperty { false } // explicit type declaration can be omitted in that case
+```
+Inside a lambda expression `BotContext` is available as a lambda parameter. 
+In case the property is considred to be computable but not assignable, it can be declared as a `val`
+```kotlin
+val BotContext.isUserBlocked by clientProperty { blackList.contains(it.clientId) }
+```
+
+### saveDefault
+By default such properties will recompute default value on each access while some explicit value is not set. 
+Sometimes it's desired behavior (as in the above example), but sometimes it's not. 
+For example getting default value may consist of costly computations, or it must be computed only once by design.
+In this case parameter `saveDefault` should be set to `true`:
+```kotlin
+val BotContext.sessionStartedAt by sessionProperty(saveDefault = true) { Instant.now() } // will be computed only once and immediately saved to `BotContext.session`
+val BotContext.userInfo by clientProperty(saveDeafault = true) { httpClient.getUserInfo(it.clientId) } // requires long computation but will be computed only once
+
+state("start") {
+    action {
+        val startTime = context.sessionStartedAt
+        val userInfo = context.userInfo
+        // ...
+    }
+}
+
+state("hangup") {
+    action {
+        val duration = Instant.now() - context.sessionStartedAt
+        // ...
+    }
+}
+```
+
+### removeOnNull
+Kotlin properties must either be able to provide some value or throw an exception in other case, it cannot be "cleared" in any sense.
+But sometimes an entry should be fully removed from underlying storage.
+In this case parameter `removeOnNull` should be set to `true`. _Unfortunately, in that case the property must have a nullable type even if default value is not `null`_:
+```kotlin
+var BotContext.order by sessionProperty<Order?>(removeOnNull = true) { createEmptyOrder() }
+
+state("addItem") {
+    action {
+        context.order!!.add(item)
+    }
+}
+
+state("clearOrder") {
+    action {
+        context.order = null
+    }
+}
+```
+
+### key
+In all of the above cases key of the property was not explicitely specified. In that case name of the property is used as a key in an underlying storage.
+In case explicit key is required, it can be passed in a function via the `key` parameter:
+```kotlin
+var BotContext.isUserBlocked by clientProperty { false } // key: "isUserBlocked"
+var BotContext.isUserBlocked by clientProperty("blockStatus") { false } // key: "blockStatus"
+```
+
+## Binding BotContext properties to other classes
+It also possible to bind BotContext property to any class `BotContext` is accessible from, for example to `ActionContext`.
+
+## withContext
+
+Function `withContext` allows to bind `BotContext` delegated property to a receiver of any other type by defining a way to get a `BotContext` from the new receiver:
+```kotlin
+val DefaultActionContext.order by sessionProperty<Order?>(removeOnNull = true) { createEmptyOrder() } withContext { context }
+```
+Here `context` inside a lambda is obtained from `ActionContext.context`.
+
+Now property `order` can be accessed on `ActionContext`:
+```kotlin
+action {
+    order.add(item)
+}
+```
+
+## with
+
+Function `with` is similar to `withContext`, it also required defining a way to obtain `BotContext`, 
+but it can be used only for properties, created by `clientProperty`, `sessionProperty` or `tempProperty` functions, 
+contrary to `withContext` that can be used for any delegated property.
+With this limitation function `with` allows to redefine default value of the property with new one that will be computed with new receiver instead of `BotContext`:
+```kotlin
+val DefaultActionContext.phoneNumber by clientProperty<String>(saveDefault = true).with({ context }) {
+    request.telegram?.contact?.phoneNumber ?: error("No phone number found") // `request` from `DefaultActionContext`
+}
+
+state("getContact") {
+    activators {
+        event(TelegramEvent.CONTACT)
+    }
+    
+    action {
+        scheduleCall(phoneNumber) // here `phoneNumber` is delegated property on ActionContext
+    }
+}
+```


### PR DESCRIPTION
This PR adds handy functions `clientProperty`, `sessionProperty` and `tempProperty` for easy defining extension properties on `BotContext`.
Also allows defining extensions on any class by providing `BotContext` selector:
```kotlin
val DefaultActionContext.prop by clientProperty { "abc" } withContext { context }
```