### PR TITLE
Normalize api urls endings

### DIFF
--- a/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookChannel.kt
+++ b/channels/facebook/src/main/kotlin/com/justai/jaicf/channel/facebook/FacebookChannel.kt
@@ -14,6 +14,7 @@ import com.justai.jaicf.channel.jaicp.JaicpCompatibleAsyncBotChannel
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleAsyncChannelFactory
 import com.justai.jaicf.channel.jaicp.JaicpLiveChatProvider
 import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.helpers.http.withTrailingSlash
 import java.util.*
 
 class FacebookChannel private constructor(
@@ -29,7 +30,7 @@ class FacebookChannel private constructor(
     }
 
     private constructor(botApi: BotApi, baseUrl: String, liveChatProvider: JaicpLiveChatProvider) : this(botApi) {
-        messenger = Messenger.create("", "", "", baseUrl)
+        messenger = Messenger.create("", "", "", baseUrl.withTrailingSlash(false))
         this.liveChatProvider = liveChatProvider
     }
 

--- a/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramChannel.kt
+++ b/channels/telegram/src/main/kotlin/com/justai/jaicf/channel/telegram/TelegramChannel.kt
@@ -29,6 +29,7 @@ import com.justai.jaicf.channel.jaicp.JaicpCompatibleAsyncBotChannel
 import com.justai.jaicf.channel.jaicp.JaicpCompatibleAsyncChannelFactory
 import com.justai.jaicf.channel.jaicp.JaicpLiveChatProvider
 import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.helpers.http.withTrailingSlash
 import com.justai.jaicf.helpers.kotlin.PropertyWithBackingField
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -44,7 +45,7 @@ class TelegramChannel(
     private lateinit var botUpdater: Updater
 
     private val bot = bot {
-        apiUrl = telegramApiUrl
+        apiUrl = telegramApiUrl.withTrailingSlash()
         token = telegramBotToken
         botUpdater = updater
 

--- a/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/sdk/api/ViberClient.kt
+++ b/channels/viber/src/main/kotlin/com/justai/jaicf/channel/viber/sdk/api/ViberClient.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.justai.jaicf.channel.viber.sdk.api.request.ApiRequest
 import com.justai.jaicf.channel.viber.sdk.api.request.ApiResponse
 import com.justai.jaicf.channel.viber.sdk.viberObjectMapper
+import com.justai.jaicf.helpers.http.withTrailingSlash
 
-open class ViberClient(val apiUrl: String, val httpClient: ViberHttpClient) {
+open class ViberClient(apiUrl: String, val httpClient: ViberHttpClient) {
+    val apiUrl: String = apiUrl.withTrailingSlash(false)
 
     inline fun <T : ApiRequest, reified R : ApiResponse> sendRequest(
         endpoint: ViberHttpEndpoint,

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/AliceChannel.kt
@@ -11,6 +11,7 @@ import com.justai.jaicf.channel.yandexalice.api.AliceBotRequest
 import com.justai.jaicf.channel.yandexalice.api.AliceBotResponse
 import com.justai.jaicf.channel.yandexalice.manager.AliceBotContextManager
 import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.helpers.http.withTrailingSlash
 import com.justai.jaicf.helpers.kotlin.ifTrue
 
 class AliceChannel(
@@ -20,6 +21,7 @@ class AliceChannel(
 ) : JaicpCompatibleChannelWithApiClient {
 
     private var aliceApiUrl = DEFAULT_ALICE_API_URL
+
     private val contextManager = useDataStorage.ifTrue { AliceBotContextManager() }
 
     override fun configureApiUrl(proxyUrl: String) {

--- a/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/api/AliceApi.kt
+++ b/channels/yandex-alice/src/main/kotlin/com/justai/jaicf/channel/yandexalice/api/AliceApi.kt
@@ -4,6 +4,7 @@ import com.justai.jaicf.channel.yandexalice.JSON
 import com.justai.jaicf.channel.yandexalice.api.storage.Image
 import com.justai.jaicf.channel.yandexalice.api.storage.Images
 import com.justai.jaicf.channel.yandexalice.api.storage.UploadedImage
+import com.justai.jaicf.helpers.http.withTrailingSlash
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.features.json.*
@@ -29,8 +30,9 @@ private val client = HttpClient(CIO) {
 class AliceApi(
     private val oauthToken: String,
     private val skillId: String,
-    private val apiUrl: String,
+    apiUrl: String,
 ) {
+    private val apiUrl: String = apiUrl.withTrailingSlash(false)
 
     companion object {
         private val imageStorage = mutableMapOf<String, MutableMap<String, String>>()

--- a/core/src/main/kotlin/com/justai/jaicf/helpers/http/URL.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/helpers/http/URL.kt
@@ -1,3 +1,5 @@
 package com.justai.jaicf.helpers.http
 
 fun String.toUrl() = this.replace("(?<=[^:\\s])(/+/)".toRegex(), "/")
+
+fun String.withTrailingSlash(with: Boolean = true) = dropLastWhile { it == '/' } + if (with) "/" else ""

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/helpers/HttpHelpersTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/helpers/HttpHelpersTest.kt
@@ -1,0 +1,39 @@
+package com.justai.jaicf.core.test.helpers
+
+import com.justai.jaicf.helpers.http.withTrailingSlash
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.test.assertEquals
+
+class HttpHelpersTest {
+
+    @Nested
+    inner class TrailingSlashesTest {
+        private val symbols = ('a'..'z') + ('A'..'Z') + ('0'..'9') + arrayOf('/', '\\', ':', '?', '&', '@')
+
+        private fun randomString(len: Int) =
+            (1..len).joinToString("") { symbols.random().toString() }.dropLastWhile { it == '/' }
+
+        private fun nSlashes(len: Int): String =
+            (1..len).joinToString("") { "/" }
+
+
+        @Test
+        fun `Test trailing slash without slashes`() = repeat(100) {
+            val str = randomString(Random.nextInt(0, 100))
+
+            assertEquals("$str/", str.withTrailingSlash())
+            assertEquals(str, str.withTrailingSlash(false))
+        }
+
+        @Test
+        fun `Test trailing slash with slashes`() = repeat(100) {
+            val base = randomString(Random.nextInt(5, 20))
+            val str = base + nSlashes(Random.nextInt(1, 5))
+
+            assertEquals("$base/", str.withTrailingSlash())
+            assertEquals(base, str.withTrailingSlash(false))
+        }
+    }
+}


### PR DESCRIPTION
Different SDKs require different formats of `base url`, some with trailing slash, some without.
This PR adds normalization of URLs according to SDK contract before passing it to SDK or ApiClient.