### PR TITLE
Fix CAILA slot filling. Add tests

### DIFF
--- a/activators/caila/build.gradle.kts
+++ b/activators/caila/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `jaicf-kotlin`
     `jaicf-kotlin-serialization`
     `jaicf-publish`
+    `jaicf-junit`
 }
 
 dependencies {
@@ -15,4 +16,6 @@ dependencies {
     api(ktor("ktor-client-cio"))
     api(ktor("ktor-client-logging-jvm"))
     api(ktor("ktor-client-serialization-jvm"))
+    testImplementation("io.mockk:mockk" version { mockk })
+    testImplementation(ktor("ktor-client-mock"))
 }

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivatorContext.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivatorContext.kt
@@ -17,7 +17,7 @@ data class CailaIntentActivatorContext(
 
     var slots = intentData.slots?.map { it.name to it.value }?.toMap() ?: emptyMap()
 
-    val entities = result.entitiesLookup.entities
+    val entities get() = result.entitiesLookup.entities
 
     companion object {
         private const val serialVersionUID = 4934755046273038374L

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/client/CailaKtorClient.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/client/CailaKtorClient.kt
@@ -5,6 +5,7 @@ import com.justai.jaicf.activator.caila.JSON
 import com.justai.jaicf.activator.caila.dto.*
 import com.justai.jaicf.helpers.logging.WithLogger
 import io.ktor.client.*
+import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
@@ -18,11 +19,12 @@ class CailaKtorClient(
     override val accessToken: String,
     override val url: String = DEFAULT_CAILA_URL,
     override val inferenceNBest: Int,
-    logLevel: LogLevel = LogLevel.INFO
+    logLevel: LogLevel = LogLevel.INFO,
+    engine: HttpClientEngine = CIO.create()
 ) : WithLogger,
     CailaHttpClient {
 
-    private val client = HttpClient(CIO) {
+    private val client = HttpClient(engine) {
         expectSuccess = true
         install(Logging) {
             logger = Logger.DEFAULT

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceRequestData.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceRequestData.kt
@@ -27,7 +27,7 @@ data class CailaInferenceRequestData(
 @Serializable
 data class CailaPhraseMarkupData(
     val text: String,
-    val entities: MutableList<CailaEntityMarkupData>
+    var entities: MutableList<CailaEntityMarkupData>
 ) : java.io.Serializable {
     companion object {
         private const val serialVersionUID = -6194136165197848082L

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingContext.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingContext.kt
@@ -10,7 +10,7 @@ import java.io.Serializable
 
 internal data class CailaSlotFillingContext(
     val initialActivatorContext: ActivatorContext,
-    val requiredSlots: List<CailaSlotData>,
+    val slots: List<CailaSlotData>,
     val knownSlots: MutableList<CailaKnownSlotData>,
     val knownEntities: MutableList<CailaEntityMarkupData>,
     val maxRetries: MutableMap<String, Int> = HashMap()
@@ -21,7 +21,7 @@ internal data class CailaSlotFillingContext(
                 ?: mutableListOf()
             val knownEntities = initial.caila?.entities?.toMutableList()
                 ?: mutableListOf()
-            val requiredSlots = initial.caila?.topIntent?.slots?.filter { it.required }?.toMutableList()
+            val requiredSlots = initial.caila?.topIntent?.slots?.toMutableList()
                 ?: mutableListOf()
             val maxRetries = initial.caila?.topIntent?.slots?.map { it.name to 0 }?.toMap()?.toMutableMap()
                 ?: mutableMapOf()
@@ -30,7 +30,7 @@ internal data class CailaSlotFillingContext(
                 initialActivatorContext = initial,
                 knownSlots = knownSlots,
                 knownEntities = knownEntities,
-                requiredSlots = requiredSlots,
+                slots = requiredSlots,
                 maxRetries = maxRetries
             )
         }

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingHelper.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingHelper.kt
@@ -34,6 +34,10 @@ internal class CailaSlotFillingHelper(
             return SlotFillingFinished(initialActivationContext)
         }
 
+        if (initialActivationContext == null && botRequest.input.matches(Regex("/start", RegexOption.IGNORE_CASE))) {
+            return SlotFillingInterrupted()
+        }
+
         val ctx = restoreContext(botContext, initialActivationContext)
         val required = ctx.slots.filter { it.required }
         val known = ctx.knownSlots

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingHelper.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/slotfilling/CailaSlotFillingHelper.kt
@@ -80,7 +80,7 @@ internal class CailaSlotFillingHelper(
         val newSlots = ctx.knownSlots.map { it.name to it.value }.toMap()
         val newEntities = ctx.knownEntities
         ctx.initialActivatorContext.caila?.slots = newSlots
-        ctx.initialActivatorContext.caila?.result?.entitiesLookup?.entities?.addAll(newEntities)
+        ctx.initialActivatorContext.caila?.result?.entitiesLookup?.entities = newEntities
         clearSlotFillingContext(botContext)
         return SlotFillingFinished(ctx.initialActivatorContext)
     }

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorBaseTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorBaseTest.kt
@@ -1,0 +1,147 @@
+package com.justai.jaicf.activator.caila
+
+import com.justai.jaicf.activator.Activator
+import com.justai.jaicf.activator.caila.client.CailaKtorClient
+import com.justai.jaicf.activator.caila.slotfilling.CailaSlotFillingSettings
+import com.justai.jaicf.activator.selection.ActivationSelector
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.api.QueryBotRequest
+import com.justai.jaicf.builder.ScenarioGraphBuilder
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.context.manager.InMemoryBotContextManager
+import com.justai.jaicf.model.activation.Activation
+import com.justai.jaicf.model.scenario.Scenario
+import com.justai.jaicf.plugin.StateDeclaration
+import com.justai.jaicf.plugin.StateName
+import com.justai.jaicf.reactions.Reactions
+import com.justai.jaicf.slotfilling.SlotFillingFinished
+import com.justai.jaicf.slotfilling.SlotReactor
+import com.justai.jaicf.test.reactions.TestReactions
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class CailaActivatorBaseTest {
+    abstract val scenario: Scenario
+
+    private val cm = InMemoryBotContextManager
+    private lateinit var clientId: String
+
+    private var _reactions: TestReactions? = null
+    private var _context: BotContext? = null
+    private var request: BotRequest? = null
+
+    val reactions: TestReactions get() = _reactions!!
+    val context: BotContext get() = _context!!
+
+    private val mockKtorEngine = MockEngine { request ->
+        val method = request.url.encodedPath.substringAfterLast('/')
+        val response = getCailaResponse(this@CailaActivatorBaseTest.request!!.input, method)
+        respond(
+            content = ByteReadChannel(response.use { it.readBytes() }),
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+    }
+
+    private val cailaHttpClientMock = CailaKtorClient("token", inferenceNBest = -1, engine = mockKtorEngine)
+
+    @BeforeEach
+    fun setUp() {
+        clientId = UUID.randomUUID().toString()
+        request = null
+        _reactions = null
+        _context = loadContext()
+    }
+
+    val Activation.intentContext get() = assertNotNull(context.caila)
+    val SlotFillingFinished.intentContext get() = assertNotNull(activatorContext.caila)
+
+    val Activation.entityContext get() = assertNotNull(context.cailaEntity)
+    val SlotFillingFinished.entityContext get() = assertNotNull(activatorContext.cailaEntity)
+
+    fun test(
+        confidenceThreshold: Double = 0.2,
+        maxSlotRetries: Int = 2,
+        stopOnAnyIntent: Boolean = false,
+        stopOnAnyIntentThreshold: Double = 1.0,
+        body: CailaIntentActivator.() -> Unit
+    ): Unit = CailaIntentActivator(
+        scenario.model,
+        CailaNLUSettings(
+            "token",
+            confidenceThreshold = confidenceThreshold,
+            cailaSlotFillingSettings = CailaSlotFillingSettings(
+                maxSlotRetries, stopOnAnyIntent, stopOnAnyIntentThreshold
+            )
+        ),
+        cailaHttpClientMock
+    ).run(body)
+
+    fun Activator.activate(request: BotRequest, botContext: BotContext = context) =
+        activate(botContext, request, ActivationSelector.default)
+
+    fun Activator.mustActivate(request: BotRequest, botContext: BotContext = context) =
+        assertNotNull(activate(botContext, request, ActivationSelector.default))
+
+    fun Activator.mustNotActivate(request: BotRequest, botContext: BotContext = context) =
+        assertNull(activate(botContext, request, ActivationSelector.default))
+
+    fun CailaIntentActivator.recognizeIntent(request: BotRequest) = recogniseIntent(context, request)
+
+    fun Activator.fillSlots(
+        request: BotRequest,
+        reactions: Reactions = createReactions(),
+        botContext: BotContext = context,
+        activation: Activation? = null,
+        slotReactor: SlotReactor? = null
+    ) = fillSlots(request, reactions, botContext, activation?.context, slotReactor)
+
+    fun Activation.assertCaila(body: CailaIntentActivatorContext.() -> Unit) = intentContext.body()
+
+    fun SlotFillingFinished.assertCaila(body: CailaIntentActivatorContext.() -> Unit) = intentContext.body()
+
+    inline fun <reified T> Any?.assertType(): T = run {
+        assertTrue(this is T)
+        this
+    }
+
+    fun CailaIntentActivatorContext.assertSlot(name: String, value: String) {
+        val slot = assertNotNull(slots[name])
+        assertEquals(value, slot)
+    }
+
+    private fun createReactions() = mockk<TestReactions>(relaxed = true).also { _reactions = it }
+
+    fun saveContext(botContext: BotContext) =
+        InMemoryBotContextManager.saveContext(botContext, QueryBotRequest(clientId, ""), null, RequestContext.DEFAULT)
+
+    fun loadContext(): BotContext =
+        InMemoryBotContextManager.loadContext(QueryBotRequest(clientId, ""), RequestContext.DEFAULT)
+
+    fun exchangeContext(botContext: BotContext) = saveContext(botContext).run { loadContext() }
+
+    fun query(input: String) = QueryBotRequest(clientId, input).also {
+        request = it
+        _context = _context?.let(::exchangeContext) ?: loadContext()
+    }
+
+    @StateDeclaration
+    fun ScenarioGraphBuilder<*, *>.intent(@StateName name: String) = state(name) { activators { intent(name) } }
+
+    @StateDeclaration
+    fun ScenarioGraphBuilder<*, *>.entity(@StateName name: String) = state(name) { activators { cailaEntity(name) } }
+
+    private fun getCailaResponse(query: String, method: String) =
+        javaClass.getResourceAsStream("/caila_responses/$method/${query.replace(" ", "_").toLowerCase()}.json")!!
+}

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorBaseTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorBaseTest.kt
@@ -121,6 +121,22 @@ abstract class CailaActivatorBaseTest {
         assertEquals(value, slot)
     }
 
+    fun CailaIntentActivatorContext.assertSlots(vararg content: Pair<String, String>) {
+        content.forEach {
+            val slot = assertNotNull(slots[it.first])
+            assertEquals(it.second, slot)
+        }
+        assertEquals(slots.size, content.size)
+    }
+
+    fun CailaIntentActivatorContext.assertEntities(vararg content: Pair<String, String>) {
+        content.forEach { e ->
+            val entity = assertNotNull(entities.find { it.entity == e.first }).value
+            assertEquals(e.second, entity)
+        }
+        assertEquals(entities.size, content.size)
+    }
+
     private fun createReactions() = mockk<TestReactions>(relaxed = true).also { _reactions = it }
 
     fun saveContext(botContext: BotContext) =

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
@@ -169,7 +169,7 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
         }
 
         @Test
-        fun `Should stop slotfilling after max retries`() = test(stopOnAnyIntent = false, maxSlotRetries = 2) {
+        fun `Should stop slotfilling after max retries`() = test(stopOnAnyIntent = false, maxSlotRetries = 3) {
             val activation = mustActivate(query("order"))
             fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
             fillSlots(query("order 10 am")).assertType<SlotFillingInProgress>()

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
@@ -7,6 +7,8 @@ import com.justai.jaicf.slotfilling.SlotFillingInterrupted
 import io.mockk.Called
 import io.mockk.verify
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.RepetitionInfo
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -197,6 +199,14 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
             val activation = mustActivate(query("order"))
             fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
             fillSlots(query("hello")).assertType<SlotFillingInProgress>()
+        }
+
+        @RepeatedTest(4)
+        fun `Should interrupt slot filling on start`(repetition: RepetitionInfo) = test(stopOnAnyIntent = false) {
+            val starts = arrayOf("/start", "/START", "/Start", "/StArT")
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query(starts[repetition.currentRepetition - 1])).assertType<SlotFillingInterrupted>()
         }
     }
 

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
@@ -126,7 +126,7 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
         }
 
         @Test
-        fun `Should now answer with slot prompt on slotfilling finished`() = test {
+        fun `Should not answer with slot prompt on slotfilling finished`() = test {
             val activation = mustActivate(query("order pizza 10 am"))
             fillSlots(query("order pizza 10 am"), activation = activation).assertType<SlotFillingFinished>()
 
@@ -144,8 +144,8 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
             val activation = mustActivate(query("order pizza 10 am"))
             fillSlots(query("order pizza 10 am"), activation = activation).assertType<SlotFillingFinished>().assertCaila {
                 assertEquals("Order", intent)
-                assertSlot("pizza", "pizza")
-                assertSlot("time", "10 am")
+                assertSlots("pizza" to "pizza", "time" to "10 am")
+                assertEntities("Pizza" to "pizza", "duckling.time" to "10 am")
             }
         }
 
@@ -154,7 +154,8 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
             val activation = mustActivate(query("order pizza"))
             fillSlots(query("order pizza"), activation = activation).assertType<SlotFillingFinished>().assertCaila {
                 assertEquals("Order", intent)
-                assertSlot("pizza", "pizza")
+                assertSlots("pizza" to "pizza")
+                assertEntities("Pizza" to "pizza")
             }
         }
 
@@ -165,8 +166,19 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
             fillSlots(query("order 10 am")).assertType<SlotFillingInProgress>()
             fillSlots(query("order pizza 10 am")).assertType<SlotFillingFinished>().assertCaila {
                 assertEquals("Order", intent)
-                assertSlot("pizza", "pizza")
-                assertSlot("time", "10 am")
+                assertSlots("pizza" to "pizza", "time" to "10 am")
+                assertEntities("Pizza" to "pizza", "duckling.time" to "10 am")
+            }
+        }
+
+        @Test
+        fun `Should fill all required slots 2`() = test {
+            val activation = mustActivate(query("order 10 am"))
+            fillSlots(query("order 10 am"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query("order pizza 10 am")).assertType<SlotFillingFinished>().assertCaila {
+                assertEquals("Order", intent)
+                assertSlots("pizza" to "pizza", "time" to "10 am")
+                assertEntities("Pizza" to "pizza", "duckling.time" to "10 am")
             }
         }
 
@@ -178,7 +190,6 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
             fillSlots(query("hello")).assertType<SlotFillingInProgress>()
             fillSlots(query("hello")).assertType<SlotFillingInterrupted>()
         }
-
 
         @Test
         fun `Should interrupt slot filling if enabled with big confidence`() = test(stopOnAnyIntent = true, stopOnAnyIntentThreshold = 0.7) {

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
@@ -1,0 +1,234 @@
+package com.justai.jaicf.activator.caila
+
+import com.justai.jaicf.builder.Scenario
+import com.justai.jaicf.slotfilling.SlotFillingFinished
+import com.justai.jaicf.slotfilling.SlotFillingInProgress
+import com.justai.jaicf.slotfilling.SlotFillingInterrupted
+import io.mockk.Called
+import io.mockk.verify
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CailaActivatorTest : CailaActivatorBaseTest() {
+    override val scenario = Scenario {
+        intent("Hello")
+        intent("Order")
+
+        state("onlyHello", modal = true) {
+            intent("Hello")
+        }
+
+        state("onlyOrder", modal = true) {
+            intent("Order")
+        }
+
+        state("entity", modal = true) {
+            entity("Pizza")
+            entity("duckling.time")
+        }
+    }
+
+    @Nested
+    inner class IntentActivationTest {
+
+        @Test
+        fun `Should recognize all intents above confidence threshold`() = test(confidenceThreshold = 0.0) {
+            recognizeIntent(query("hello")).run {
+                assertTrue(any { it.intent == "Hello" })
+                assertTrue(any { it.intent == "Order" })
+            }
+        }
+
+        @Test
+        fun `Should not recognize intents below confidence threshold`() = test(confidenceThreshold = 0.3) {
+            recognizeIntent(query("order")).run {
+                assertTrue(any { it.intent == "Order" })
+                assertFalse(any { it.intent == "Hello" })
+            }
+        }
+
+        @Test
+        fun `Should activate intent Hello above confidence threshold`() = test(confidenceThreshold = 0.3) {
+            context.dialogContext.currentContext = "/onlyHello"
+            mustActivate(query("hello")).run {
+                assertEquals("Hello", intentContext.intent)
+                assertEquals("/onlyHello/Hello", state)
+            }
+        }
+
+        @Test
+        fun `Should activate intent Order above confidence threshold`() = test(confidenceThreshold = 0.3) {
+            context.dialogContext.currentContext = "/onlyOrder"
+            mustActivate(query("order")).run {
+                assertEquals("Order", intentContext.intent)
+                assertEquals("/onlyOrder/Order", state)
+            }
+        }
+
+
+        @Test
+        fun `Should not activate intent Hello below confidence threshold`() = test(confidenceThreshold = 0.3) {
+            context.dialogContext.currentContext = "/onlyOrder"
+            mustNotActivate(query("hello"))
+        }
+
+        @Test
+        fun `Should not activate intent Order below confidence threshold`() = test(confidenceThreshold = 0.3) {
+            context.dialogContext.currentContext = "/onlyHello"
+            mustNotActivate(query("order"))
+        }
+
+        @Test
+        fun `Should activate most confident intent Hello`() = test(confidenceThreshold = 0.0) {
+            mustActivate(query("hello")).run {
+                assertEquals("Hello", intentContext.intent)
+                assertEquals("/Hello", state)
+            }
+        }
+
+        @Test
+        fun `Should activate most confident intent Order`() = test(confidenceThreshold = 0.0) {
+            mustActivate(query("order")).run {
+                assertEquals("Order", intentContext.intent)
+                assertEquals("/Order", state)
+            }
+        }
+    }
+
+    @Nested
+    inner class SlotFillingTest {
+
+        @Test
+        fun `Should not start slotfilling for Hello`() = test {
+            val activation = mustActivate(query("hello"))
+            fillSlots(query("hello"), activation = activation).assertType<SlotFillingFinished>().assertCaila {
+                assertEquals("Hello", intent)
+            }
+        }
+
+        @Test
+        fun `Should start slotfilling for Order without all slots`() = test {
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+        }
+
+        @Test
+        fun `Should answer with slot prompt on slotfilling in progress`() = test {
+            val activation = mustActivate(query("order 10 am"))
+            fillSlots(query("order 10 am"), activation = activation).assertType<SlotFillingInProgress>()
+
+            verify { reactions.say("what do you want to order?") }
+        }
+
+        @Test
+        fun `Should now answer with slot prompt on slotfilling finished`() = test {
+            val activation = mustActivate(query("order pizza 10 am"))
+            fillSlots(query("order pizza 10 am"), activation = activation).assertType<SlotFillingFinished>()
+
+            verify { reactions wasNot Called }
+        }
+
+        @Test
+        fun `Should start slotfilling for Order without required slots`() = test {
+            val activation = mustActivate(query("order 10 am"))
+            fillSlots(query("order 10 am"), activation = activation).assertType<SlotFillingInProgress>()
+        }
+
+        @Test
+        fun `Should not start slotfilling for Order with all slots`() = test {
+            val activation = mustActivate(query("order pizza 10 am"))
+            fillSlots(query("order pizza 10 am"), activation = activation).assertType<SlotFillingFinished>().assertCaila {
+                assertEquals("Order", intent)
+                assertSlot("pizza", "pizza")
+                assertSlot("time", "10 am")
+            }
+        }
+
+        @Test
+        fun `Should not start slotfilling for Order with all required slots`() = test {
+            val activation = mustActivate(query("order pizza"))
+            fillSlots(query("order pizza"), activation = activation).assertType<SlotFillingFinished>().assertCaila {
+                assertEquals("Order", intent)
+                assertSlot("pizza", "pizza")
+            }
+        }
+
+        @Test
+        fun `Should fill all required slots`() = test {
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query("order 10 am")).assertType<SlotFillingInProgress>()
+            fillSlots(query("order pizza 10 am")).assertType<SlotFillingFinished>().assertCaila {
+                assertEquals("Order", intent)
+                assertSlot("pizza", "pizza")
+                assertSlot("time", "10 am")
+            }
+        }
+
+        @Test
+        fun `Should stop slotfilling after max retries`() = test(stopOnAnyIntent = false, maxSlotRetries = 2) {
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query("order 10 am")).assertType<SlotFillingInProgress>()
+            fillSlots(query("hello")).assertType<SlotFillingInProgress>()
+            fillSlots(query("hello")).assertType<SlotFillingInterrupted>()
+        }
+
+
+        @Test
+        fun `Should interrupt slot filling if enabled with big confidence`() = test(stopOnAnyIntent = true, stopOnAnyIntentThreshold = 0.7) {
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query("hello")).assertType<SlotFillingInterrupted>()
+        }
+
+        @Test
+        fun `Should not interrupt slot filling if enabled with small confidence`() = test(stopOnAnyIntent = true, stopOnAnyIntentThreshold = 0.9) {
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query("hello")).assertType<SlotFillingInProgress>()
+        }
+
+        @Test
+        fun `Should not interrupt slot filling if disabled`() = test(stopOnAnyIntent = false) {
+            val activation = mustActivate(query("order"))
+            fillSlots(query("order"), activation = activation).assertType<SlotFillingInProgress>()
+            fillSlots(query("hello")).assertType<SlotFillingInProgress>()
+        }
+    }
+
+    @Nested
+    inner class EntitiesActivationTest {
+
+        @Test
+        fun `Should activate entity time`() = test {
+            context.dialogContext.currentContext = "/entity"
+            mustActivate(query("order 10 am")).run {
+                assertEquals("/entity/duckling.time", state)
+                assertEquals("duckling.time", entityContext.entity)
+                assertEquals("10 am", entityContext.text)
+                assertEquals("10 am", entityContext.value)
+            }
+        }
+
+        @Test
+        fun `Should activate entity pizza`() = test {
+            context.dialogContext.currentContext = "/entity"
+            mustActivate(query("order pizza")).run {
+                assertEquals("/entity/Pizza", state)
+                assertEquals("Pizza", entityContext.entity)
+                assertEquals("pizza", entityContext.text)
+                assertEquals("pizza", entityContext.value)
+            }
+        }
+
+        @Test
+        fun `Should not activate if no entity`() = test {
+            context.dialogContext.currentContext = "/entity"
+            mustNotActivate(query("hello"))
+        }
+    }
+}

--- a/activators/caila/src/test/resources/caila_responses/analyze/hello.json
+++ b/activators/caila/src/test/resources/caila_responses/analyze/hello.json
@@ -1,0 +1,95 @@
+{
+  "markup": {
+    "source": "Hello",
+    "correctedText": "Hello",
+    "words": [
+      {
+        "annotations": {
+          "lemma": "hello",
+          "pos": "NOUN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Hello",
+        "word": "hello"
+      }
+    ]
+  },
+  "entitiesLookup": {
+    "text": "Hello",
+    "entities": [],
+    "stagedPhraseIdx": null,
+    "phraseMarkup": [
+      {
+        "annotations": {
+          "lemma": "hello",
+          "pos": "NOUN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Hello",
+        "word": "hello"
+      }
+    ]
+  },
+  "inference": {
+    "phrase": {
+      "text": "Hello",
+      "entities": [],
+      "stagedPhraseIdx": null,
+      "phraseMarkup": null
+    },
+    "variants": [
+      {
+        "intent": {
+          "id": 5124,
+          "path": "/Hello",
+          "answer": null,
+          "customData": null,
+          "slots": null,
+          "priority": 0
+        },
+        "confidence": 0.8,
+        "slots": [],
+        "debug": null
+      },
+      {
+        "intent": {
+          "id": 2824235,
+          "path": "/Order",
+          "answer": null,
+          "customData": null,
+          "slots": [
+            {
+              "name": "pizza",
+              "entity": "Pizza",
+              "required": true,
+              "prompts": [
+                "what do you want to order?"
+              ],
+              "array": null
+            },
+            {
+              "name": "time",
+              "entity": "duckling.time",
+              "required": false,
+              "prompts": [
+                "when?"
+              ],
+              "array": null
+            }
+          ],
+          "priority": 0
+        },
+        "confidence": 0.2,
+        "slots": [],
+        "debug": null
+      }
+    ],
+    "spelledWords": null
+  }
+}

--- a/activators/caila/src/test/resources/caila_responses/analyze/order.json
+++ b/activators/caila/src/test/resources/caila_responses/analyze/order.json
@@ -1,0 +1,95 @@
+{
+  "markup": {
+    "source": "Order",
+    "correctedText": "Order",
+    "words": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "PROPN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      }
+    ]
+  },
+  "entitiesLookup": {
+    "text": "Order",
+    "entities": [],
+    "stagedPhraseIdx": null,
+    "phraseMarkup": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "PROPN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      }
+    ]
+  },
+  "inference": {
+    "phrase": {
+      "text": "Order",
+      "entities": [],
+      "stagedPhraseIdx": null,
+      "phraseMarkup": null
+    },
+    "variants": [
+      {
+        "intent": {
+          "id": 2824235,
+          "path": "/Order",
+          "answer": null,
+          "customData": null,
+          "slots": [
+            {
+              "name": "pizza",
+              "entity": "Pizza",
+              "required": true,
+              "prompts": [
+                "what do you want to order?"
+              ],
+              "array": null
+            },
+            {
+              "name": "time",
+              "entity": "duckling.time",
+              "required": false,
+              "prompts": [
+                "when?"
+              ],
+              "array": null
+            }
+          ],
+          "priority": 0
+        },
+        "confidence": 0.8,
+        "slots": [],
+        "debug": null
+      },
+      {
+        "intent": {
+          "id": 5124,
+          "path": "/Hello",
+          "answer": null,
+          "customData": null,
+          "slots": null,
+          "priority": 0
+        },
+        "confidence": 0.2,
+        "slots": [],
+        "debug": null
+      }
+    ],
+    "spelledWords": null
+  }
+}

--- a/activators/caila/src/test/resources/caila_responses/analyze/order_10_am.json
+++ b/activators/caila/src/test/resources/caila_responses/analyze/order_10_am.json
@@ -1,0 +1,175 @@
+{
+  "markup": {
+    "source": "Order 10 am",
+    "correctedText": "Order 10 am",
+    "words": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "PROPN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      },
+      {
+        "annotations": {
+          "lemma": "10",
+          "pos": "NUM"
+        },
+        "startPos": 6,
+        "endPos": 8,
+        "pattern": false,
+        "punctuation": false,
+        "source": "10",
+        "word": "10"
+      },
+      {
+        "annotations": {
+          "lemma": "am",
+          "pos": "X"
+        },
+        "startPos": 9,
+        "endPos": 11,
+        "pattern": false,
+        "punctuation": false,
+        "source": "am",
+        "word": "am"
+      }
+    ]
+  },
+  "entitiesLookup": {
+    "text": "Order 10 am",
+    "entities": [
+      {
+        "entity": "duckling.time",
+        "slot": null,
+        "startPos": 6,
+        "endPos": 11,
+        "text": "10 am",
+        "value": "10 am",
+        "default": true,
+        "system": true,
+        "entityId": null,
+        "fuzzy": null
+      }
+    ],
+    "stagedPhraseIdx": null,
+    "phraseMarkup": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "PROPN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      },
+      {
+        "annotations": {
+          "lemma": "10",
+          "pos": "NUM"
+        },
+        "startPos": 6,
+        "endPos": 8,
+        "pattern": false,
+        "punctuation": false,
+        "source": "10",
+        "word": "10"
+      },
+      {
+        "annotations": {
+          "lemma": "am",
+          "pos": "X"
+        },
+        "startPos": 9,
+        "endPos": 11,
+        "pattern": false,
+        "punctuation": false,
+        "source": "am",
+        "word": "am"
+      }
+    ]
+  },
+  "inference": {
+    "phrase": {
+      "text": "Order 10 am",
+      "entities": [
+        {
+          "entity": "duckling.time",
+          "slot": null,
+          "startPos": 6,
+          "endPos": 11,
+          "text": "10 am",
+          "value": "10 am",
+          "default": true,
+          "system": true,
+          "entityId": null,
+          "fuzzy": null
+        }
+      ],
+      "stagedPhraseIdx": null,
+      "phraseMarkup": null
+    },
+    "variants": [
+      {
+        "intent": {
+          "id": 2824235,
+          "path": "/Order",
+          "answer": null,
+          "customData": null,
+          "slots": [
+            {
+              "name": "pizza",
+              "entity": "Pizza",
+              "required": true,
+              "prompts": [
+                "what do you want to order?"
+              ],
+              "array": null
+            },
+            {
+              "name": "time",
+              "entity": "duckling.time",
+              "required": false,
+              "prompts": [
+                "when?"
+              ],
+              "array": null
+            }
+          ],
+          "priority": 0
+        },
+        "confidence": 0.8,
+        "slots": [
+          {
+            "name": "time",
+            "value": "10 am",
+            "array": null
+          }
+        ],
+        "debug": null
+      },
+      {
+        "intent": {
+          "id": 5124,
+          "path": "/Hello",
+          "answer": null,
+          "customData": null,
+          "slots": null,
+          "priority": 0
+        },
+        "confidence": 0.2,
+        "slots": [],
+        "debug": null
+      }
+    ],
+    "spelledWords": null
+  }
+}

--- a/activators/caila/src/test/resources/caila_responses/analyze/order_pizza.json
+++ b/activators/caila/src/test/resources/caila_responses/analyze/order_pizza.json
@@ -1,0 +1,151 @@
+{
+  "markup": {
+    "source": "Order pizza",
+    "correctedText": "Order pizza",
+    "words": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "X"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      },
+      {
+        "annotations": {
+          "lemma": "pizza",
+          "pos": "X"
+        },
+        "startPos": 6,
+        "endPos": 11,
+        "pattern": false,
+        "punctuation": false,
+        "source": "pizza",
+        "word": "pizza"
+      }
+    ]
+  },
+  "entitiesLookup": {
+    "text": "Order pizza",
+    "entities": [
+      {
+        "entity": "Pizza",
+        "slot": null,
+        "startPos": 6,
+        "endPos": 11,
+        "text": "pizza",
+        "value": "pizza",
+        "default": true,
+        "system": false,
+        "entityId": 82729,
+        "fuzzy": null
+      }
+    ],
+    "stagedPhraseIdx": null,
+    "phraseMarkup": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "X"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      },
+      {
+        "annotations": {
+          "lemma": "pizza",
+          "pos": "X"
+        },
+        "startPos": 6,
+        "endPos": 11,
+        "pattern": false,
+        "punctuation": false,
+        "source": "pizza",
+        "word": "pizza"
+      }
+    ]
+  },
+  "inference": {
+    "phrase": {
+      "text": "Order pizza",
+      "entities": [
+        {
+          "entity": "Pizza",
+          "slot": null,
+          "startPos": 6,
+          "endPos": 11,
+          "text": "pizza",
+          "value": "pizza",
+          "default": true,
+          "system": false,
+          "entityId": 82729,
+          "fuzzy": null
+        }
+      ],
+      "stagedPhraseIdx": null,
+      "phraseMarkup": null
+    },
+    "variants": [
+      {
+        "intent": {
+          "id": 2824235,
+          "path": "/Order",
+          "answer": null,
+          "customData": null,
+          "slots": [
+            {
+              "name": "pizza",
+              "entity": "Pizza",
+              "required": true,
+              "prompts": [
+                "what do you want to order?"
+              ],
+              "array": null
+            },
+            {
+              "name": "time",
+              "entity": "duckling.time",
+              "required": false,
+              "prompts": [
+                "when?"
+              ],
+              "array": null
+            }
+          ],
+          "priority": 0
+        },
+        "confidence": 0.8,
+        "slots": [
+          {
+            "name": "pizza",
+            "value": "pizza",
+            "array": null
+          }
+        ],
+        "debug": null
+      },
+      {
+        "intent": {
+          "id": 5124,
+          "path": "/Hello",
+          "answer": null,
+          "customData": null,
+          "slots": null,
+          "priority": 0
+        },
+        "confidence": 0.2,
+        "slots": [],
+        "debug": null
+      }
+    ],
+    "spelledWords": null
+  }
+}

