### PR TITLE
VS-5909: Bump retrofit and okhttp version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.3.7-SNAPSHOT"
+    version = "1.3.7"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.just-ai.jaicf"
-    version = "1.3.6"
+    version = "1.3.7-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -10,6 +10,7 @@ object Version {
     const val jUnit = "5.6.0"
     const val jetty = "9.4.3.v20170317"
 
+    const val okhttp3 = "4.9.3"
     const val ktor = "1.5.1"
     const val serializationRuntime = "1.0.1"
     const val coroutinesCore = "1.4.2"

--- a/channels/telegram/build.gradle.kts
+++ b/channels/telegram/build.gradle.kts
@@ -16,7 +16,12 @@ dependencies {
         exclude("org.jetbrains.kotlin", "kotlin-stdlib")
         exclude("com.squareup.okhttp3", "okhttp")
         exclude("com.squareup.okhttp3", "logging-interceptor")
+        exclude("com.squareup.retrofit2", "retrofit")
     }
-    api("com.squareup.okhttp3:okhttp:3.14.0")
-    api("com.squareup.okhttp3:logging-interceptor:3.14.0")
+    api("com.squareup.retrofit2:retrofit:2.5.0") {
+        exclude("com.squareup.okhttp3", "okhttp")
+        exclude("com.squareup.okhttp3", "logging-interceptor")
+    }
+    api("com.squareup.okhttp3:okhttp", Version.okhttp3)
+    api("com.squareup.okhttp3:logging-interceptor", Version.okhttp3)
 }

--- a/channels/telegram/build.gradle.kts
+++ b/channels/telegram/build.gradle.kts
@@ -22,6 +22,6 @@ dependencies {
         exclude("com.squareup.okhttp3", "okhttp")
         exclude("com.squareup.okhttp3", "logging-interceptor")
     }
-    api("com.squareup.okhttp3:okhttp", Version.okhttp3)
-    api("com.squareup.okhttp3:logging-interceptor", Version.okhttp3)
+    api("com.squareup.okhttp3:okhttp:${Version.okhttp3}")
+    api("com.squareup.okhttp3:logging-interceptor:${Version.okhttp3}")
 }


### PR DESCRIPTION
В данный момент через jaicf транзитивно из библиотеки kotling-telegram-bot (её компонента dispatcher) тянется несовместимая с трассировками из Micrometer Tracing версия okhttp3.

Пересобрал зависимости с бампом версий okhttp и retrofit.