### PR TITLE
telegram channel - use okhttp 3.14 for better http/2 support with tls

### DIFF
--- a/channels/telegram/build.gradle.kts
+++ b/channels/telegram/build.gradle.kts
@@ -14,5 +14,9 @@ dependencies {
     api("com.github.kotlin-telegram-bot:kotlin-telegram-bot:6.0.4") {
         exclude("com.github.kotlin-telegram-bot.kotlin-telegram-bot", "webhook")
         exclude("org.jetbrains.kotlin", "kotlin-stdlib")
+        exclude("com.squareup.okhttp3", "okhttp")
+        exclude("com.squareup.okhttp3", "logging-interceptor")
     }
+    api("com.squareup.okhttp3:okhttp:3.14.0")
+    api("com.squareup.okhttp3:logging-interceptor:3.14.0")
 }


### PR DESCRIPTION
okhttp3 version 3.8.0 in telegram library has a number of issues with HTTP/2. This version bump resolves most of issues for telegram channel
