### PR TITLE
CailaIntentActivator - separate thresolds for patterns and phrases match

### DIFF
--- a/activators/README.md
+++ b/activators/README.md
@@ -25,7 +25,7 @@ val dialogflowActivator = DialogflowIntentActivator.Factory(
 val cailaActivator = CailaIntentActivator.Factory(
     CailaNLUSettings(
         accessToken = "<your_jaicp_access_token>", 
-        confidenceThreshold = 0.2  
+        confidenceThreshold = 0.2 
 ))
 
 

--- a/activators/caila/README.md
+++ b/activators/caila/README.md
@@ -63,7 +63,12 @@ We have full guide, [How to integrate with JAICP](https://github.com/just-ai/jai
 val cailaActivator = CailaIntentActivator.Factory(
     CailaNLUSettings(
         accessToken = "<your_jaicp_access_token>", 
-        confidenceThreshold = 0.2  
+        confidenceThreshold = 0.2,
+        // optional thresholds for patterns and phrases match. If it's not specified, confidenceThreshold will be used
+        intentThresholds = IntentThresholds (
+            patterns = 0.3,
+            phrases = 0.3
+        )
 ))
 
 val helloWorldBot = BotEngine(

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivator.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivator.kt
@@ -17,6 +17,7 @@ import com.justai.jaicf.model.scenario.ScenarioModel
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.slotfilling.SlotFillingResult
 import com.justai.jaicf.slotfilling.SlotReactor
+import com.justai.zb.scenarios.engine.CailaThresholdProcessor
 
 
 open class CailaIntentActivator(
@@ -52,8 +53,9 @@ open class CailaIntentActivator(
     }
 
     private fun extractIntents(response: CailaAnalyzeResponseData): List<CailaIntentActivatorContext> {
+        val thresholdProcessor = CailaThresholdProcessor(settings)
         return response.inference.variants
-            .filter { it.confidence >= settings.confidenceThreshold }
+            .mapNotNull { thresholdProcessor.applyThresholds(it) }
             .map { CailaIntentActivatorContext(response, it) }
     }
 

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivator.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaIntentActivator.kt
@@ -17,7 +17,6 @@ import com.justai.jaicf.model.scenario.ScenarioModel
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.slotfilling.SlotFillingResult
 import com.justai.jaicf.slotfilling.SlotReactor
-import com.justai.zb.scenarios.engine.CailaThresholdProcessor
 
 
 open class CailaIntentActivator(

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaNLUSettings.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaNLUSettings.kt
@@ -5,9 +5,15 @@ import com.justai.jaicf.activator.caila.slotfilling.CailaSlotFillingSettings
 data class CailaNLUSettings(
     val accessToken: String,
     val confidenceThreshold: Double = 0.2,
+    val intentThresholds: IntentThresholds = IntentThresholds(),
     val cailaSlotFillingSettings: CailaSlotFillingSettings = CailaSlotFillingSettings.DEFAULT,
     val classifierNBest: Int = 5,
     val cailaUrl: String = "$DEFAULT_CAILA_URL/api/caila/p"
 )
 
 internal const val DEFAULT_CAILA_URL = "https://app.jaicp.com/cailapub"
+
+data class IntentThresholds(
+    val phrases: Double? = null,
+    val patterns: Double? = null
+)

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaThresoldProcessor.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaThresoldProcessor.kt
@@ -1,6 +1,5 @@
-package com.justai.zb.scenarios.engine
+package com.justai.jaicf.activator.caila
 
-import com.justai.jaicf.activator.caila.CailaNLUSettings
 import com.justai.jaicf.activator.caila.dto.CailaInferenceResultData
 import kotlin.math.max
 

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaThresoldProcessor.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/CailaThresoldProcessor.kt
@@ -1,0 +1,36 @@
+package com.justai.zb.scenarios.engine
+
+import com.justai.jaicf.activator.caila.CailaNLUSettings
+import com.justai.jaicf.activator.caila.dto.CailaInferenceResultData
+import kotlin.math.max
+
+class CailaThresholdProcessor(
+    settings: CailaNLUSettings
+) {
+    private val patternThreshold = settings.intentThresholds.patterns ?: settings.confidenceThreshold
+    private val phrasesThreshold = settings.intentThresholds.phrases ?: settings.confidenceThreshold
+
+    //  Due to different thresholds for patters and phrases result.confidence can be changed after this method
+    //
+    //  For example, if intent has patterns score 0.6 and phrases score 0.5, initial confidence will be 0.6.
+    //  If pattern threshold >= 0.6 and phrases threshold <= 0.5, intent confidence should change to phrases score
+    fun applyThresholds(result: CailaInferenceResultData): CailaInferenceResultData? {
+        var patternConfidence = result.weights?.patterns ?: 0.0
+        var phrasesConfidence = result.weights?.phrases ?: 0.0
+        if (patternConfidence == 0.0 && phrasesConfidence == 0.0) {
+            // that means that custom thresholds are not applicable (External NLU most likely), so we need to use confidence as score
+            return if (result.confidence > phrasesThreshold) result else null
+        }
+        var updatedResult = result;
+        if (result.weights != null) {
+            if (result.weights.patterns < patternThreshold) {
+                patternConfidence = 0.0
+            }
+            if (result.weights.phrases < phrasesThreshold) {
+                phrasesConfidence = 0.0
+            }
+            updatedResult = result.copy(confidence = max(patternConfidence, phrasesConfidence))
+        }
+        return if (updatedResult.confidence > 0.0) updatedResult else null
+    }
+}

--- a/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceResultData.kt
+++ b/activators/caila/src/main/kotlin/com/justai/jaicf/activator/caila/dto/CailaInferenceResultData.kt
@@ -9,7 +9,8 @@ data class CailaInferenceResultData(
     val intent: CailaIntentData,
     val confidence: Double,
     val slots: List<CailaKnownSlotData>?,
-    val debug: JsonObject?
+    val debug: JsonObject?,
+    val weights: InferenceResultWeights? = null
 ) : java.io.Serializable {
     companion object {
         private const val serialVersionUID = 1698636910227622116L
@@ -52,5 +53,15 @@ data class CailaKnownSlotData(
 ) : java.io.Serializable {
     companion object {
         private const val serialVersionUID = 1467148388316177817L
+    }
+}
+
+@Serializable
+data class InferenceResultWeights(
+    val patterns: Double,
+    val phrases: Double,
+) : java.io.Serializable {
+    companion object {
+        private const val serialVersionUID = 7438255714694047836L;
     }
 }

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorBaseTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorBaseTest.kt
@@ -72,6 +72,7 @@ abstract class CailaActivatorBaseTest {
 
     fun test(
         confidenceThreshold: Double = 0.2,
+        intentThresholds: IntentThresholds = IntentThresholds(),
         maxSlotRetries: Int = 2,
         stopOnAnyIntent: Boolean = false,
         stopOnAnyIntentThreshold: Double = 1.0,
@@ -83,7 +84,8 @@ abstract class CailaActivatorBaseTest {
             confidenceThreshold = confidenceThreshold,
             cailaSlotFillingSettings = CailaSlotFillingSettings(
                 maxSlotRetries, stopOnAnyIntent, stopOnAnyIntentThreshold
-            )
+            ),
+            intentThresholds = intentThresholds
         ),
         cailaHttpClientMock
     ).run(body)

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaActivatorTest.kt
@@ -98,6 +98,26 @@ class CailaActivatorTest : CailaActivatorBaseTest() {
                 assertEquals("/Order", state)
             }
         }
+
+        @Test
+        fun `Should activate intent Order by phrases threshold `() = test(
+            intentThresholds = IntentThresholds(patterns = 0.3, phrases = 0.0)
+        ) {
+            mustActivate(query("order")).run {
+                assertEquals("Order", intentContext.intent)
+                assertEquals("/Order", state)
+            }
+        }
+
+        @Test
+        fun `Should activate intent Hello by phrases threshold `() = test(
+            intentThresholds = IntentThresholds(patterns = 0.05, phrases = 0.99)
+        ) {
+            mustActivate(query("order")).run {
+                assertEquals("Hello", intentContext.intent)
+                assertEquals("/Hello", state)
+            }
+        }
     }
 
     @Nested

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaThresholdProcessorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaThresholdProcessorTest.kt
@@ -1,0 +1,136 @@
+package com.justai.jaicf.activator.caila
+
+import com.justai.jaicf.activator.caila.dto.CailaInferenceResultData
+import com.justai.jaicf.activator.caila.dto.CailaIntentData
+import com.justai.jaicf.activator.caila.dto.InferenceResultWeights
+import com.justai.zb.scenarios.engine.CailaThresholdProcessor
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CailaThresholdProcessorTest {
+
+    @ParameterizedTest
+    @MethodSource("provideApplyThresholdsTestCaseArguments")
+    fun applyThresholdsTest(
+        caseName: String,
+        expectedConfidence: Double?,  // if null - no result expected
+        intentConfidence: Double?,
+        intentPatternsScore: Double?,
+        intentPhrasesScore: Double?,
+        patternsThreshold: Double?,
+        phrasesThreshold: Double?
+    ) {
+        val settings: CailaNLUSettings = createTestConfiguration(null, patternsThreshold, phrasesThreshold)
+        val inferenceResult = createTestInferenceResult(intentConfidence, intentPatternsScore, intentPhrasesScore)
+
+        val actualResult = CailaThresholdProcessor(settings).applyThresholds(inferenceResult)
+
+        if (expectedConfidence == null) {
+            assertNull(actualResult)
+        } else {
+            assertEquals(expectedConfidence, actualResult!!.confidence, "Error in case: $caseName")
+        }
+    }
+
+    companion object {
+        private fun createTestConfiguration(
+            confidenceThreshold: Double?,
+            patternsThreshold: Double?,
+            phrasesThreshold: Double?
+        ): CailaNLUSettings {
+            var settings = CailaNLUSettings(accessToken = "fakeToken")
+            if (confidenceThreshold != null) {
+                settings = settings.copy(confidenceThreshold = confidenceThreshold)
+            }
+            if (patternsThreshold != null || phrasesThreshold != null) {
+                settings = settings.copy(intentThresholds = IntentThresholds(phrasesThreshold, patternsThreshold))
+            }
+            return settings
+        }
+
+        private fun createTestInferenceResult(
+            intentConfidence: Double?,
+            intentPatternsScore: Double?,
+            intentPhrasesScore: Double?
+        ): CailaInferenceResultData {
+            var inferenceResult = CailaInferenceResultData(
+                intent = CailaIntentData(
+                    id = 0L,
+                    path = "fakeIntentPath",
+                    answer = null,
+                    customData = null,
+                    slots = null
+                ),
+                confidence = (intentConfidence ?: 0.0),
+                slots = null,
+                debug = null
+            )
+            if (intentPatternsScore != null || intentPhrasesScore != null) {
+                inferenceResult = inferenceResult.copy(
+                    weights = InferenceResultWeights(intentPatternsScore ?: 0.0, intentPhrasesScore ?: 0.0)
+                )
+            }
+            return inferenceResult
+        }
+
+        @JvmStatic
+        fun provideApplyThresholdsTestCaseArguments() =
+            listOf(
+                Arguments.of(
+                    "no result expected - zero confidence result",
+                    null, 0.0, null, null, null, null
+                ),
+                Arguments.of(
+                    "no weights. Phrases threshold should be used. Intent should not be filtered out",
+                    0.33, 0.33, null, null, 0.4, 0.3
+                ),
+                Arguments.of(
+                    "no weights. Phrases threshold should be used. Intent should be filtered out",
+                    null, 0.33, null, null, 0.3, 0.4
+                ),
+                Arguments.of(
+                    "Zero pattern weight. Phrases weight higher that threshold",
+                    0.5, 0.5, 0.0, 0.5, 0.2, 0.2
+                ),
+                Arguments.of(
+                    "Zero pattern weight. Phrases weight lower that threshold",
+                    null, 0.5, 0.0, 0.5, 0.2, 0.9
+                ),
+                Arguments.of(
+                    "Zero phrases weight. Pattern weight higher that threshold",
+                    0.5, 0.5, 0.5, 0.0, 0.2, 0.2
+                ),
+                Arguments.of(
+                    "Zero phrases weight. Pattern weight lower that threshold",
+                    null, 0.5, 0.5, 0.0, 0.9, 0.2
+                ),
+                Arguments.of(
+                    "Has all weights. No thresholds applied",
+                    0.5, 0.5, 0.5, 0.3, 0.2, 0.2
+                ),
+                Arguments.of(
+                    "Has all weights. Lower phrases score threshold applied",
+                    0.5, 0.5, 0.5, 0.3, 0.2, 0.4
+                ),
+                Arguments.of(
+                    "Has all weights. Lower patterns score threshold applied",
+                    0.5, 0.5, 0.3, 0.5, 0.4, 0.2
+                ),
+                Arguments.of(
+                    "Has all weights. Higher phrases score threshold applied",
+                    0.3, 0.5, 0.3, 0.5, 0.2, 0.6
+                ),
+                Arguments.of(
+                    "Has all weights. Higher patterns score threshold applied",
+                    0.3, 0.5, 0.5, 0.3, 0.6, 0.2
+                ),
+                Arguments.of(
+                    "Has all weights. All threshold applied",
+                    null, 0.5, 0.3, 0.5, 0.4, 0.6
+                )
+            )
+    }
+}

--- a/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaThresholdProcessorTest.kt
+++ b/activators/caila/src/test/kotlin/com/justai/jaicf/activator/caila/CailaThresholdProcessorTest.kt
@@ -3,7 +3,6 @@ package com.justai.jaicf.activator.caila
 import com.justai.jaicf.activator.caila.dto.CailaInferenceResultData
 import com.justai.jaicf.activator.caila.dto.CailaIntentData
 import com.justai.jaicf.activator.caila.dto.InferenceResultWeights
-import com.justai.zb.scenarios.engine.CailaThresholdProcessor
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource

--- a/activators/caila/src/test/resources/caila_responses/analyze/order.json
+++ b/activators/caila/src/test/resources/caila_responses/analyze/order.json
@@ -74,7 +74,11 @@
         },
         "confidence": 0.8,
         "slots": [],
-        "debug": null
+        "debug": null,
+        "weights": {
+          "patterns": 0.1,
+          "phrases": 0.8
+        }
       },
       {
         "intent": {
@@ -87,7 +91,11 @@
         },
         "confidence": 0.2,
         "slots": [],
-        "debug": null
+        "debug": null,
+        "weights": {
+          "patterns": 0.2,
+          "phrases": 0.1
+        }
       }
     ],
     "spelledWords": null

--- a/buildSrc/src/main/kotlin/plugins/junit/JaicfJUnitPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugins/junit/JaicfJUnitPlugin.kt
@@ -16,6 +16,7 @@ class JaicfJUnit(project: Project) : PluginAdapter(project) {
         dependencies {
             "testImplementation"("org.jetbrains.kotlin:kotlin-test-junit" version { kotlin })
             "testImplementation"("org.junit.jupiter:junit-jupiter-api" version { jUnit })
+            "testImplementation"("org.junit.jupiter:junit-jupiter-params" version { jUnit })
             "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine" version { jUnit })
         }
         tasks.named<Test>("test") { useJUnitPlatform() }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(`tomcat-servlet`())
     implementation(ktor("ktor-server-core"))
     implementation("org.junit.jupiter:junit-jupiter-api" version { jUnit })
+    implementation("org.junit.jupiter:junit-jupiter-params" version { jUnit })
 
     testImplementation(kotlin("test-junit"))
     testImplementation(kotlin("test"))

--- a/docs/pages/nlu/Caila.md
+++ b/docs/pages/nlu/Caila.md
@@ -70,7 +70,12 @@ We have full guide, [How to integrate with JAICP](https://github.com/just-ai/jai
 val cailaActivator = CailaIntentActivator.Factory(
     CailaNLUSettings(
         accessToken = "<your_jaicp_access_token>", 
-        confidenceThreshold = 0.2  
+        confidenceThreshold = 0.2,
+        // optional thresholds for patterns and phrases match. If it's not specified, confidenceThreshold will be used
+        intentThresholds = IntentThresholds (
+            patterns = 0.3,
+            phrases = 0.3
+        )
 ))
 
 val helloWorldBot = BotEngine(


### PR DESCRIPTION
CAILA uses different algorithms for pattern and phrases matching, so using same confidence threshold for both of them is not correct. After recent changes CAILA response contains weights for both of match types, so we can specify different thresholds in JAICF

Things i changed:
- added weights to `CailaInferenceResultData` 
- added optional thresholds for patterns and phrases in `CailaNLUSettings`
- added `CailaThresholdProcessor`:
-- it should apply current threshold settings to `CailaInferenceResultData`
-- Due to backward compatibility, if phrases or patterns threshold not provided, we should use `confidenceThreshold` field
-- overall result confidence can change after processor