### PR TITLE
add modal and noContext fields to transition for activation selectors

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/builder/ScenarioBuilder.kt
@@ -264,7 +264,7 @@ class StateBuilder<B : BotRequest, R : Reactions> internal constructor(
     fun activators(@PathValue fromState: String = parent.toString(), body: ActivationRulesBuilder.() -> Unit) {
         val toState = path.toString()
         val rules = ActivationRulesBuilder().apply(body).build()
-        val transitions = rules.map { Transition(fromState, toState, it) }
+        val transitions = rules.map { Transition(fromState, toState, it, modal, noContext) }
         scenarioModelBuilder.transitions.addAll(transitions)
     }
 

--- a/core/src/main/kotlin/com/justai/jaicf/model/transition/Transition.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/model/transition/Transition.kt
@@ -5,5 +5,7 @@ import com.justai.jaicf.model.activation.ActivationRule
 data class Transition(
     val fromState: String,
     val toState: String,
-    val rule: ActivationRule
+    val rule: ActivationRule,
+    val modal: Boolean,
+    val noContext: Boolean
 )


### PR DESCRIPTION
This PR adds more fields to `Transition` object. 

**Why?**
We need `modal` field to implement JAICP-like `ActivationSelector` in some projects.


