### PR TITLE
Add support REFER method to TelephonySwitchReply

### DIFF
--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/channels/TelephonyEvents.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/channels/TelephonyEvents.kt
@@ -10,6 +10,7 @@ package com.justai.jaicf.channel.jaicp.channels
  * NO_DTMF_ANSWER           - is sent when we expect client to dial specific code on keypad, but client dialed nothing.
  * BARGE_IN_EVENT           - is sent when client barged in.
  * ON_CALL_NOT_CONNECTED    - is sent when the bot doesn't reach the client. For example, the client did not pick up the phone or the number was busy.
+ * TRANSFER                 - is sent when the call was transferred to the agent
  *
  * @see com.justai.jaicf.channel.jaicp.JaicpEvents
  * */
@@ -21,4 +22,5 @@ object TelephonyEvents {
     const val NO_DTMF_ANSWER = "noDtmfAnswerEvent"
     const val BARGE_IN_EVENT = "bargeInIntent"
     const val ON_CALL_NOT_CONNECTED = "onCallNotConnected"
+    const val TRANSFER = "transfer"
 }

--- a/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
+++ b/channels/jaicp/src/main/kotlin/com/justai/jaicf/channel/jaicp/dto/JaicpReplies.kt
@@ -92,6 +92,7 @@ class HangupReply(val state: String? = null) : Reply("hangup") {
  * @param transferBotId - JAICP bot identifier to transfer call to. This bot must be a telephony bot created in JAICP Console.
  * @param continueCall - whether to return call back to bot after transfer. True to return call back.
  * @param continueRecording - whether to continue recording after transfer. True to continue recording after transfer.
+ * @param method - [TelephonySwitchMethod] - call routing method.
  *  */
 @Suppress("MemberVisibilityCanBePrivate")
 @Serializable
@@ -102,9 +103,30 @@ class TelephonySwitchReply(
     val transferBotId: String? = null,
     val continueCall: Boolean? = null,
     val continueRecording: Boolean? = null,
-    val state: String? = null
+    val state: String? = null,
+    val method: TelephonySwitchMethod = TelephonySwitchMethod.INVITE
 ) : Reply("switch") {
     override fun serialized() = JSON.encodeToString(serializer(), this)
+}
+
+/**
+ * TelephonySwitchMethod to specify call routing method.
+ * Not all providers support call routing via SIP REFER.
+ * When you route calls via SIP REFER, the headers, transferBotId, continueCall, and continueRecording properties will be ignored.
+ * @property INVITE call transfer with the connection preserved. This is the default value.
+ * @property REFER call transfer with the connection terminated
+ * */
+@Serializable
+enum class TelephonySwitchMethod {
+    @SerialName("refer")
+    REFER,
+
+    @SerialName("invite")
+    INVITE,
+
+    @Deprecated("Deprecated in JAICP Cloud releases", replaceWith = ReplaceWith("REFER"))
+    @SerialName("transfer")
+    TRANSFER
 }
 
 /**

--- a/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/channels/JaicpNativeChannelTests.kt
+++ b/channels/jaicp/src/test/kotlin/com/justai/jaicf/channel/jaicp/channels/JaicpNativeChannelTests.kt
@@ -3,10 +3,14 @@ package com.justai.jaicf.channel.jaicp.channels
 import com.justai.jaicf.BotEngine
 import com.justai.jaicf.channel.jaicp.JaicpBaseTest
 import com.justai.jaicf.channel.jaicp.JaicpTestChannel
+import com.justai.jaicf.channel.jaicp.ScenarioFactory
 import com.justai.jaicf.channel.jaicp.ScenarioFactory.echoWithAction
+import com.justai.jaicf.channel.jaicp.dto.TelephonySwitchMethod
+import com.justai.jaicf.channel.jaicp.dto.TelephonySwitchReply
 import com.justai.jaicf.channel.jaicp.dto.bargein.BargeInMode
 import com.justai.jaicf.channel.jaicp.dto.bargein.BargeInTrigger
 import com.justai.jaicf.channel.jaicp.reactions.telephony
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -51,6 +55,55 @@ internal class JaicpNativeChannelTests : JaicpBaseTest() {
         val channel = JaicpTestChannel(bot, TelephonyChannel)
         val response = channel.process(requestFromResources)
         assertEquals(responseFromResources, response.jaicp)
+    }
+
+    @Test
+    fun `005 webhooks should answer telephony with default transfer`() {
+        val bot = BotEngine(
+            ScenarioFactory.echoWithAction {
+                reactions.say("You said: ${request.input} from ${reactions::class.simpleName}")
+                reactions.telephony?.transferCall("79123456789")
+            }
+        )
+        val channel = JaicpTestChannel(bot, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        Assertions.assertEquals(responseFromResources, response.jaicp)
+    }
+
+    @Test
+    fun `006 webhooks should answer telephony with REFER transfer`() {
+        val bot = BotEngine(
+            ScenarioFactory.echoWithAction {
+                reactions.say("You said: ${request.input} from ${reactions::class.simpleName}")
+                reactions.telephony?.transferCall(
+                    TelephonySwitchReply(
+                        phoneNumber = "79123456789",
+                        method = TelephonySwitchMethod.REFER
+                    )
+                )
+            }
+        )
+        val channel = JaicpTestChannel(bot, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        Assertions.assertEquals(responseFromResources, response.jaicp)
+    }
+
+    @Test
+    fun `007 webhooks should answer telephony with INVITE transfer`() {
+        val bot = BotEngine(
+            ScenarioFactory.echoWithAction {
+                reactions.say("You said: ${request.input} from ${reactions::class.simpleName}")
+                reactions.telephony?.transferCall(
+                    TelephonySwitchReply(
+                        phoneNumber = "79123456789",
+                        method = TelephonySwitchMethod.INVITE
+                    )
+                )
+            }
+        )
+        val channel = JaicpTestChannel(bot, TelephonyChannel)
+        val response = channel.process(requestFromResources)
+        Assertions.assertEquals(responseFromResources, response.jaicp)
     }
 }
 

--- a/channels/jaicp/src/test/resources/webhooks/005/req.json
+++ b/channels/jaicp/src/test/resources/webhooks/005/req.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+
+  },
+  "version": 1,
+  "botId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "resterisk-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/webhooks/005/resp.json
+++ b/channels/jaicp/src/test/resources/webhooks/005/resp.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "replies": [
+      {
+        "type": "text",
+        "text": "You said: /start from TelephonyReactions",
+        "state": "/fallback"
+      },
+      {
+        "type": "switch",
+        "phoneNumber": "79123456789",
+        "state": "/fallback"
+      }
+    ],
+    "answer": "You said: /start from TelephonyReactions",
+    "dialer": {},
+    "sessionId": "resterisk-mva_jaicf_project-263-XQt-test-3b7a0f56-5605-427a-991b-8c4c51f0333e"
+  },
+  "botId": "mva_jaicf_project-263-XQt",
+  "accountId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "resterisk-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1681996038987,
+  "currentState": "/fallback",
+  "processingTime": 41,
+  "requestData": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/webhooks/006/req.json
+++ b/channels/jaicp/src/test/resources/webhooks/006/req.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+
+  },
+  "version": 1,
+  "botId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "resterisk-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/webhooks/006/resp.json
+++ b/channels/jaicp/src/test/resources/webhooks/006/resp.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "replies": [
+      {
+        "type": "text",
+        "text": "You said: /start from TelephonyReactions",
+        "state": "/fallback"
+      },
+      {
+        "type": "switch",
+        "phoneNumber": "79123456789",
+        "method": "refer"
+      }
+    ],
+    "answer": "You said: /start from TelephonyReactions",
+    "dialer": {},
+    "sessionId": "resterisk-mva_jaicf_project-263-XQt-test-a8d42981-4591-4afc-897d-6fd6a2c02fd2"
+  },
+  "botId": "mva_jaicf_project-263-XQt",
+  "accountId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "resterisk-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1681996232442,
+  "currentState": "/fallback",
+  "processingTime": 37,
+  "requestData": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/webhooks/007/req.json
+++ b/channels/jaicp/src/test/resources/webhooks/007/req.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+
+  },
+  "version": 1,
+  "botId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "resterisk-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1583767519.497000000,
+  "rawRequest": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  },
+  "userFrom": {
+    "id": "test",
+    "firstName": "test"
+  }
+}

--- a/channels/jaicp/src/test/resources/webhooks/007/resp.json
+++ b/channels/jaicp/src/test/resources/webhooks/007/resp.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "replies": [
+      {
+        "type": "text",
+        "text": "You said: /start from TelephonyReactions",
+        "state": "/fallback"
+      },
+      {
+        "type": "switch",
+        "phoneNumber": "79123456789"
+      }
+    ],
+    "answer": "You said: /start from TelephonyReactions",
+    "dialer": {},
+    "sessionId": "resterisk-mva_jaicf_project-263-XQt-test-7e4267df-9b94-4655-93b4-42163153cccc"
+  },
+  "botId": "mva_jaicf_project-263-XQt",
+  "accountId": "mva_jaicf_project-263-XQt",
+  "channelType": "resterisk",
+  "channelBotId": "mva_jaicf_project-263-XQt",
+  "channelUserId": "resterisk-mva_jaicf_project-263-XQt-test",
+  "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+  "query": "/start",
+  "timestamp": 1681996396596,
+  "currentState": "/fallback",
+  "processingTime": 36,
+  "requestData": {
+    "token": "GNVXJdeo:718e36f7005fbba3e2a9696784b83dc3bd0f3d9a",
+    "clientId": "test",
+    "questionId": "aaa99bea-aae1-41d2-aede-76e4f13b0ccc",
+    "query": "/start",
+    "timestamp": "2020-03-09T15:25:19.497",
+    "userId": "test"
+  }
+}


### PR DESCRIPTION
Docs - https://help.just-ai.com/docs/en/telephony/call_routing#refer-method
Add param - TelephonySwitchMethod, and event TRANSFER + docs
add tests, scenario for test:
```
val TelephonyBotScenario = Scenario(telephony) {
    state("ringing") {
        activators {
            event(TelephonyEvents.RINGING)
        }
        action {
            logger.debug("Incoming call from ${request.caller}")
        }
    }

    state("start") {
        activators {
            regex("/start")
            intent("hello")
        }
        action {
            reactions.say("Hello! Transferring call to operator")
            logger.debug("Transferring call from ${request.caller} to operator")
            reactions.transferCall(TelephonySwitchReply(phoneNumber = "+79123456789", method = TelephonySwitchMethod.REFER))
        }
    }

    state("transfer") {
        globalActivators {
            event(TelephonyEvents.TRANSFER)
        }
        action {
            logger.debug("Transfer status: ${request.transferStatus}")
        }
    }

    state("hangup") {
        activators {
            event(TelephonyEvents.HANGUP)
        }
        action {
            logger.info("Conversation ended with caller: ${request.caller}")
            reactions.run {endSession()}
        }
    }

    fallback {
        reactions.say("You said ${request.input}", bargeIn = true)
        logger.info("Unrecognized message from caller: ${request.caller}")
    }
}
```