--- a/activators/caila/src/test/resources/caila_responses/analyze/order_pizza_10_am.json
+++ b/activators/caila/src/test/resources/caila_responses/analyze/order_pizza_10_am.json
@@ -1,0 +1,228 @@
+{
+  "markup": {
+    "source": "Order pizza 10 am",
+    "correctedText": "Order pizza 10 am",
+    "words": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "PROPN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      },
+      {
+        "annotations": {
+          "lemma": "pizza",
+          "pos": "X"
+        },
+        "startPos": 6,
+        "endPos": 11,
+        "pattern": false,
+        "punctuation": false,
+        "source": "pizza",
+        "word": "pizza"
+      },
+      {
+        "annotations": {
+          "lemma": "10",
+          "pos": "NUM"
+        },
+        "startPos": 12,
+        "endPos": 14,
+        "pattern": false,
+        "punctuation": false,
+        "source": "10",
+        "word": "10"
+      },
+      {
+        "annotations": {
+          "lemma": "am",
+          "pos": "X"
+        },
+        "startPos": 15,
+        "endPos": 17,
+        "pattern": false,
+        "punctuation": false,
+        "source": "am",
+        "word": "am"
+      }
+    ]
+  },
+  "entitiesLookup": {
+    "text": "Order pizza 10 am",
+    "entities": [
+      {
+        "entity": "Pizza",
+        "slot": null,
+        "startPos": 6,
+        "endPos": 11,
+        "text": "pizza",
+        "value": "pizza",
+        "default": true,
+        "system": false,
+        "entityId": 82729,
+        "fuzzy": null
+      },
+      {
+        "entity": "duckling.time",
+        "slot": null,
+        "startPos": 12,
+        "endPos": 17,
+        "text": "10 am",
+        "value": "10 am",
+        "default": true,
+        "system": true,
+        "entityId": null,
+        "fuzzy": null
+      }
+    ],
+    "stagedPhraseIdx": null,
+    "phraseMarkup": [
+      {
+        "annotations": {
+          "lemma": "order",
+          "pos": "PROPN"
+        },
+        "startPos": 0,
+        "endPos": 5,
+        "pattern": false,
+        "punctuation": false,
+        "source": "Order",
+        "word": "order"
+      },
+      {
+        "annotations": {
+          "lemma": "pizza",
+          "pos": "X"
+        },
+        "startPos": 6,
+        "endPos": 11,
+        "pattern": false,
+        "punctuation": false,
+        "source": "pizza",
+        "word": "pizza"
+      },
+      {
+        "annotations": {
+          "lemma": "10",
+          "pos": "NUM"
+        },
+        "startPos": 12,
+        "endPos": 14,
+        "pattern": false,
+        "punctuation": false,
+        "source": "10",
+        "word": "10"
+      },
+      {
+        "annotations": {
+          "lemma": "am",
+          "pos": "X"
+        },
+        "startPos": 15,
+        "endPos": 17,
+        "pattern": false,
+        "punctuation": false,
+        "source": "am",
+        "word": "am"
+      }
+    ]
+  },
+  "inference": {
+    "phrase": {
+      "text": "Order pizza 10 am",
+      "entities": [
+        {
+          "entity": "Pizza",
+          "slot": null,
+          "startPos": 6,
+          "endPos": 11,
+          "text": "pizza",
+          "value": "pizza",
+          "default": true,
+          "system": false,
+          "entityId": 82729,
+          "fuzzy": null
+        },
+        {
+          "entity": "duckling.time",
+          "slot": null,
+          "startPos": 12,
+          "endPos": 17,
+          "text": "10 am",
+          "value": "10 am",
+          "default": true,
+          "system": true,
+          "entityId": null,
+          "fuzzy": null
+        }
+      ],
+      "stagedPhraseIdx": null,
+      "phraseMarkup": null
+    },
+    "variants": [
+      {
+        "intent": {
+          "id": 2824235,
+          "path": "/Order",
+          "answer": null,
+          "customData": null,
+          "slots": [
+            {
+              "name": "pizza",
+              "entity": "Pizza",
+              "required": true,
+              "prompts": [
+                "what do you want to order?"
+              ],
+              "array": null
+            },
+            {
+              "name": "time",
+              "entity": "duckling.time",
+              "required": false,
+              "prompts": [
+                "when?"
+              ],
+              "array": null
+            }
+          ],
+          "priority": 0
+        },
+        "confidence": 0.8,
+        "slots": [
+          {
+            "name": "pizza",
+            "value": "pizza",
+            "array": null
+          },
+          {
+            "name": "time",
+            "value": "10 am",
+            "array": null
+          }
+        ],
+        "debug": null
+      },
+      {
+        "intent": {
+          "id": 5124,
+          "path": "/Hello",
+          "answer": null,
+          "customData": null,
+          "slots": null,
+          "priority": 0
+        },
+        "confidence": 0.2,
+        "slots": [],
+        "debug": null
+      }
+    ],
+    "spelledWords": null
+  }
+}

