### PR TITLE
Add transferStatus variable in TelephonyBotRequest

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
@@ -140,7 +140,7 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
 /**
  * Contains the status of the transfer of a customer to an operator.
  *
- * @property status agent transfer status. It returns a string: `SUCCESS` or `FAIL`.
+ * @property status agent transfer status. It returns an enum value of [Status.SUCCESS] or [Status.FAIL].
  *
  * @property hangup true means the customer has ended the conversation.
  * false means the customer is still online and was re-directed to the bot (if continueCall: true in [TelephonySwitchReply]).
@@ -150,11 +150,16 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
 
 @Serializable
 data class TransferStatus(
-    val status: String,
+    val status: Status,
     val hangup: Boolean,
     val number: String
 ) {
-    val isSuccess = status == "SUCCESS"
+
+    enum class Status {
+        SUCCESS, FAIL
+    }
+
+    val isSuccess = status == Status.SUCCESS
 }
 
 @Serializable

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
@@ -83,6 +83,14 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
             ?.let { JSON.decodeFromJsonElement(it) }
 
     /**
+     * Returns an object with data about the transfer status of a customer to an operator.
+     *
+     * @see [TransferStatus]
+     */
+    val transferStatus: TransferStatus?
+        get() = jaicp.rawRequest.jsonObject["transferStatus"]?.let(JSON::decodeFromJsonElement)
+
+    /**
      * Returns a token for downloading call recordings made in the current project.
      * The Record calls toggle in the phone channel settings must be set to active so that call recordings become available for download.
      */
@@ -127,6 +135,26 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
             BotRequestType.INTENT -> error("Jaicp intent events are not supported")
         }
     }
+}
+
+/**
+ * Contains the status of the transfer of a customer to an operator.
+ *
+ * @property status agent transfer status. It returns a string: `SUCCESS` or `FAIL`.
+ *
+ * @property hangup true means the customer has ended the conversation.
+ * false means the customer is still online and was re-directed to the bot (if continueCall: true in [TelephonySwitchReply]).
+ *
+ * @property number the phone number the call was transferred to.
+ */
+
+@Serializable
+data class TransferStatus(
+    val status: String,
+    val hangup: Boolean,
+    val number: String
+) {
+    val isSuccess = status == "SUCCESS"
 }
 
 @Serializable


### PR DESCRIPTION
The `transferStatus` variable has been added to make it easier to describe the settings of the `state("Transfer")` in the scenario.

Changes:

-  `transferStatus` property extracts the transfer status from the `rawRequest`.
-  `isSuccess` property to the `TransferStatus` class to simplify checking the success of the transfer.