### PR TITLE
add noInputTimeout reaction

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpDialerAPI.kt
@@ -13,6 +13,7 @@ class JaicpDialerAPI {
     private var callResultPayload: String? = null
     private var reportData: MutableMap<String, CallReportData> = mutableMapOf()
     private var redial: RedialData? = null
+    private var noInputTimeout: Int? = null
 
     /**
      * Reports data to be stored in .xsls report.
@@ -155,6 +156,10 @@ class JaicpDialerAPI {
     internal fun result(result: String?, resultPayload: String?) {
         callResult = result
         callResultPayload = resultPayload
+    }
+
+    internal fun noInputTimeout(duration: Int) {
+        noInputTimeout = duration
     }
 }
 

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -322,6 +322,8 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
 
     /**
      * Allows changing the default timeout (5 seconds) for the speechNotRecognized event in state.
+     * The timeout duration must be specified in milliseconds as an integer between 1000 (1 second) and 20000 (20 seconds).
+     * If you set a duration outside the range, the default timeout will be used.
      *
      * Example usage:
      * ```

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/reactions/TelephonyReactions.kt
@@ -321,6 +321,24 @@ class TelephonyReactions(private val bargeInDefaultProps: BargeInProperties) : J
     }
 
     /**
+     * Allows changing the default timeout (5 seconds) for the speechNotRecognized event in state.
+     *
+     * Example usage:
+     * ```
+     * state("BeforeSilence") {
+     *    activators {
+     *        regex(.*)
+     *    }
+     *    action {
+     *        reactions.noInputTimeout(15000)
+     *    }
+     * }
+     * ```
+     * @param duration the duration of the timeout in milliseconds.
+     * */
+    fun noInputTimeout(duration: Int) = dialer.noInputTimeout(duration)
+
+    /**
      * Allows to barge in speech synthesis or audio playback during handling bargeIn event.
      *
      * This reaction works only when manually handling bargeIn event.

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/dialer/JaicpDialerAPITests.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/dialer/JaicpDialerAPITests.kt
@@ -108,4 +108,16 @@ internal class JaicpDialerAPITests : JaicpBaseTest() {
         val response = channel.process(requestFromResources)
         assertEquals(responseFromResources, response.jaicp)
     }
+
+    @Test
+    fun `006 dialer should set no input timeout`() {
+        val scenario = echoWithAction {
+            reactions.telephony?.noInputTimeout(15000)
+            reactions.say("You said: ${request.input}")
+        }
+
+        val channel = JaicpTestChannel(scenario, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        assertEquals(responseFromResources, response.jaicp)
+    }
 }

--- a/channels/jaicp/src/test/resources/dialer/006/req.json
+++ b/channels/jaicp/src/test/resources/dialer/006/req.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "livechatStatus": {
+      "enabled": false
+    }
+  },
+  "version": 1,
+  "botId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/dialer/006/resp.json
+++ b/channels/jaicp/src/test/resources/dialer/006/resp.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "replies": [
+      {
+        "type": "text",
+        "text": "You said: /start",
+        "state": "/fallback"
+      }
+    ],
+    "answer": "You said: /start",
+    "dialer": {
+      "noInputTimeout": 15000
+    }
+  },
+  "botId": "mva_jaicf_project-263-XQt",
+  "accountId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "chatapi-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 0,
+  "currentState": "/fallback",
+  "processingTime": 0,
+  "requestData": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  }
+}


### PR DESCRIPTION
This PR adds a new method `noInputTimeout` in `class TelephonyReactions`, which allows changing the default timeout for the `SPEECH_NOT_RECOGNISED` event.