--- a/activators/caila/src/test/resources/caila_responses/entities/hello.json
+++ b/activators/caila/src/test/resources/caila_responses/entities/hello.json
@@ -1,0 +1,19 @@
+{
+  "text": "Hello",
+  "entities": [],
+  "stagedPhraseIdx": null,
+  "phraseMarkup": [
+    {
+      "annotations": {
+        "lemma": "hello",
+        "pos": "NOUN"
+      },
+      "startPos": 0,
+      "endPos": 5,
+      "pattern": false,
+      "punctuation": false,
+      "source": "Hello",
+      "word": "hello"
+    }
+  ]
+}

--- a/activators/caila/src/test/resources/caila_responses/entities/order.json
+++ b/activators/caila/src/test/resources/caila_responses/entities/order.json
@@ -1,0 +1,19 @@
+{
+  "text": "Order",
+  "entities": [],
+  "stagedPhraseIdx": null,
+  "phraseMarkup": [
+    {
+      "annotations": {
+        "lemma": "order",
+        "pos": "PROPN"
+      },
+      "startPos": 0,
+      "endPos": 5,
+      "pattern": false,
+      "punctuation": false,
+      "source": "Order",
+      "word": "order"
+    }
+  ]
+}

--- a/activators/caila/src/test/resources/caila_responses/entities/order_10_am.json
+++ b/activators/caila/src/test/resources/caila_responses/entities/order_10_am.json
@@ -1,0 +1,56 @@
+{
+  "text": "Order 10 am",
+  "entities": [
+    {
+      "entity": "duckling.time",
+      "slot": null,
+      "startPos": 6,
+      "endPos": 11,
+      "text": "10 am",
+      "value": "10 am",
+      "default": true,
+      "system": true,
+      "entityId": null,
+      "fuzzy": null
+    }
+  ],
+  "stagedPhraseIdx": null,
+  "phraseMarkup": [
+    {
+      "annotations": {
+        "lemma": "order",
+        "pos": "PROPN"
+      },
+      "startPos": 0,
+      "endPos": 5,
+      "pattern": false,
+      "punctuation": false,
+      "source": "Order",
+      "word": "order"
+    },
+    {
+      "annotations": {
+        "lemma": "10",
+        "pos": "NUM"
+      },
+      "startPos": 6,
+      "endPos": 8,
+      "pattern": false,
+      "punctuation": false,
+      "source": "10",
+      "word": "10"
+    },
+    {
+      "annotations": {
+        "lemma": "am",
+        "pos": "X"
+      },
+      "startPos": 9,
+      "endPos": 11,
+      "pattern": false,
+      "punctuation": false,
+      "source": "am",
+      "word": "am"
+    }
+  ]
+}

