### PR TITLE
support only-if activation predicates on AnyIntent/AnyEvent

### DIFF
--- a/core/src/main/kotlin/com/justai/jaicf/activator/event/EventActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/event/EventActivationRule.kt
@@ -1,10 +1,9 @@
 package com.justai.jaicf.activator.event
 
-import com.justai.jaicf.model.activation.ActivationRule
 import com.justai.jaicf.model.activation.ActivationRuleAdapter
 
 abstract class EventActivationRule(val matches: (EventActivatorContext) -> Boolean): ActivationRuleAdapter()
 
 open class EventByNameActivationRule(val event: String): EventActivationRule({ it.event == event})
 
-class AnyEventActivationRule(val except: List<String> = mutableListOf()): EventActivationRule({ it.event !in except })
+class AnyEventActivationRule(val except: MutableList<String> = mutableListOf()): EventActivationRule({ it.event !in except })

--- a/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/activator/intent/IntentActivationRule.kt
@@ -5,4 +5,5 @@ import com.justai.jaicf.model.activation.ActivationRuleAdapter
 abstract class IntentActivationRule(val matches: (IntentActivatorContext) -> Boolean): ActivationRuleAdapter()
 
 open class IntentByNameActivationRule(val intent: String): IntentActivationRule({ it.intent == intent })
-class AnyIntentActivationRule(val except: List<String> = mutableListOf()): IntentActivationRule({ it.intent !in except })
+
+class AnyIntentActivationRule(val except: MutableList<String> = mutableListOf()): IntentActivationRule({ it.intent !in except })

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/activators/OnlyIfPredicatesTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/activators/OnlyIfPredicatesTest.kt
@@ -11,6 +11,7 @@ import com.justai.jaicf.model.activation.onlyIfNotInSession
 import com.justai.jaicf.test.ScenarioTest
 import com.justai.jaicf.test.reactions.TestReactions
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNull
 
 private class BotRequestType1(clientId: String, input: String) : QueryBotRequest(clientId, input)
 private class BotRequestType2(clientId: String, input: String) : QueryBotRequest(clientId, input)
@@ -58,6 +59,18 @@ private val contextTestScenario = Scenario {
     state("context test 7") {
         activators {
             regex("context test").onlyIfInSession("age")
+        }
+    }
+
+    state("context test 8") {
+        activators {
+            anyIntent().onlyIfInClient("age")
+        }
+    }
+
+    state("context test 9") {
+        activators {
+            anyEvent().onlyIfInClient("age")
         }
     }
 }
@@ -137,5 +150,32 @@ class OnlyIfPredicatesTest : ScenarioTest(onlyIfScenario) {
 
         withCurrentContext("/type test")
         process(BotRequestType2(botContext.clientId, "type test")) goesToState "/type test/type test 2"
+    }
+
+    @Test
+    fun `onlyIf should activate by anyIntent`() {
+        withCurrentContext("/context test")
+        withBotContext { client["age"] = "something" }
+        intent("context test") goesToState "/context test/context test 8"
+    }
+
+    @Test
+    fun `onlyIf should prohibit activation by anyIntent on no client property`() {
+        withCurrentContext("/context test")
+        assertNull(intent("context test").reactions.executionContext.activationContext)
+    }
+
+    @Test
+    fun `onlyIf should activate by anyEvent`() {
+        withCurrentContext("/context test")
+        withBotContext { client["age"] = "something" }
+        event("context test") goesToState "/context test/context test 9"
+    }
+
+
+    @Test
+    fun `onlyIf should prohibit activation by anyEvent on no client property`() {
+        withCurrentContext("/context test")
+        assertNull(intent("context test").reactions.executionContext.activationContext)
     }
 }


### PR DESCRIPTION
Adds `anyIntent` or `anyEvent` activation predicates support for onlyIf activation rules.

**What was the problem:**
postProcessing for `anyIntent` and `anyEvent` didn't copy onlyIf predicates recreating ActivationRules with new matching method.
```
transitions.map {
    when (it.rule) {
        is AnyIntentActivationRule -> it.copy(rule = AnyIntentActivationRule(intents))
        is AnyEventActivationRule -> it.copy(rule = AnyEventActivationRule(events))
        else -> it
    }
}
```


**What's changed**
We start copying onlyIf predicates to new ActivationRules in `postProcess`
