### PR TITLE
ASR & TTS provider settings

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpNativeBotRequest.kt
@@ -6,6 +6,8 @@ import com.justai.jaicf.api.EventBotRequest
 import com.justai.jaicf.api.QueryBotRequest
 import com.justai.jaicf.channel.jaicp.JSON
 import com.justai.jaicf.channel.jaicp.dto.bargein.BargeInRequest
+import com.justai.jaicf.channel.jaicp.dto.config.AsrConfig
+import com.justai.jaicf.channel.jaicp.dto.config.TtsConfig
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -63,6 +65,22 @@ interface TelephonyBotRequest : JaicpNativeBotRequest {
         get() = jaicp.rawRequest.jsonObject["originateData"]?.jsonObject?.get("callScenarioData")
             ?.jsonObject?.get("schedule")?.jsonObject?.get("dialSchedule")?.jsonObject
             ?.let(JSON::decodeFromJsonElement)
+
+    /**
+     * Returns the ASR provider settings of the phone channel used for the current call.
+     * Returns a settings object of [AsrConfig].
+     */
+    val asrConfig: AsrConfig?
+        get() = jaicp.rawRequest.jsonObject["asrTtsProviderData"]?.jsonObject?.get("asr")
+            ?.let { JSON.decodeFromJsonElement(it) }
+
+    /**
+     * Returns the TTS provider settings of the phone channel used for the current call.
+     * Returns a settings object of [TtsConfig].
+     */
+    val ttsConfig: TtsConfig?
+        get() = jaicp.rawRequest.jsonObject["asrTtsProviderData"]?.jsonObject?.get("tts")
+            ?.let { JSON.decodeFromJsonElement(it) }
 
     /**
      * Returns a token for downloading call recordings made in the current project.

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpResponseData.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpResponseData.kt
@@ -1,5 +1,7 @@
 package com.justai.jaicf.channel.jaicp.dto
 
+import com.justai.jaicf.channel.jaicp.dto.config.AsrConfig
+import com.justai.jaicf.channel.jaicp.dto.config.TtsConfig
 import com.justai.jaicf.channel.jaicp.dto.bargein.BargeInProperties
 import com.justai.jaicf.channel.jaicp.dto.bargein.BargeInResponse
 import com.justai.jaicf.channel.jaicp.toJson
@@ -17,6 +19,8 @@ internal class JaicpResponseData private constructor(
     val bargeInInterrupt: BargeInResponse? = null,
     val sessionId: String,
     val responseData: Map<String, JsonElement> = mapOf(),
+    val ttsConfig: TtsConfig? = null,
+    val asrConfig: AsrConfig? = null
 ) {
     internal constructor(
         replies: List<Reply>,
@@ -25,6 +29,8 @@ internal class JaicpResponseData private constructor(
         bargeInInterrupt: BargeInResponse?,
         sessionId: String,
         responseData: Map<String, JsonElement> = mapOf(),
+        ttsConfig: TtsConfig?,
+        asrConfig: AsrConfig?
     ) : this(
         replies = replies.map { it.serialized().toJson() },
         answer = replies.filterIsInstance<TextReply>().joinToString("\n\n") { it.text },
@@ -32,7 +38,9 @@ internal class JaicpResponseData private constructor(
         bargeIn = bargeInData,
         bargeInInterrupt = bargeInInterrupt,
         sessionId = sessionId,
-        responseData = responseData
+        responseData = responseData,
+        ttsConfig = ttsConfig,
+        asrConfig = asrConfig
     )
 }
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpResponseData.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpResponseData.kt
@@ -29,8 +29,8 @@ internal class JaicpResponseData private constructor(
         bargeInInterrupt: BargeInResponse?,
         sessionId: String,
         responseData: Map<String, JsonElement> = mapOf(),
-        ttsConfig: TtsConfig?,
-        asrConfig: AsrConfig?
+        ttsConfig: TtsConfig? = null,
+        asrConfig: AsrConfig? = null
     ) : this(
         replies = replies.map { it.serialized().toJson() },
         answer = replies.filterIsInstance<TextReply>().joinToString("\n\n") { it.text },

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/AsrConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/AsrConfig.kt
@@ -4,12 +4,20 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Properties for ASR provider setting for telephone channel.
+ * Configuration parameters for the automatic speech recognition (ASR) provider used in a telephone channel.
  *
- * The properties for each provider are different and determined in the relevant classes.
- * Not null there can be only one provider.
- * @param type is provider of the current session.
+ * The properties for each ASR provider are different and are defined in the relevant classes.
+ * Only one provider can be specified in the configuration.
  *
+ * @param type is asr provider of the current session.
+ * @param yandex configuration options for the Yandex ASR provider, if used.
+ * @param zitech configuration options for the Zitech ASR provider, if used.
+ * @param google configuration options for the Google ASR provider, if used.
+ * @param amiVoice configuration options for the AmiVoice ASR provider, if used.
+ * @param mts configuration options for the MTS ASR provider, if used.
+ * @param azure configuration options for the Azure ASR provider, if used.
+ * @param asm configuration options for the ASM ASR provider, if used.
+ * @param sber configuration options for the Sber ASR provider, if used.
  **/
 @Serializable
 data class AsrConfig(
@@ -57,6 +65,10 @@ data class AsrConfig(
     }
 }
 
+/**
+ * Base class for ASR provider configuration.
+ * Subclasses contain provider-specific settings that are used to configure the ASR provider for the current session.
+ **/
 @Serializable
 sealed class AsrProviderConfig
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/AsrConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/AsrConfig.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  * @param yandex configuration options for the Yandex ASR provider, if used.
  * @param zitech configuration options for the Zitech ASR provider, if used.
  * @param google configuration options for the Google ASR provider, if used.
- * @param amiVoice configuration options for the AmiVoice ASR provider, if used.
+ * @param aimyvoice configuration options for the Aimyvoice ASR provider, if used.
  * @param mts configuration options for the MTS ASR provider, if used.
  * @param azure configuration options for the Azure ASR provider, if used.
  * @param asm configuration options for the ASM ASR provider, if used.
@@ -25,7 +25,8 @@ data class AsrConfig(
     val yandex: AsrYandexConfig? = null,
     val zitech: AsrZitechConfig? = null,
     val google: AsrGoogleConfig? = null,
-    val amiVoice: AsrAmiVoiceConfig? = null,
+    @SerialName("amiVoice")
+    val aimyvoice: AsrAimyvoiceConfig? = null,
     val mts: AsrMtsConfig? = null,
     val azure: AsrAzureConfig? = null,
     val asm: AsrAsmConfig? = null,
@@ -49,7 +50,7 @@ data class AsrConfig(
         ZITECH,
 
         @SerialName("amiVoice")
-        AMIVOICE,
+        AIMYVOICE,
 
         @SerialName("azure")
         AZURE,
@@ -100,7 +101,7 @@ data class AsrMtsConfig(
 ) : AsrProviderConfig()
 
 @Serializable
-data class AsrAmiVoiceConfig(
+data class AsrAimyvoiceConfig(
     val codec: String? = null,
     val mode: String? = null,
     val grammarFileNames: String? = null

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/AsrConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/AsrConfig.kt
@@ -1,0 +1,115 @@
+package com.justai.jaicf.channel.jaicp.dto.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Properties for ASR provider setting for telephone channel.
+ *
+ * The properties for each provider are different and determined in the relevant classes.
+ * Not null there can be only one provider.
+ * @param type is provider of the current session.
+ *
+ **/
+@Serializable
+data class AsrConfig(
+    val type: AsrProviderType? = null,
+    val yandex: AsrYandexConfig? = null,
+    val zitech: AsrZitechConfig? = null,
+    val google: AsrGoogleConfig? = null,
+    val amiVoice: AsrAmiVoiceConfig? = null,
+    val mts: AsrMtsConfig? = null,
+    val azure: AsrAzureConfig? = null,
+    val asm: AsrAsmConfig? = null,
+    val sber: AsrSberConfig? = null
+) {
+    @Serializable
+    enum class AsrProviderType {
+        @SerialName("yandex")
+        YANDEX,
+
+        @SerialName("google")
+        GOOGLE,
+
+        @SerialName("tinkoff")
+        TINKOFF,
+
+        @SerialName("mts")
+        MTS,
+
+        @SerialName("zitech")
+        ZITECH,
+
+        @SerialName("amiVoice")
+        AMIVOICE,
+
+        @SerialName("azure")
+        AZURE,
+
+        @SerialName("asm")
+        ASM,
+
+        @SerialName("sber")
+        SBER,
+
+        @SerialName("kaldi")
+        KALDI
+    }
+}
+
+@Serializable
+sealed class AsrProviderConfig
+
+@Serializable
+data class AsrGoogleConfig(
+    val model: String? = null,
+    val lang: String? = null
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrZitechConfig(
+    val model: String? = null,
+    val lang: String? = null
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrYandexConfig(
+    val model: String? = null,
+    val lang: String? = null,
+    val numbersAsWords: Boolean? = null,
+    val sensitivityReduction: Boolean? = null
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrMtsConfig(
+    val model: String? = null,
+    val lang: String? = null,
+    val transferType: String? = null
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrAmiVoiceConfig(
+    val codec: String? = null,
+    val mode: String? = null,
+    val grammarFileNames: String? = null
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrAzureConfig(
+    val language: String? = null,
+    val outputFormat: String? = null,
+    val profanityOption: String? = null,
+    val enableDictation: Boolean? = null
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrAsmConfig(
+    val sampleRate: Long? = null,
+    val model: String? = null,
+) : AsrProviderConfig()
+
+@Serializable
+data class AsrSberConfig(
+    val language: String? = null,
+    val model: String? = null
+) : AsrProviderConfig()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/TtsConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/TtsConfig.kt
@@ -1,0 +1,103 @@
+package com.justai.jaicf.channel.jaicp.dto.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Properties for TTS provider setting for telephone channel.
+ *
+ * The properties for each provider are different and determined in the relevant classes.
+ * Not null there can be only one provider.
+ * @param type is provider of the current session.
+ *
+ **/
+@Serializable
+data class TtsConfig(
+    val type: TtsProviderType? = null,
+    val yandex: TtsConfigYandex? = null,
+    val google: TtsConfigGoogle? = null,
+    val mts: TtsConfigMts? = null,
+    val zitech: TtsConfigZitech? = null,
+    val azure: TtsConfigAzure? = null,
+    val aimyvoice: TtsConfigAimyvoice? = null,
+    val sber: TtsConfigSber? = null,
+) {
+    @Serializable
+    enum class TtsProviderType {
+        @SerialName("yandex")
+        YANDEX,
+
+        @SerialName("google")
+        GOOGLE,
+
+        @SerialName("mts")
+        MTS,
+
+        @SerialName("zitech")
+        ZITECH,
+
+        @SerialName("azure")
+        AZURE,
+
+        @SerialName("aimyvoice")
+        AIMYVOICE,
+
+        @SerialName("sber")
+        SBER
+    }
+}
+
+@Serializable
+sealed class TtsProviderConfig
+
+@Serializable
+data class TtsConfigAimyvoice(
+    val voice: String? = null
+) : TtsProviderConfig()
+
+@Serializable
+data class TtsConfigYandex(
+    val lang: String? = null,
+    val voice: String? = null,
+    val emotion: String? = null,
+    val speed: Double? = null,
+    val volume: Double? = null,
+    val useV3: Boolean? = null,
+    val useVariables: Boolean? = null,
+) : TtsProviderConfig()
+
+@Serializable
+data class TtsConfigMts(
+    val sampleRate: Int? = null,
+    val lang: String? = null,
+    val mediaType: String? = null,
+    val modelType: String? = null,
+    val voice: String? = null
+) : TtsProviderConfig()
+
+@Serializable
+data class TtsConfigGoogle(
+    val voice: String? = null,
+    val pitch: Double? = null,
+    val speakingRate: Double? = null,
+    val volumeGain: Double? = null
+) : TtsProviderConfig()
+
+@Serializable
+data class TtsConfigZitech(
+    val sampleRate: Int? = null,
+    val model: String? = null,
+    val speed: Double? = null,
+    val tone: Double? = null
+) : TtsProviderConfig()
+
+@Serializable
+data class TtsConfigAzure(
+    val sampleRate: Int? = null,
+    val voiceName: String? = null
+) : TtsProviderConfig()
+
+@Serializable
+data class TtsConfigSber(
+    val voice: String? = null
+) : TtsProviderConfig()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/TtsConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/TtsConfig.kt
@@ -21,13 +21,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TtsConfig(
     val type: TtsProviderType? = null,
-    val yandex: TtsConfigYandex? = null,
-    val google: TtsConfigGoogle? = null,
-    val mts: TtsConfigMts? = null,
-    val zitech: TtsConfigZitech? = null,
-    val azure: TtsConfigAzure? = null,
-    val aimyvoice: TtsConfigAimyvoice? = null,
-    val sber: TtsConfigSber? = null,
+    val yandex: TtsYandexConfig? = null,
+    val google: TtsGoogleConfig? = null,
+    val mts: TtsMtsConfig? = null,
+    val zitech: TtsZitechConfig? = null,
+    val azure: TtsAzureConfig? = null,
+    val aimyvoice: TtsAimyvoiceConfig? = null,
+    val sber: TtsSberConfig? = null,
 ) {
     @Serializable
     enum class TtsProviderType {
@@ -62,12 +62,12 @@ data class TtsConfig(
 sealed class TtsProviderConfig
 
 @Serializable
-data class TtsConfigAimyvoice(
+data class TtsAimyvoiceConfig(
     val voice: String? = null
 ) : TtsProviderConfig()
 
 @Serializable
-data class TtsConfigYandex(
+data class TtsYandexConfig(
     val lang: String? = null,
     val voice: String? = null,
     val emotion: String? = null,
@@ -78,7 +78,7 @@ data class TtsConfigYandex(
 ) : TtsProviderConfig()
 
 @Serializable
-data class TtsConfigMts(
+data class TtsMtsConfig(
     val sampleRate: Int? = null,
     val lang: String? = null,
     val mediaType: String? = null,
@@ -87,7 +87,7 @@ data class TtsConfigMts(
 ) : TtsProviderConfig()
 
 @Serializable
-data class TtsConfigGoogle(
+data class TtsGoogleConfig(
     val voice: String? = null,
     val pitch: Double? = null,
     val speakingRate: Double? = null,
@@ -95,7 +95,7 @@ data class TtsConfigGoogle(
 ) : TtsProviderConfig()
 
 @Serializable
-data class TtsConfigZitech(
+data class TtsZitechConfig(
     val sampleRate: Int? = null,
     val model: String? = null,
     val speed: Double? = null,
@@ -103,12 +103,12 @@ data class TtsConfigZitech(
 ) : TtsProviderConfig()
 
 @Serializable
-data class TtsConfigAzure(
+data class TtsAzureConfig(
     val sampleRate: Int? = null,
     val voiceName: String? = null
 ) : TtsProviderConfig()
 
 @Serializable
-data class TtsConfigSber(
+data class TtsSberConfig(
     val voice: String? = null
 ) : TtsProviderConfig()

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/TtsConfig.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/config/TtsConfig.kt
@@ -4,12 +4,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Properties for TTS provider setting for telephone channel.
+ * Configuration parameters for the text-to-speech (TTS) provider used in a telephone channel.
  *
- * The properties for each provider are different and determined in the relevant classes.
- * Not null there can be only one provider.
- * @param type is provider of the current session.
+ * The properties for each TTS provider are different and are defined in the relevant classes.
+ * Only one provider can be specified in the configuration.
  *
+ * @param type is provider TTS of the current session.
+ * @param yandex configuration options for the Yandex TTS provider, if used.
+ * @param google configuration options for the Google TTS provider, if used.
+ * @param mts configuration options for the MTS TTS provider, if used.
+ * @param zitech configuration options for the Zitech TTS provider, if used.
+ * @param azure configuration options for the Azure TTS provider, if used.
+ * @param aimyvoice configuration options for the Aimyvoice TTS provider, if used.
+ * @param sber configuration options for the Sber TTS provider, if used.
  **/
 @Serializable
 data class TtsConfig(
@@ -47,6 +54,10 @@ data class TtsConfig(
     }
 }
 
+/**
+ * Base class for TTS provider configuration.
+ * Subclasses contain provider-specific settings that are used to configure the TTS provider for the current session.
+ **/
 @Serializable
 sealed class TtsProviderConfig
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/JaicpReactions.kt
@@ -85,7 +85,9 @@ open class JaicpReactions : Reactions() {
                 bargeInData = telephony?.bargeIn,
                 bargeInInterrupt = telephony?.bargeInInterrupt,
                 sessionId = SessionManager.get(executionContext).getOrCreateSessionId().sessionId,
-                responseData = responseData
+                responseData = responseData,
+                ttsConfig = telephony?.ttsConfig,
+                asrConfig = telephony?.asrConfig
             )
         ).jsonObject
     }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -129,7 +129,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * to the corresponding fields in the TtsConfig class.
      * @param config TtsProviderConfig subclass containing the provider-specific configuration settings to use for TTS.
      * */
-    fun <T : TtsProviderConfig> setTtsConfig(config: T) {
+    fun setTtsConfig(config: TtsProviderConfig) {
         ttsConfig = TtsConfig(
             type = executionContext.request.telephony?.ttsConfig?.type,
             yandex = config as? TtsConfigYandex,
@@ -164,7 +164,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * to the corresponding fields in the AsrConfig class.
      * @param config AsrProviderConfig subclass containing the provider-specific configuration settings to use for ASR.
      * */
-    fun <T : AsrProviderConfig> setAsrConfig(config: T) {
+    fun setAsrConfig(config: AsrProviderConfig) {
         asrConfig = AsrConfig(
             type = executionContext.request.telephony?.asrConfig?.type,
             yandex = config as? AsrYandexConfig,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -120,7 +120,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * ```
      * state("tts") {
      *    action {
-     *        reactions.telephony?.setTtsConfig(TtsConfigAimyvoice("Никита"))
+     *        reactions.telephony?.setTtsConfig(TtsAimyvoiceConfig("Никита"))
      *    }
      * }
      * ```
@@ -132,13 +132,13 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
     fun setTtsConfig(config: TtsProviderConfig) {
         ttsConfig = TtsConfig(
             type = executionContext.request.telephony?.ttsConfig?.type,
-            yandex = config as? TtsConfigYandex,
-            google = config as? TtsConfigGoogle,
-            mts = config as? TtsConfigMts,
-            zitech = config as? TtsConfigZitech,
-            azure = config as? TtsConfigAzure,
-            aimyvoice = config as? TtsConfigAimyvoice,
-            sber = config as? TtsConfigSber
+            yandex = config as? TtsYandexConfig,
+            google = config as? TtsGoogleConfig,
+            mts = config as? TtsMtsConfig,
+            zitech = config as? TtsZitechConfig,
+            azure = config as? TtsAzureConfig,
+            aimyvoice = config as? TtsAimyvoiceConfig,
+            sber = config as? TtsSberConfig
         )
     }
 
@@ -170,7 +170,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
             yandex = config as? AsrYandexConfig,
             zitech = config as? AsrZitechConfig,
             google = config as? AsrGoogleConfig,
-            amiVoice = config as? AsrAmiVoiceConfig,
+            aimyvoice = config as? AsrAimyvoiceConfig,
             mts = config as? AsrMtsConfig,
             azure = config as? AsrAzureConfig,
             asm = config as? AsrAsmConfig,

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -114,17 +114,20 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
     }
 
     /**
-     * This method overrides the TTS provider settings of the phone channel used for the current call.
+     * This method overrides the TTS configuration of the phone channel used for the current call.
      *
-     * example usage:
+     * Example usage:
      * ```
      * state("tts") {
      *    action {
      *        reactions.telephony?.setTtsConfig(TtsConfigAimyvoice("Никита"))
-     *        )
      *    }
      * }
      * ```
+     * The configuration is determined by the TtsProviderConfig subclass passed in as a parameter.
+     * The appropriate provider-specific configuration settings are extracted and assigned
+     * to the corresponding fields in the TtsConfig class.
+     * @param config TtsProviderConfig subclass containing the provider-specific configuration settings to use for TTS.
      * */
     fun <T : TtsProviderConfig> setTtsConfig(config: T) {
         ttsConfig = TtsConfig(
@@ -140,8 +143,7 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
     }
 
     /**
-     * This method overrides the ASR provider settings of the phone channel used for the current call.
-     *
+     * This method overrides the ASR configuration of the phone channel used for the current call.
      * example usage:
      * ```
      * state("asr") {
@@ -152,11 +154,15 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      *                lang = "ru-RU",
      *                numbersAsWords = true,
      *                sensitivityReduction = true
-     *            )
-     *         )
+     *           )
+     *        )
      *    }
      * }
      * ```
+     * The configuration is determined by the AsrProviderConfig subclass passed in as a parameter.
+     * The appropriate provider-specific configuration settings are extracted and assigned
+     * to the corresponding fields in the AsrConfig class.
+     * @param config AsrProviderConfig subclass containing the provider-specific configuration settings to use for ASR.
      * */
     fun <T : AsrProviderConfig> setAsrConfig(config: T) {
         asrConfig = AsrConfig(

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -3,6 +3,7 @@ package com.justai.jaicf.channel.jaicp.reactions
 import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
 import com.justai.jaicf.channel.jaicp.dto.*
 import com.justai.jaicf.channel.jaicp.dto.bargein.*
+import com.justai.jaicf.channel.jaicp.dto.config.*
 import com.justai.jaicf.helpers.http.toUrl
 import com.justai.jaicf.logging.AudioReaction
 import com.justai.jaicf.logging.SayReaction
@@ -22,6 +23,10 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
     internal var bargeIn: BargeInProperties? = null
 
     internal var bargeInInterrupt: BargeInResponse? = null
+
+    internal var ttsConfig: TtsConfig? = null
+
+    internal var asrConfig: AsrConfig? = null
 
     companion object {
         private const val CURRENT_CONTEXT_PATH = "."
@@ -106,6 +111,65 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
      * */
     fun bargeIn(mode: BargeInMode, trigger: BargeInTrigger, noInterruptTimeMs: Int) {
         bargeIn = BargeInProperties(mode, trigger, noInterruptTimeMs)
+    }
+
+    /**
+     * This method overrides the TTS provider settings of the phone channel used for the current call.
+     *
+     * example usage:
+     * ```
+     * state("tts") {
+     *    action {
+     *        reactions.telephony?.setTtsConfig(TtsConfigAimyvoice("Никита"))
+     *        )
+     *    }
+     * }
+     * ```
+     * */
+    fun <T : TtsProviderConfig> setTtsConfig(config: T) {
+        ttsConfig = TtsConfig(
+            type = executionContext.request.telephony?.ttsConfig?.type,
+            yandex = config as? TtsConfigYandex,
+            google = config as? TtsConfigGoogle,
+            mts = config as? TtsConfigMts,
+            zitech = config as? TtsConfigZitech,
+            azure = config as? TtsConfigAzure,
+            aimyvoice = config as? TtsConfigAimyvoice,
+            sber = config as? TtsConfigSber
+        )
+    }
+
+    /**
+     * This method overrides the ASR provider settings of the phone channel used for the current call.
+     *
+     * example usage:
+     * ```
+     * state("asr") {
+     *    action {
+     *        reactions.telephony?.setAsrConfig(
+     *            AsrYandexConfig(
+     *                model = "general",
+     *                lang = "ru-RU",
+     *                numbersAsWords = true,
+     *                sensitivityReduction = true
+     *            )
+     *         )
+     *    }
+     * }
+     * ```
+     * */
+    fun <T : AsrProviderConfig> setAsrConfig(config: T) {
+        asrConfig = AsrConfig(
+            type = executionContext.request.telephony?.asrConfig?.type,
+            yandex = config as? AsrYandexConfig,
+            zitech = config as? AsrZitechConfig,
+            google = config as? AsrGoogleConfig,
+            amiVoice = config as? AsrAmiVoiceConfig,
+            mts = config as? AsrMtsConfig,
+            azure = config as? AsrAzureConfig,
+            asm = config as? AsrAsmConfig,
+            sber = config as? AsrSberConfig
+        )
     }
 
     /**

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/config/ProviderConfigTest.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/config/ProviderConfigTest.kt
@@ -1,0 +1,41 @@
+package com.justai.jaicf.channel.jaicp.config
+
+import com.justai.jaicf.channel.jaicp.JaicpBaseTest
+import com.justai.jaicf.channel.jaicp.JaicpTestChannel
+import com.justai.jaicf.channel.jaicp.ScenarioFactory.echoWithAction
+import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
+import com.justai.jaicf.channel.jaicp.dto.config.AsrYandexConfig
+import com.justai.jaicf.channel.jaicp.dto.config.TtsConfigAimyvoice
+import com.justai.jaicf.channel.jaicp.reactions.telephony
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class ProviderConfigTest : JaicpBaseTest() {
+
+    @Test
+    fun `001 config tts provider`() {
+        val scenario = echoWithAction {
+            reactions.telephony?.setTtsConfig(TtsConfigAimyvoice("Никита"))
+        }
+        val channel = JaicpTestChannel(scenario, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        assertEquals(responseFromResources, response.jaicp)
+    }
+
+    @Test
+    fun `002 config asr provider`() {
+        val scenario = echoWithAction {
+            reactions.telephony?.setAsrConfig(
+                AsrYandexConfig(
+                    model = "general:rc",
+                    lang = "pt-BR",
+                    numbersAsWords = true,
+                    sensitivityReduction = true
+                )
+            )
+        }
+        val channel = JaicpTestChannel(scenario, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        assertEquals(responseFromResources, response.jaicp)
+    }
+}

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/config/ProviderConfigTest.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/config/ProviderConfigTest.kt
@@ -5,7 +5,7 @@ import com.justai.jaicf.channel.jaicp.JaicpTestChannel
 import com.justai.jaicf.channel.jaicp.ScenarioFactory.echoWithAction
 import com.justai.jaicf.channel.jaicp.channels.TelephonyChannel
 import com.justai.jaicf.channel.jaicp.dto.config.AsrYandexConfig
-import com.justai.jaicf.channel.jaicp.dto.config.TtsConfigAimyvoice
+import com.justai.jaicf.channel.jaicp.dto.config.TtsAimyvoiceConfig
 import com.justai.jaicf.channel.jaicp.reactions.telephony
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -15,7 +15,7 @@ internal class ProviderConfigTest : JaicpBaseTest() {
     @Test
     fun `001 config tts provider`() {
         val scenario = echoWithAction {
-            reactions.telephony?.setTtsConfig(TtsConfigAimyvoice("Никита"))
+            reactions.telephony?.setTtsConfig(TtsAimyvoiceConfig("Никита"))
         }
         val channel = JaicpTestChannel(scenario, TelephonyChannel)
         val response = channel.process(requestFromResources)

--- a/channels/jaicp/src/test/resources/config/001/req.json
+++ b/channels/jaicp/src/test/resources/config/001/req.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "livechatStatus": {
+      "enabled": false
+    }
+  },
+  "version": 1,
+  "botId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test",
+    "asrTtsProviderData": {
+      "asr": {
+        "type": "yandex",
+        "internal": true,
+        "yandex": {
+          "model": "general",
+          "lang": "ru-RU",
+          "numbersAsWords": false,
+          "sensitivityReduction": false
+        }
+      },
+      "tts": {
+        "type": "aimyvoice",
+        "internal": true,
+        "aimyvoice": {
+          "voice": "Татьяна"
+        }
+      }
+    }
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/config/001/resp.json
+++ b/channels/jaicp/src/test/resources/config/001/resp.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "replies": [],
+    "answer": "",
+    "dialer": {},
+    "ttsConfig": {
+      "type": "aimyvoice",
+      "aimyvoice": {
+        "voice": "Никита"
+      }
+    }
+  },
+  "botId": "mva_jaicf_project-263-XQt",
+  "accountId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 0,
+  "currentState": "/fallback",
+  "processingTime": 0,
+  "requestData": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test",
+    "asrTtsProviderData": {
+      "asr": {
+        "type": "yandex",
+        "internal": true,
+        "yandex": {
+          "model": "general",
+          "lang": "ru-RU",
+          "numbersAsWords": false,
+          "sensitivityReduction": false
+        }
+      },
+      "tts": {
+        "type": "aimyvoice",
+        "internal": true,
+        "aimyvoice": {
+          "voice": "Татьяна"
+        }
+      }
+    }
+  }
+}

--- a/channels/jaicp/src/test/resources/config/002/req.json
+++ b/channels/jaicp/src/test/resources/config/002/req.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "livechatStatus": {
+      "enabled": false
+    }
+  },
+  "version": 1,
+  "botId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test",
+    "asrTtsProviderData": {
+      "asr": {
+        "type": "yandex",
+        "internal": true,
+        "yandex": {
+          "model": "general",
+          "lang": "ru-RU",
+          "numbersAsWords": false,
+          "sensitivityReduction": false
+        }
+      },
+      "tts": {
+        "type": "aimyvoice",
+        "internal": true,
+        "aimyvoice": {
+          "voice": "Татьяна"
+        }
+      }
+    }
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/config/002/resp.json
+++ b/channels/jaicp/src/test/resources/config/002/resp.json
@@ -1,0 +1,53 @@
+{
+  "data": {
+    "replies": [],
+    "answer": "",
+    "dialer": {},
+    "asrConfig": {
+      "type": "yandex",
+      "yandex": {
+        "model": "general:rc",
+        "lang": "pt-BR",
+        "numbersAsWords": true,
+        "sensitivityReduction": true
+      }
+    }
+  },
+  "botId": "mva_jaicf_project-263-XQt",
+  "accountId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 0,
+  "currentState": "/fallback",
+  "processingTime": 0,
+  "requestData": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test",
+    "asrTtsProviderData": {
+      "asr": {
+        "type": "yandex",
+        "internal": true,
+        "yandex": {
+          "model": "general",
+          "lang": "ru-RU",
+          "numbersAsWords": false,
+          "sensitivityReduction": false
+        }
+      },
+      "tts": {
+        "type": "aimyvoice",
+        "internal": true,
+        "aimyvoice": {
+          "voice": "Татьяна"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds functions for the voice provider settings in the scenario, allowing for dynamic switching between different settings current provider in session. 

Changes:

- `AsrConfig`  & `TtsConfig` data classes were created to define the ASR  TTS provider configuration.
- `asrConfig` & `ttsConfig`  properties return the configuration parameters of the ASR and TTS providers used in the current session. 
- `setTtsConfig()` &` setAsrConfig()` methods overrides the TTS ASR configuration.

P.S. Manual testing has been performed on Aimyvoice (for TTS) and Yandex (for ASR  TTS), but I expect that if we provide the configuration settings in accordance with the documentation, other providers should also work fine, provided that we support them.