--- a/activators/caila/src/test/resources/caila_responses/entities/order_pizza.json
+++ b/activators/caila/src/test/resources/caila_responses/entities/order_pizza.json
@@ -1,0 +1,44 @@
+{
+  "text": "Order pizza",
+  "entities": [
+    {
+      "entity": "Pizza",
+      "slot": null,
+      "startPos": 6,
+      "endPos": 11,
+      "text": "pizza",
+      "value": "pizza",
+      "default": true,
+      "system": false,
+      "entityId": 82729,
+      "fuzzy": null
+    }
+  ],
+  "stagedPhraseIdx": null,
+  "phraseMarkup": [
+    {
+      "annotations": {
+        "lemma": "order",
+        "pos": "X"
+      },
+      "startPos": 0,
+      "endPos": 5,
+      "pattern": false,
+      "punctuation": false,
+      "source": "Order",
+      "word": "order"
+    },
+    {
+      "annotations": {
+        "lemma": "pizza",
+        "pos": "X"
+      },
+      "startPos": 6,
+      "endPos": 11,
+      "pattern": false,
+      "punctuation": false,
+      "source": "pizza",
+      "word": "pizza"
+    }
+  ]
+}

--- a/activators/caila/src/test/resources/caila_responses/entities/order_pizza_10_am.json
+++ b/activators/caila/src/test/resources/caila_responses/entities/order_pizza_10_am.json
@@ -1,0 +1,80 @@
+{
+  "text": "Order pizza 10 am",
+  "entities": [
+    {
+      "entity": "Pizza",
+      "slot": null,
+      "startPos": 6,
+      "endPos": 11,
+      "text": "pizza",
+      "value": "pizza",
+      "default": true,
+      "system": false,
+      "entityId": 82729,
+      "fuzzy": null
+    },
+    {
+      "entity": "duckling.time",
+      "slot": null,
+      "startPos": 12,
+      "endPos": 17,
+      "text": "10 am",
+      "value": "10 am",
+      "default": true,
+      "system": true,
+      "entityId": null,
+      "fuzzy": null
+    }
+  ],
+  "stagedPhraseIdx": null,
+  "phraseMarkup": [
+    {
+      "annotations": {
+        "lemma": "order",
+        "pos": "PROPN"
+      },
+      "startPos": 0,
+      "endPos": 5,
+      "pattern": false,
+      "punctuation": false,
+      "source": "Order",
+      "word": "order"
+    },
+    {
+      "annotations": {
+        "lemma": "pizza",
+        "pos": "X"
+      },
+      "startPos": 6,
+      "endPos": 11,
+      "pattern": false,
+      "punctuation": false,
+      "source": "pizza",
+      "word": "pizza"
+    },
+    {
+      "annotations": {
+        "lemma": "10",
+        "pos": "NUM"
+      },
+      "startPos": 12,
+      "endPos": 14,
+      "pattern": false,
+      "punctuation": false,
+      "source": "10",
+      "word": "10"
+    },
+    {
+      "annotations": {
+        "lemma": "am",
+        "pos": "X"
+      },
+      "startPos": 15,
+      "endPos": 17,
+      "pattern": false,
+      "punctuation": false,
+      "source": "am",
+      "word": "am"
+    }
+  ]
+}

--- a/activators/caila/src/test/resources/caila_responses/inference/hello.json
+++ b/activators/caila/src/test/resources/caila_responses/inference/hello.json
@@ -1,0 +1,13 @@
+{
+  "intent": {
+    "id": 5124,
+    "path": "/Hello",
+    "answer": null,
+    "customData": null,
+    "slots": null,
+    "priority": 0
+  },
+  "confidence": 0.8,
+  "slots": [],
+  "debug": null
+}

--- a/activators/caila/src/test/resources/caila_responses/inference/order.json
+++ b/activators/caila/src/test/resources/caila_responses/inference/order.json
@@ -1,0 +1,32 @@
+{
+  "intent": {
+    "id": 2824235,
+    "path": "/Order",
+    "answer": null,
+    "customData": null,
+    "slots": [
+      {
+        "name": "pizza",
+        "entity": "Pizza",
+        "required": true,
+        "prompts": [
+          "what do you want to order?"
+        ],
+        "array": null
+      },
+      {
+        "name": "time",
+        "entity": "duckling.time",
+        "required": false,
+        "prompts": [
+          "when?"
+        ],
+        "array": null
+      }
+    ],
+    "priority": 0
+  },
+  "confidence": 0.8,
+  "slots": [],
+  "debug": null
+}

--- a/activators/caila/src/test/resources/caila_responses/inference/order_10_am.json
+++ b/activators/caila/src/test/resources/caila_responses/inference/order_10_am.json
@@ -1,0 +1,38 @@
+{
+  "intent": {
+    "id": 2824235,
+    "path": "/Order",
+    "answer": null,
+    "customData": null,
+    "slots": [
+      {
+        "name": "pizza",
+        "entity": "Pizza",
+        "required": true,
+        "prompts": [
+          "what do you want to order?"
+        ],
+        "array": null
+      },
+      {
+        "name": "time",
+        "entity": "duckling.time",
+        "required": false,
+        "prompts": [
+          "when?"
+        ],
+        "array": null
+      }
+    ],
+    "priority": 0
+  },
+  "confidence": 0.8,
+  "slots": [
+    {
+      "name": "time",
+      "value": "10 am",
+      "array": null
+    }
+  ],
+  "debug": null
+}

--- a/activators/caila/src/test/resources/caila_responses/inference/order_pizza.json
+++ b/activators/caila/src/test/resources/caila_responses/inference/order_pizza.json
@@ -1,0 +1,38 @@
+{
+  "intent": {
+    "id": 2824235,
+    "path": "/Order",
+    "answer": null,
+    "customData": null,
+    "slots": [
+      {
+        "name": "pizza",
+        "entity": "Pizza",
+        "required": true,
+        "prompts": [
+          "what do you want to order?"
+        ],
+        "array": null
+      },
+      {
+        "name": "time",
+        "entity": "duckling.time",
+        "required": false,
+        "prompts": [
+          "when?"
+        ],
+        "array": null
+      }
+    ],
+    "priority": 0
+  },
+  "confidence": 0.8,
+  "slots": [
+    {
+      "name": "pizza",
+      "value": "pizza",
+      "array": null
+    }
+  ],
+  "debug": null
+}

--- a/activators/caila/src/test/resources/caila_responses/inference/order_pizza_10_am.json
+++ b/activators/caila/src/test/resources/caila_responses/inference/order_pizza_10_am.json
@@ -1,0 +1,43 @@
+{
+  "intent": {
+    "id": 2824235,
+    "path": "/Order",
+    "answer": null,
+    "customData": null,
+    "slots": [
+      {
+        "name": "pizza",
+        "entity": "Pizza",
+        "required": true,
+        "prompts": [
+          "what do you want to order?"
+        ],
+        "array": null
+      },
+      {
+        "name": "time",
+        "entity": "duckling.time",
+        "required": false,
+        "prompts": [
+          "when?"
+        ],
+        "array": null
+      }
+    ],
+    "priority": 0
+  },
+  "confidence": 0.8,
+  "slots": [
+    {
+      "name": "pizza",
+      "value": "pizza",
+      "array": null
+    },
+    {
+      "name": "time",
+      "value": "10 am",
+      "array": null
+    }
+  ],
+  "debug": null
+}

--- a/buildSrc/src/main/kotlin/plugins/junit/JaicfJUnitPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugins/junit/JaicfJUnitPlugin.kt
@@ -14,6 +14,7 @@ class JaicfJUnitPlugin : Plugin<Project> by apply<JaicfJUnit>()
 class JaicfJUnit(project: Project) : PluginAdapter(project) {
     override fun Project.apply() {
         dependencies {
+            "testImplementation"("org.jetbrains.kotlin:kotlin-test-junit" version { kotlin })
             "testImplementation"("org.junit.jupiter:junit-jupiter-api" version { jUnit })
             "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine" version { jUnit })
         }


### PR DESCRIPTION
This PR covers CAILA Activator with tests

Also, tests shown that slot-filling doesn't work properly in CAILA. 

Fixes:
* CAILA Activator ignores non-required slots, even if they are provided in user request
* CAILA Activator increments retry counter for the slot even if other slots are provided in request
Example:
Let `maxRetries = 2`, intent Order, slots [item, adress, date]
-> I want to make an order. (no "item" slot, increment counter)
<- What do you want to order?
-> Tomorrow at 10 am. (no "item" slot, increment counter)
<- What do you want to order?
-> Baker Street 221B. (no "item slot", failure)

