### PR TITLE
Fix/custom OpenAI client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ build/
 managers/mapdb/.mapdb
 /docs/.sass-cache/
 /docs/_site/
+bin/
 .DS_Store

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMAction.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMAction.kt
@@ -10,6 +10,9 @@ import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.ActivatorContext
 import com.justai.jaicf.generic.ChannelTypeToken
 import com.justai.jaicf.reactions.Reactions
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.activator.llm.telemetry.AgentInvokeFinishHook
+import com.justai.jaicf.activator.llm.telemetry.AgentInvokeStartHook
 
 
 typealias LLMActionBlock = suspend LLMActionContext<out ActivatorContext, out BotRequest, out Reactions>.() -> Unit
@@ -26,9 +29,28 @@ private suspend fun <A: ActivatorContext, B: BotRequest, R: Reactions> ActionCon
     val context = LLMActionContext(context, activator, request, reactions, llm)
 
     try {
+        BotEngine.current()?.run {
+            hooks.triggerHook(
+                AgentInvokeStartHook(
+                    model.states[context.context.dialogContext.currentState]!!,
+                    context.context, context.request, context.reactions, context.activator,
+                    attributes = emptyMap()
+                )
+            )
+        }
         body.invoke(context)
     } catch (e: LLMToolInterruptionException) {
         e.callback.invoke(this)
+    } finally {
+        BotEngine.current()?.run {
+            hooks.triggerHook(
+                AgentInvokeFinishHook(
+                    model.states[context.context.dialogContext.currentState]!!,
+                    context.context, context.request, context.reactions, context.activator,
+                    attributes = emptyMap()
+                )
+            )
+        }
     }
 }
 

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt
@@ -16,7 +16,7 @@ import com.openai.models.chat.completions.ChatCompletionCreateParams
 private val DefaultOpenAIClient = try {
     OpenAIOkHttpClient.fromEnv()
 } catch (_: IllegalStateException) {
-    OpenAIOkHttpClient.builder().credential(BearerTokenCredential.create("")).build()
+    null
 }
 private val DefaultProps = LLMProps(
     client = DefaultOpenAIClient,
@@ -28,7 +28,7 @@ class LLMActionAPI(val defaultProps: LLMProps = DefaultProps) {
         params: ChatCompletionCreateParams,
         client: OpenAIClient? = null,
     ): StreamResponse<ChatCompletionChunk> {
-        val client = client ?: defaultProps.client ?: DefaultOpenAIClient
+        val client = client ?: defaultProps.client ?: DefaultOpenAIClient ?: throw IllegalStateException("OpenAIClient is required")
         return client.chat().completions().createStreaming(params)
     }
 

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt
@@ -15,8 +15,7 @@ import com.openai.models.chat.completions.ChatCompletionCreateParams
 
 private val DefaultOpenAIClient = try {
     OpenAIOkHttpClient.fromEnv()
-} catch (_: IllegalStateException
-) {
+} catch (_: IllegalStateException) {
     OpenAIOkHttpClient.builder().credential(BearerTokenCredential.create("")).build()
 }
 private val DefaultProps = LLMProps(

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt
@@ -8,11 +8,17 @@ import com.justai.jaicf.context.BotContext
 import com.openai.client.OpenAIClient
 import com.openai.client.okhttp.OpenAIOkHttpClient
 import com.openai.core.http.StreamResponse
+import com.openai.credential.BearerTokenCredential
 import com.openai.models.chat.completions.ChatCompletionChunk
 import com.openai.models.chat.completions.ChatCompletionCreateParams
 
 
-private val DefaultOpenAIClient = OpenAIOkHttpClient.fromEnv()
+private val DefaultOpenAIClient = try {
+    OpenAIOkHttpClient.fromEnv()
+} catch (_: IllegalStateException
+) {
+    OpenAIOkHttpClient.builder().credential(BearerTokenCredential.create("")).build()
+}
 private val DefaultProps = LLMProps(
     client = DefaultOpenAIClient,
     withUsages = true,

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import java.util.stream.Stream
-import kotlin.coroutines.coroutineContext
 import kotlin.jvm.optionals.getOrDefault
 import kotlin.jvm.optionals.getOrNull
 
@@ -116,7 +115,7 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
                 )
             )
         }
-        response = api.createStreaming(params)
+        response = api.createStreaming(params, props.client)
         stream = response.stream()
         throwIfCancelled()
     }

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt
@@ -5,8 +5,31 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.justai.jaicf.BotEngine
-import com.justai.jaicf.activator.llm.*
-import com.justai.jaicf.activator.llm.tool.*
+import com.justai.jaicf.activator.llm.LLMContext
+import com.justai.jaicf.activator.llm.LLMEvent
+import com.justai.jaicf.activator.llm.LLMMessage
+import com.justai.jaicf.activator.llm.LLMToolCallHook
+import com.justai.jaicf.activator.llm.LLMToolCallsHook
+import com.justai.jaicf.activator.llm.ifLLMMemory
+import com.justai.jaicf.activator.llm.telemetry.AfterLLMCallHook
+import com.justai.jaicf.activator.llm.telemetry.BeforeLLMCallHook
+import com.justai.jaicf.activator.llm.telemetry.LLMSpanName
+import com.justai.jaicf.telemetry.TelemetrySpan
+import com.justai.jaicf.telemetry.currentTelemetrySpanBlocking
+import com.justai.jaicf.telemetry.getTelemetrySpan
+import com.justai.jaicf.telemetry.removeTelemetrySpan
+import com.justai.jaicf.telemetry.setTelemetrySpan
+import com.justai.jaicf.activator.llm.telemetry.ToolCallErrorHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallFinishHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallStartHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallsFinishHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallsStartHook
+import com.justai.jaicf.activator.llm.tool.LLMTool
+import com.justai.jaicf.activator.llm.tool.LLMToolCall
+import com.justai.jaicf.activator.llm.tool.LLMToolCallContext
+import com.justai.jaicf.activator.llm.tool.LLMToolFunction
+import com.justai.jaicf.activator.llm.tool.LLMToolInterruptionException
+import com.justai.jaicf.activator.llm.tool.LLMToolResult
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.ActionContext
 import com.justai.jaicf.context.ActivatorContext
@@ -21,8 +44,17 @@ import com.openai.models.chat.completions.ChatCompletion
 import com.openai.models.chat.completions.ChatCompletionChunk
 import com.openai.models.chat.completions.ChatCompletionMessageToolCall
 import com.openai.models.completions.CompletionUsage
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import java.util.stream.Stream
 import kotlin.coroutines.coroutineContext
 import kotlin.jvm.optionals.getOrDefault
@@ -38,6 +70,10 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
     override val reactions: R,
     val llm: LLMContext,
 ) : ActionContext<A, B, R>(context, activator, request, reactions) {
+
+    private var startStreamTime: Long = 0L
+    private var firstChunkTime: Long? = null
+
     private lateinit var response: StreamResponse<ChatCompletionChunk>
     private lateinit var stream: Stream<ChatCompletionChunk>
     private lateinit var acc: ChatCompletionAccumulator
@@ -66,7 +102,20 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
 
     internal suspend fun LLMContext.startStream() = withActiveJob {
         completed = null
-        acc = ChatCompletionAccumulator.Companion.create()
+        acc = ChatCompletionAccumulator.create()
+        startStreamTime = System.nanoTime()
+        BotEngine.current()?.run {
+            hooks.triggerHook(
+                BeforeLLMCallHook(
+                    model.states[context.dialogContext.currentState]!!,
+                    context, request, reactions, activator,
+                    attributes = mapOf(
+                        "llm.model" to (props.model ?: ""),
+                        "llm.tools.declared" to (props.tools?.size ?: 0)
+                    )
+                )
+            )
+        }
         response = api.createStreaming(params)
         stream = response.stream()
         throwIfCancelled()
@@ -96,11 +145,40 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
             channelStream { channel ->
                 var finished = false
                 val chunks = mutableListOf<ChatCompletionChunk>()
+
+                val engine = BotEngine.current()
+                val streamingSpanName = LLMSpanName.Streaming
+                val parentSpan = engine?.let {
+                    context.getTelemetrySpan(LLMSpanName.LLMCall)
+                        ?: currentTelemetrySpanBlocking(context)
+                }
+                val streamingSpan = engine?.telemetryProvider?.let { provider ->
+                    val span = provider.createSpan(
+                        streamingSpanName,
+                        emptyMap(),
+                        parentSpan
+                    )
+                    if (span != TelemetrySpan.NoOp) {
+                        span.setAttribute("jaicf.client.id", context.clientId)
+                        span.setAttribute("jaicf.request.type", request.type.name)
+                        context.setTelemetrySpan(streamingSpanName, span)
+                    }
+                    span
+                } ?: TelemetrySpan.NoOp
+                
                 try {
                     val iterator = stream.iterator()
                     while (iterator.hasNext()) {
                         val chunk = iterator.next()
                         yield()
+                        if (firstChunkTime == null) {
+                            firstChunkTime = System.nanoTime()
+                            val fblMs = (firstChunkTime!! - startStreamTime) / 1_000_000.0
+                            // Record first byte latency in streaming span
+                            if (streamingSpan != TelemetrySpan.NoOp) {
+                                streamingSpan.setAttribute("llm.fbl.ms", fblMs)
+                            }
+                        }
 
                         chunks.add(chunk)
                         channel.send(chunk)
@@ -133,6 +211,31 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
                     }
                 } finally {
                     completed!!.complete(chunks)
+                    val usage = acc.chatCompletion().usage().getOrNull()
+                    val latencyMs = (System.nanoTime() - startStreamTime) / 1_000_000.0
+
+                    if (streamingSpan != TelemetrySpan.NoOp) {
+                        streamingSpan.setAttribute("llm.stream.duration.ms", latencyMs)
+                        if (firstChunkTime != null) {
+                            val fblMs = (firstChunkTime!! - startStreamTime) / 1_000_000.0
+                            streamingSpan.setAttribute("llm.fbl.ms", fblMs)
+                        }
+                        streamingSpan.close()
+                        context.removeTelemetrySpan(streamingSpanName)
+                    }
+                    
+                    BotEngine.current()?.run {
+                        hooks.triggerHook(
+                            AfterLLMCallHook(
+                                model.states[context.dialogContext.currentState]!!,
+                                context, request, reactions, activator,
+                                completionUsage = usage,
+                                attributes = buildMap {
+                                    put("llm.latency.ms", latencyMs)
+                                }
+                            )
+                        )
+                    }
                     closeStream()
                 }
             }
@@ -213,11 +316,78 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
     }
 
     suspend fun LLMContext.callTools(): List<Result<LLMToolResult>> {
-        return coroutineScope {
+        val planned = toolCalls().size
+        BotEngine.current()?.run {
+            hooks.triggerHook(
+                ToolCallsStartHook(
+                    model.states[context.dialogContext.currentState]!!,
+                    context, request, reactions, activator,
+                    attributes = mapOf(
+                        "llm.tools.planned" to planned
+                    )
+                )
+            )
+        }
+        val results = coroutineScope {
             toolCalls().map { call ->
-                async { runCatching { callTool(call) } }
+                async {
+                    val fname = call.function().name()
+                    BotEngine.current()?.run {
+                        hooks.triggerHook(
+                            ToolCallStartHook(
+                                model.states[context.dialogContext.currentState]!!,
+                                context, request, reactions, activator,
+                                attributes = mapOf(
+                                    "llm.tool.name" to fname
+                                )
+                            )
+                        )
+                    }
+                    val res = runCatching { callTool(call) }
+                    BotEngine.current()?.run {
+                        res.exceptionOrNull()?.let { ex ->
+                            hooks.triggerHook(
+                                ToolCallErrorHook(
+                                    model.states[context.dialogContext.currentState]!!,
+                                    context, request, reactions, activator,
+                                    attributes = mapOf(
+                                        "llm.tool.name" to fname,
+                                        "llm.tool.error" to ex
+                                    )
+                                )
+                            )
+                        } ?: run {
+                            val resultSize = res.getOrNull()?.result?.toString()?.length
+                            hooks.triggerHook(
+                                ToolCallFinishHook(
+                                    model.states[context.dialogContext.currentState]!!,
+                                    context, request, reactions, activator,
+                                    attributes = buildMap {
+                                        put("llm.tool.name", fname)
+                                        resultSize?.let { put("llm.tool.result.size", it) }
+                                    }
+                                )
+                            )
+                        }
+                    }
+                    res
+                }
             }.awaitAll()
         }
+        val errors = results.count { it.isFailure }
+        BotEngine.current()?.run {
+            hooks.triggerHook(
+                ToolCallsFinishHook(
+                    model.states[context.dialogContext.currentState]!!,
+                    context, request, reactions, activator,
+                    attributes = mapOf(
+                        "llm.tools.total" to results.size,
+                        "llm.tools.errors" to errors
+                    )
+                )
+            )
+        }
+        return results
     }
 
     @Throws(LLMToolInterruptionException::class)
@@ -231,16 +401,19 @@ data class LLMActionContext<A: ActivatorContext, B: BotRequest, R: Reactions>(
             name = function.name(),
             arguments = args,
             result = tool?.let { tool ->
+                val toolContext = LLMToolCallContext(
+                    context,
+                    request,
+                    this,
+                    LLMToolCall(function.name(), call.id(), args!!, call)
+                )
                 try {
                     @Suppress("UNCHECKED_CAST")
-                    (tool.function as LLMToolFunction<Any>).invoke(
-                        LLMToolCallContext(
-                            context,
-                            request,
-                            this,
-                            LLMToolCall(function.name(), call.id(), args!!, call)
-                        )
-                    )
+                    val toolInstance = tool as LLMTool<Any>
+                    toolInstance.withToolTelemetrySpan(toolContext) {
+                        @Suppress("UNCHECKED_CAST")
+                        (toolInstance.function as LLMToolFunction<Any>).invoke(toolContext)
+                    }
                 } catch (e: Exception) {
                     if (e is LLMToolInterruptionException) throw e
                     if (e is CancellationException) throw e
@@ -346,7 +519,7 @@ private suspend inline fun <T> channelStream(
     crossinline block: suspend (Channel<T>) -> Unit
 ): Stream<T> {
     val channel = Channel<T>(Channel.UNLIMITED)
-    val job = CoroutineScope(coroutineContext).launch {
+    val job = CoroutineScope(currentCoroutineContext()).launch {
         try {
             block(channel)
         } finally {

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMHandoff.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMHandoff.kt
@@ -4,17 +4,18 @@ import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.justai.jaicf.BotEngine
 import com.justai.jaicf.activator.llm.LLMProps
+import com.justai.jaicf.activator.llm.telemetry.HandoffStartHook
 import com.justai.jaicf.activator.llm.tool.interrupt
 import com.justai.jaicf.activator.llm.tool.llmTool
 import com.justai.jaicf.activator.llm.withSystemMessage
 import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.StrictActivatorContext
 import com.justai.jaicf.helpers.context.tempProperty
 import com.justai.jaicf.helpers.kotlin.ifTrue
 import com.justai.jaicf.logging.GoReaction
 import com.justai.jaicf.plugin.PathValue
 import com.justai.jaicf.reactions.Reactions
 import com.openai.models.chat.completions.ChatCompletionMessageParam
-import kotlin.coroutines.coroutineContext
 
 
 private val HANDOFF_PROMPT_PREFIX = """
@@ -34,6 +35,9 @@ internal var BotContext.handoffMessages
 
 internal var BotContext.handoffChain
     by tempProperty { mapOf<String, String>() }
+
+internal var BotContext.handoffInfo
+    by tempProperty<Map<String, Any?>?> { null }
 
 private val LLMAgent.handoffSystemMessage
     get() = HANDOFF_PROMPT_PREFIX +
@@ -63,9 +67,7 @@ private val LLMAgent.handoffTool
         interrupt {
             val state = agentStateName(agentName)
             val model = BotEngine.current()?.model
-            if (model == null) {
-                throw IllegalStateException("Scenario model is not available in current context")
-            }
+                ?: throw IllegalStateException("Scenario model is not available in current context")
             model.states.keys.find { it.endsWith(state) }?.also { path ->
                 context.handoffChain = context.handoffChain + (name to snapshot)
                 reactions.handoff(path, messages)
@@ -85,5 +87,7 @@ fun Reactions.handoff(
     messages: List<ChatCompletionMessageParam>,
 ): GoReaction {
     botContext.handoffMessages = messages
+    // Note: HandoffFinishHook would need suspend context (BotEngine.current()), so we emit only HandoffStartHook
+    // Handoff completion is tracked by the next AgentInvokeStartHook on the target agent
     return go(path)
 }

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMHandoff.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMHandoff.kt
@@ -64,12 +64,45 @@ private val LLMAgent.handoffTool
             throw IllegalArgumentException("You try to hand off the same conversation back in cycle")
         }
 
+        val engine = BotEngine.current()
+        val currentState = engine?.model?.states?.get(context.dialogContext.currentState)
+
         interrupt {
             val state = agentStateName(agentName)
-            val model = BotEngine.current()?.model
+            val model = engine?.model
                 ?: throw IllegalStateException("Scenario model is not available in current context")
             model.states.keys.find { it.endsWith(state) }?.also { path ->
                 context.handoffChain = context.handoffChain + (name to snapshot)
+
+                // Телеметрия handoff: фиксируем факт передачи и сохраняем info для следующего action
+                if (engine != null && currentState != null) {
+                    try {
+                        engine.hooks.triggerHook(
+                            HandoffStartHook(
+                                currentState,
+                                context,
+                                request,
+                                reactions = Reactions().apply { botContext = context },
+                                activator = object : StrictActivatorContext() {},
+                                attributes = mapOf(
+                                    "llm.handoff.from.agent" to name,
+                                    "llm.handoff.to.agent" to agentName,
+                                    "llm.handoff.messages.count" to messages.size,
+                                ),
+                            ),
+                        )
+                    } catch (_: Exception) {
+                        // ignore telemetry errors
+                    }
+                }
+
+                // Эта информация будет использована в BeforeActionHook следующего состояния
+                context.handoffInfo = mapOf(
+                    "llm.handoff.from.agent" to name,
+                    "llm.handoff.to.agent" to agentName,
+                    "llm.handoff.messages.count" to messages.size,
+                )
+
                 reactions.handoff(path, messages)
             } ?: throw IllegalArgumentException("Agent not found [$agentName]")
         }

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMActionHooks.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMActionHooks.kt
@@ -1,0 +1,128 @@
+package com.justai.jaicf.activator.llm.telemetry
+
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.context.ActivatorContext
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.hook.BotActionHook
+import com.justai.jaicf.hook.BotHook
+import com.justai.jaicf.model.state.State
+import com.justai.jaicf.reactions.Reactions
+import com.openai.models.completions.CompletionUsage
+
+data class BeforeLLMCallHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class StreamingFirstByteHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class AfterLLMCallHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val completionUsage: CompletionUsage? = null,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class AgentInvokeStartHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class AgentInvokeFinishHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class ToolCallsStartHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class ToolCallsFinishHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class ToolCallStartHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class ToolCallFinishHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class ToolCallErrorHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class HandoffStartHook(
+    override val state: State,
+    override val context: BotContext,
+    override val request: BotRequest,
+    override val reactions: Reactions,
+    override val activator: ActivatorContext,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotActionHook
+
+data class ToolExecuteStartHook(
+    override val context: BotContext,
+    val request: BotRequest,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotHook
+
+data class ToolExecuteFinishHook(
+    override val context: BotContext,
+    val request: BotRequest,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotHook
+
+data class ToolExecuteErrorHook(
+    override val context: BotContext,
+    val request: BotRequest,
+    val attributes: Map<String, Any?> = emptyMap(),
+) : BotHook

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMSpan.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMSpan.kt
@@ -1,0 +1,57 @@
+package com.justai.jaicf.activator.llm.telemetry
+
+/**
+ * Domain span kinds used by LLM activator. The underlying provider maps these to its own kinds.
+ */
+enum class LLMSpanKind {
+    INTERNAL,
+    CLIENT,
+    SERVER,
+}
+
+/**
+ * Common span names used across LLM activator telemetry.
+ */
+object LLMSpanName {
+    const val AgentInvoke = "LLM AgentInvoke"
+    const val LLMCall = "LLM Call"
+    const val LLMFirstChunk = "LLM First Chunk"
+    const val ToolCalls = "ToolCalls"
+    const val ToolCall = "ToolCall"
+    const val Handoff = "Handoff"
+    const val Agent = "Agent"
+    const val Streaming = "Streaming"
+    const val VectorStore = "VectorStore"
+}
+
+/**
+ * A handle to the started span which allows adding attributes/events and finishing.
+ */
+interface LLMSpanHandle {
+    val id: String
+    val context: Any?
+
+    fun setAttribute(key: String, value: String)
+    fun setAttribute(key: String, value: Boolean)
+    fun setAttribute(key: String, value: Number)
+    fun setAttributes(attrs: Map<String, Any?>)
+
+    fun addEvent(name: String, attributes: Map<String, Any?> = emptyMap())
+
+    /**
+     * Ends the span. Optional status may be provider-specific (e.g., OK/ERROR) expressed via attributes.
+     */
+    fun end(status: LLMSpanStatus? = null)
+}
+
+/**
+ * Generic status for a span end. Provider may map this to its own status codes.
+ */
+data class LLMSpanStatus(
+    val code: Code,
+    val description: String? = null,
+) {
+    enum class Code { OK, ERROR, UNSET }
+}
+
+

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMTelemetry.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMTelemetry.kt
@@ -1,0 +1,42 @@
+package com.justai.jaicf.activator.llm.telemetry
+
+/**
+ * Provider-agnostic telemetry API for LLM activator.
+ * Concrete implementation may bridge to core TelemetryProvider or OpenTelemetry.
+ */
+interface LLMTelemetryProvider {
+    fun startSpan(
+        name: String,
+        kind: LLMSpanKind = LLMSpanKind.INTERNAL,
+        parentContext: Any? = null,
+        attributes: Map<String, Any?> = emptyMap(),
+    ): LLMSpanHandle
+}
+
+/**
+ * Singleton access to current provider used by LLM activator.
+ */
+object LLMTelemetry {
+    @Volatile
+    var provider: LLMTelemetryProvider = NoOpProvider
+
+    object NoOpProvider : LLMTelemetryProvider {
+        override fun startSpan(
+            name: String,
+            kind: LLMSpanKind,
+            parentContext: Any?,
+            attributes: Map<String, Any?>,
+        ): LLMSpanHandle = NoOpSpanHandle
+    }
+
+    private object NoOpSpanHandle : LLMSpanHandle {
+        override val id: String = "noop"
+        override val context: Any? = null
+        override fun setAttribute(key: String, value: String) {}
+        override fun setAttribute(key: String, value: Boolean) {}
+        override fun setAttribute(key: String, value: Number) {}
+        override fun setAttributes(attrs: Map<String, Any?>) {}
+        override fun addEvent(name: String, attributes: Map<String, Any?>) {}
+        override fun end(status: LLMSpanStatus?) {}
+    }
+}

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMTelemetryHookBinder.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMTelemetryHookBinder.kt
@@ -123,8 +123,8 @@ private object LLMTelemetryHookProcessor {
     }
 
     fun handleAgentInvokeStart(telemetryProvider: TelemetryProvider, hook: AgentInvokeStartHook) {
-        // Получаем текущий span из BotContext (это будет jaicf.process.start или jaicf.action.start)
-        val parent = currentTelemetrySpanBlocking(hook.context)
+        // Если есть активный Handoff span, делаем его родителем, иначе используем текущий JAICF span
+        val parent = getSpan(hook.context, LLMSpanName.Handoff) ?: currentTelemetrySpanBlocking(hook.context)
         val attributes = hook.attributes.toMutableMap().apply {
             put("llm.agent.state", hook.state.path.toString())
             put("llm.agent.input.length", hook.request.input.length)
@@ -148,6 +148,13 @@ private object LLMTelemetryHookProcessor {
             close()
             removeSpan(hook.context, LLMSpanName.AgentInvoke)
         }
+
+        // Если Handoff span был активен для этого AgentInvoke, закрываем его после завершения агента
+        getSpan(hook.context, LLMSpanName.Handoff)?.apply {
+            close()
+            removeSpan(hook.context, LLMSpanName.Handoff)
+        }
+
         // Восстанавливаем родительский span (jaicf.process.start или jaicf.action.start) как текущий
         val parentSpan = hook.context.getTelemetrySpan("jaicf.action.start") 
             ?: hook.context.getTelemetrySpan("jaicf.process.start")
@@ -246,11 +253,11 @@ private object LLMTelemetryHookProcessor {
     }
 
     fun handleHandoffStart(telemetryProvider: TelemetryProvider, hook: HandoffStartHook) {
-        val parentSpan = getSpan(hook.context, LLMSpanName.AgentInvoke) ?: currentTelemetrySpanBlocking(hook.context)
+        val parentSpan = currentTelemetrySpanBlocking(hook.context)
         val span = createSpanWithParent(telemetryProvider, LLMSpanName.Handoff, hook.attributes, parentSpan)
         if (span != TelemetrySpan.NoOp) {
             addCommonAttributes(span, hook)
-            span.close()
+            setSpan(hook.context, LLMSpanName.Handoff, span)
         }
     }
 

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMTelemetryHookBinder.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/telemetry/LLMTelemetryHookBinder.kt
@@ -1,0 +1,327 @@
+package com.justai.jaicf.activator.llm.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.activator.llm.agent.handoffInfo
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.hook.AnyErrorHook
+import com.justai.jaicf.hook.BeforeActionHook
+import com.justai.jaicf.hook.BotActionHook
+import com.justai.jaicf.hook.BotRequestHook
+import com.justai.jaicf.telemetry.TelemetryProvider
+import com.justai.jaicf.telemetry.TelemetrySpan
+import com.justai.jaicf.telemetry.closeAllTelemetrySpans
+import com.justai.jaicf.telemetry.currentTelemetrySpanBlocking
+import com.justai.jaicf.telemetry.getTelemetrySpan
+import com.justai.jaicf.telemetry.removeTelemetrySpan
+import com.justai.jaicf.telemetry.setCurrentTelemetrySpan
+import com.justai.jaicf.telemetry.setTelemetrySpan
+
+fun BotEngine.installLLMActivatorTelemetryHooks() {
+    hooks.addHookAction<BotRequestHook> {
+        LLMTelemetryHookProcessor.handleBotRequest(this)
+    }
+
+    hooks.addHookAction<AnyErrorHook> {
+        LLMTelemetryHookProcessor.handleAnyError(this)
+    }
+
+    hooks.addHookAction<AgentInvokeStartHook> {
+        LLMTelemetryHookProcessor.handleAgentInvokeStart(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<AgentInvokeFinishHook> {
+        LLMTelemetryHookProcessor.handleAgentInvokeFinish(this)
+    }
+
+    hooks.addHookAction<BeforeLLMCallHook> {
+        LLMTelemetryHookProcessor.handleBeforeLLMCall(telemetryProvider, this)
+    }
+
+
+    hooks.addHookAction<AfterLLMCallHook> {
+        LLMTelemetryHookProcessor.handleAfterLLMCall(this)
+    }
+
+    hooks.addHookAction<ToolCallsStartHook> {
+        LLMTelemetryHookProcessor.handleToolCallsStart(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<ToolCallsFinishHook> {
+        LLMTelemetryHookProcessor.handleToolCallsFinish(this)
+    }
+
+    hooks.addHookAction<ToolCallStartHook> {
+        LLMTelemetryHookProcessor.handleToolCallStart(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<ToolCallFinishHook> {
+        LLMTelemetryHookProcessor.handleToolCallFinish(this)
+    }
+
+    hooks.addHookAction<ToolCallErrorHook> {
+        LLMTelemetryHookProcessor.handleToolCallError(this)
+    }
+
+    hooks.addHookAction<BeforeActionHook> {
+        LLMTelemetryHookProcessor.handleBeforeAction(this)
+    }
+
+    hooks.addHookAction<HandoffStartHook> {
+        LLMTelemetryHookProcessor.handleHandoffStart(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<ToolExecuteStartHook> {
+        LLMTelemetryHookProcessor.handleToolExecuteStart(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<ToolExecuteFinishHook> {
+        LLMTelemetryHookProcessor.handleToolExecuteFinish(this)
+    }
+
+    hooks.addHookAction<ToolExecuteErrorHook> {
+        LLMTelemetryHookProcessor.handleToolExecuteError(this)
+    }
+}
+
+private object LLMTelemetryHookProcessor {
+
+    private fun getSpan(context: BotContext, spanName: String): TelemetrySpan? {
+        return context.getTelemetrySpan(spanName)
+    }
+
+    private fun setSpan(context: BotContext, spanName: String, span: TelemetrySpan) {
+        context.setTelemetrySpan(spanName, span)
+    }
+
+    private fun removeSpan(context: BotContext, spanName: String) {
+        context.removeTelemetrySpan(spanName)
+    }
+
+    private fun addCommonAttributes(span: TelemetrySpan, hook: BotActionHook) {
+        span.setAttribute("jaicf.state.name", hook.state.path.toString())
+        span.setAttribute("jaicf.state.current", hook.context.dialogContext.currentState)
+        span.setAttribute("jaicf.client.id", hook.context.clientId)
+        span.setAttribute("jaicf.request.type", hook.request.type.name)
+        span.setAttribute("jaicf.activator.name", hook.activator.toString())
+    }
+
+    private fun closeAllSpans(context: BotContext) {
+        context.closeAllTelemetrySpans()
+    }
+
+    private fun createSpanWithParent(
+        telemetryProvider: TelemetryProvider,
+        name: String,
+        attributes: Map<String, Any?>,
+        parentSpan: TelemetrySpan?
+    ): TelemetrySpan {
+        return try {
+            telemetryProvider.createSpan(name, attributes, parentSpan)
+        } catch (e: Throwable) {
+            TelemetrySpan.NoOp
+        }
+    }
+
+    fun handleAgentInvokeStart(telemetryProvider: TelemetryProvider, hook: AgentInvokeStartHook) {
+        // Получаем текущий span из BotContext (это будет jaicf.process.start или jaicf.action.start)
+        val parent = currentTelemetrySpanBlocking(hook.context)
+        val attributes = hook.attributes.toMutableMap().apply {
+            put("llm.agent.state", hook.state.path.toString())
+            put("llm.agent.input.length", hook.request.input.length)
+        }
+        val span = try {
+            telemetryProvider.createSpan(LLMSpanName.AgentInvoke, attributes, parent)
+        } catch (e: Throwable) {
+            TelemetrySpan.NoOp
+        }
+        if (span != TelemetrySpan.NoOp) {
+            addCommonAttributes(span, hook)
+            setSpan(hook.context, LLMSpanName.AgentInvoke, span)
+            // Устанавливаем как текущий span для дочерних спанов (LLM Call, ToolCalls)
+            hook.context.setCurrentTelemetrySpan(span)
+        }
+    }
+
+    fun handleAgentInvokeFinish(hook: AgentInvokeFinishHook) {
+        getSpan(hook.context, LLMSpanName.AgentInvoke)?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+            close()
+            removeSpan(hook.context, LLMSpanName.AgentInvoke)
+        }
+        // Восстанавливаем родительский span (jaicf.process.start или jaicf.action.start) как текущий
+        val parentSpan = hook.context.getTelemetrySpan("jaicf.action.start") 
+            ?: hook.context.getTelemetrySpan("jaicf.process.start")
+        hook.context.setCurrentTelemetrySpan(parentSpan)
+    }
+
+    fun handleBeforeLLMCall(telemetryProvider: TelemetryProvider, hook: BeforeLLMCallHook) {
+        // Получаем Agent span как parent
+        val parentSpan = getSpan(hook.context, LLMSpanName.AgentInvoke) ?: currentTelemetrySpanBlocking(hook.context)
+        val span = createSpanWithParent(telemetryProvider, LLMSpanName.LLMCall, hook.attributes, parentSpan)
+        if (span != TelemetrySpan.NoOp) {
+            addCommonAttributes(span, hook)
+            setSpan(hook.context, LLMSpanName.LLMCall, span)
+            // Устанавливаем как текущий span для дочерних спанов (Streaming, ToolCalls)
+            hook.context.setCurrentTelemetrySpan(span)
+        }
+    }
+
+
+    fun handleAfterLLMCall(hook: AfterLLMCallHook) {
+        getSpan(hook.context, LLMSpanName.LLMCall)?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+
+            hook.completionUsage?.let { usage ->
+                setAttribute("llm.tokens.prompt", usage.promptTokens())
+                setAttribute("llm.tokens.completion", usage.completionTokens())
+                setAttribute("llm.tokens.total", usage.totalTokens())
+            }
+
+            close()
+            removeSpan(hook.context, LLMSpanName.LLMCall)
+        }
+        // Восстанавливаем Agent span как текущий
+        val parentSpan = getSpan(hook.context, LLMSpanName.AgentInvoke)
+        hook.context.setCurrentTelemetrySpan(parentSpan)
+    }
+
+    fun handleToolCallsStart(telemetryProvider: TelemetryProvider, hook: ToolCallsStartHook) {
+        // Получаем LLM Call span как parent
+        val parentSpan = getSpan(hook.context, LLMSpanName.LLMCall) ?: currentTelemetrySpanBlocking(hook.context)
+        val span = createSpanWithParent(telemetryProvider, LLMSpanName.ToolCalls, hook.attributes, parentSpan)
+        if (span != TelemetrySpan.NoOp) {
+            addCommonAttributes(span, hook)
+            setSpan(hook.context, LLMSpanName.ToolCalls, span)
+            // Устанавливаем как текущий span для дочерних ToolCall спанов
+            hook.context.setCurrentTelemetrySpan(span)
+        }
+    }
+
+    fun handleToolCallsFinish(hook: ToolCallsFinishHook) {
+        getSpan(hook.context, LLMSpanName.ToolCalls)?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+            close()
+            removeSpan(hook.context, LLMSpanName.ToolCalls)
+        }
+        // Восстанавливаем LLM Call span как текущий
+        val parentSpan = getSpan(hook.context, LLMSpanName.LLMCall)
+        hook.context.setCurrentTelemetrySpan(parentSpan)
+    }
+
+    fun handleToolCallStart(telemetryProvider: TelemetryProvider, hook: ToolCallStartHook) {
+        val toolName = hook.attributes["llm.tool.name"] as? String ?: "unknown"
+        val parentSpan = getSpan(hook.context, LLMSpanName.ToolCalls) ?: currentTelemetrySpanBlocking(hook.context)
+        val span = createSpanWithParent(telemetryProvider, LLMSpanName.ToolCall, hook.attributes, parentSpan)
+        if (span != TelemetrySpan.NoOp) {
+            addCommonAttributes(span, hook)
+            setSpan(hook.context, "${LLMSpanName.ToolCall}:$toolName", span)
+        }
+    }
+
+    fun handleToolCallFinish(hook: ToolCallFinishHook) {
+        val toolName = hook.attributes["llm.tool.name"] as? String ?: "unknown"
+        getSpan(hook.context, "${LLMSpanName.ToolCall}:$toolName")?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+            close()
+            removeSpan(hook.context, "${LLMSpanName.ToolCall}:$toolName")
+        }
+    }
+
+    fun handleToolCallError(hook: ToolCallErrorHook) {
+        val toolName = hook.attributes["llm.tool.name"] as? String ?: "unknown"
+        getSpan(hook.context, "${LLMSpanName.ToolCall}:$toolName")?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+            hook.attributes["llm.tool.error"]?.let { error ->
+                val errorType = error::class.simpleName ?: "Unknown"
+                setAttribute("llm.tool.error.type", errorType)
+                if (error is Throwable) {
+                    error.message?.take(200)?.let { msg ->
+                        setAttribute("llm.tool.error.message", msg)
+                    }
+                }
+            }
+            close()
+            removeSpan(hook.context, "${LLMSpanName.ToolCall}:$toolName")
+        }
+    }
+
+    fun handleHandoffStart(telemetryProvider: TelemetryProvider, hook: HandoffStartHook) {
+        val parentSpan = getSpan(hook.context, LLMSpanName.AgentInvoke) ?: currentTelemetrySpanBlocking(hook.context)
+        val span = createSpanWithParent(telemetryProvider, LLMSpanName.Handoff, hook.attributes, parentSpan)
+        if (span != TelemetrySpan.NoOp) {
+            addCommonAttributes(span, hook)
+            span.close()
+        }
+    }
+
+    fun handleBeforeAction(hook: BeforeActionHook) {
+        val handoffInfo = hook.context.handoffInfo
+        if (handoffInfo != null) {
+            currentTelemetrySpanBlocking(hook.context)?.apply {
+                handoffInfo.forEach { (k, v) -> setAttribute(k, v) }
+            }
+            hook.context.handoffInfo = null
+        }
+    }
+
+    fun handleToolExecuteStart(telemetryProvider: TelemetryProvider, hook: ToolExecuteStartHook) {
+        val toolName = hook.attributes["llm.tool.name"] as? String ?: "unknown"
+        val callId = hook.attributes["llm.tool.call_id"] as? String ?: ""
+        val spanName = "llm.tool.execute:$toolName:$callId"
+
+        val parentSpan = currentTelemetrySpanBlocking(hook.context)
+        val span = createSpanWithParent(telemetryProvider, "llm.tool.execute.$toolName", hook.attributes, parentSpan)
+        if (span != TelemetrySpan.NoOp) {
+            span.setAttribute("jaicf.client.id", hook.context.clientId)
+            span.setAttribute("jaicf.request.type", hook.request.type.name)
+            hook.attributes.forEach { (k, v) -> span.setAttribute(k, v) }
+            setSpan(hook.context, spanName, span)
+        }
+    }
+
+    fun handleToolExecuteFinish(hook: ToolExecuteFinishHook) {
+        val toolName = hook.attributes["llm.tool.name"] as? String ?: "unknown"
+        val callId = hook.attributes["llm.tool.call_id"] as? String ?: ""
+        val spanName = "llm.tool.execute:$toolName:$callId"
+        getSpan(hook.context, spanName)?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+            close()
+            removeSpan(hook.context, spanName)
+        }
+    }
+
+    fun handleToolExecuteError(hook: ToolExecuteErrorHook) {
+        val toolName = hook.attributes["llm.tool.name"] as? String ?: "unknown"
+        val callId = hook.attributes["llm.tool.call_id"] as? String ?: ""
+        val spanName = "llm.tool.execute:$toolName:$callId"
+        getSpan(hook.context, spanName)?.apply {
+            hook.attributes.forEach { (k, v) -> setAttribute(k, v) }
+            hook.attributes["llm.tool.error"]?.let { error ->
+                val errorType = error::class.simpleName ?: "Unknown"
+                setAttribute("llm.tool.error.type", errorType)
+                if (error is Throwable) {
+                    recordException(error)
+                    error.message?.take(200)?.let { msg ->
+                        setAttribute("llm.tool.error.message", msg)
+                    }
+                }
+            }
+            close()
+            removeSpan(hook.context, spanName)
+        }
+    }
+
+    fun handleBotRequest(hook: BotRequestHook) {
+        //closeAllSpans(hook.context)
+    }
+
+    fun handleAnyError(hook: AnyErrorHook) {
+        currentTelemetrySpanBlocking(hook.context)?.apply {
+            setAttribute("jaicf.error.type", hook.exception::class.simpleName ?: "Unknown")
+            hook.exception.message?.take(500)?.let { msg ->
+                setAttribute("jaicf.error.message", msg)
+            }
+        }
+        closeAllSpans(hook.context)
+    }
+}

--- a/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/tool/LLMTool.kt
+++ b/activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/tool/LLMTool.kt
@@ -5,8 +5,12 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
+import com.justai.jaicf.BotEngine
 import com.justai.jaicf.activator.llm.LLMContext
 import com.justai.jaicf.activator.llm.builder.JsonSchemaBuilder
+import com.justai.jaicf.activator.llm.telemetry.ToolExecuteErrorHook
+import com.justai.jaicf.activator.llm.telemetry.ToolExecuteFinishHook
+import com.justai.jaicf.activator.llm.telemetry.ToolExecuteStartHook
 import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.context.BotContext
 import com.openai.models.chat.completions.ChatCompletionMessageToolCall
@@ -55,6 +59,66 @@ open class LLMTool<T>(
 
     val withoutConfirmation by lazy {
         withConfirmation { true }
+    }
+
+    /**
+     * Wraps tool function execution in a telemetry span using hooks.
+     * Creates a long-lived span for the tool execution with proper parent hierarchy.
+     */
+    suspend fun <R> withToolTelemetrySpan(
+        context: LLMToolCallContext<T>,
+        block: suspend LLMToolCallContext<T>.() -> R
+    ): R {
+        val engine = BotEngine.current()!!
+
+        val toolName = context.call.name
+        val baseAttributes = mapOf(
+            "llm.tool.name" to toolName,
+            "llm.tool.call_id" to context.call.callId,
+            "llm.tool.arguments" to (context.call.arguments?.toString() ?: "")
+        )
+
+        var started = false
+        return try {
+            engine.hooks.triggerHook(
+                ToolExecuteStartHook(
+                    context.context,
+                    context.request,
+                    baseAttributes
+                )
+            )
+            started = true
+
+            val result = context.block()
+            engine.hooks.triggerHook(
+                ToolExecuteFinishHook(
+                    context.context,
+                    context.request,
+                    baseAttributes
+                )
+            )
+            result
+        } catch (e: LLMToolInterruptionException) {
+            if (started) {
+                engine.hooks.triggerHook(
+                    ToolExecuteFinishHook(
+                        context.context,
+                        context.request,
+                        baseAttributes + ("llm.tool.cancelled" to true)
+                    )
+                )
+            }
+            throw e
+        } catch (e: Throwable) {
+            engine.hooks.triggerHook(
+                ToolExecuteErrorHook(
+                    context.context,
+                    context.request,
+                    baseAttributes + mapOf("llm.tool.error" to e)
+                )
+            )
+            throw e
+        }
     }
 
     companion object {

--- a/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/BotEngine.kt
@@ -13,26 +13,56 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.BotRequestController
 import com.justai.jaicf.api.routing.BotRequestRerouteException
 import com.justai.jaicf.api.routing.activators.TargetStateActivator
-import com.justai.jaicf.context.*
+import com.justai.jaicf.context.ActivatorContext
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.DialogContext
+import com.justai.jaicf.context.ExecutionContext
+import com.justai.jaicf.context.ProcessContext
+import com.justai.jaicf.context.RequestContext
 import com.justai.jaicf.context.manager.BotContextManager
 import com.justai.jaicf.context.manager.InMemoryBotContextManager
-import com.justai.jaicf.exceptions.*
+import com.justai.jaicf.exceptions.ActionException
+import com.justai.jaicf.exceptions.ActivationException
+import com.justai.jaicf.exceptions.BotException
+import com.justai.jaicf.exceptions.BotExecutionException
+import com.justai.jaicf.exceptions.NoStateFoundException
+import com.justai.jaicf.exceptions.scenarioCause
 import com.justai.jaicf.helpers.logging.WithLogger
-import com.justai.jaicf.hook.*
+import com.justai.jaicf.hook.ActionErrorHook
+import com.justai.jaicf.hook.AfterActionHook
+import com.justai.jaicf.hook.AfterProcessHook
+import com.justai.jaicf.hook.AnyErrorHook
+import com.justai.jaicf.hook.BeforeActionHook
+import com.justai.jaicf.hook.BeforeActivationHook
+import com.justai.jaicf.hook.BeforeProcessHook
+import com.justai.jaicf.hook.BotExceptionHandlingHook
+import com.justai.jaicf.hook.BotHook
+import com.justai.jaicf.hook.BotHookException
+import com.justai.jaicf.hook.BotHookHandler
+import com.justai.jaicf.hook.BotRequestHook
 import com.justai.jaicf.logging.ConversationLogger
 import com.justai.jaicf.logging.Slf4jConversationLogger
 import com.justai.jaicf.model.scenario.Scenario
 import com.justai.jaicf.model.state.State
 import com.justai.jaicf.reactions.Reactions
 import com.justai.jaicf.reactions.ResponseReactions
-import com.justai.jaicf.slotfilling.*
+import com.justai.jaicf.slotfilling.SlotFillingFinished
+import com.justai.jaicf.slotfilling.SlotFillingInProgress
+import com.justai.jaicf.slotfilling.SlotFillingInterrupted
+import com.justai.jaicf.slotfilling.SlotReactor
+import com.justai.jaicf.slotfilling.getSlotFillingContext
+import com.justai.jaicf.slotfilling.isActiveSlotFilling
+import com.justai.jaicf.slotfilling.startSlotFilling
+import com.justai.jaicf.telemetry.TelemetryProvider
+import com.justai.jaicf.telemetry.installTelemetryHooks
+import com.justai.jaicf.telemetry.runWithTelemetry
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 
 /**
  * Default [BotApi] implementation.
@@ -75,9 +105,11 @@ open class BotEngine(
 ) : BotApi, WithLogger {
 
     val model = scenario.model.verify()
-
     private val requestDispatcher = requestExecutor.asCoroutineDispatcher()
     private val activatorsList = activators.map { it.create(model) }.addBuiltinActivators()
+
+    var telemetryProvider: TelemetryProvider = TelemetryProvider.NoOp
+        private set
 
     private fun List<Activator>.addBuiltinActivators(): List<Activator> {
         fun MutableList<Activator>.removeIfPresent(a: Activator) = removeIf { it.name == a.name }
@@ -122,17 +154,21 @@ open class BotEngine(
         requestContext: RequestContext,
         contextManager: BotContextManager? = null,
     ) {
-        try {
-            val manager = contextManager ?: defaultContextManager
-            val botContext = manager.loadContext(request, requestContext)
-            val executionContext = ExecutionContext(requestContext, null, botContext, request)
-            processRequest(request, reactions, requestContext, botContext, executionContext)
-            saveContext(manager, botContext, request, reactions, requestContext)
-        } catch (e: BotRequestRerouteException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error("", e)
-            throw e
+        val manager = contextManager ?: defaultContextManager
+        val botContext = manager.loadContext(request, requestContext)
+        runWithTelemetry(request, requestContext, botContext) {
+            try {
+                val executionContext = ExecutionContext(requestContext, null, botContext, request)
+                processRequest(request, reactions, requestContext, botContext, executionContext)
+                saveContext(manager, botContext, request, reactions, requestContext)
+            } catch (e: BotRequestRerouteException) {
+                throw e
+            } catch (e: Exception) {
+                val exception = BotExecutionException(e, botContext.currentState)
+                withHook(AnyErrorHook(botContext, request, reactions, exception))
+                logger.error("", e)
+                throw e
+            }
         }
     }
 
@@ -220,8 +256,13 @@ open class BotEngine(
             hooks.triggerHook(hook)
             block.invoke()
         } catch (e: BotHookException) {
-            logger.debug("Hook $hook interrupted a request processing", e)
+            logger.debug("Hook {} interrupted a request processing", hook, e)
         }
+    }
+
+    fun withTelemetry(provider: TelemetryProvider): BotEngine = apply {
+        telemetryProvider = provider
+        installTelemetryHooks(provider)
     }
 
     private inline fun <reified T : BotExceptionHandlingHook> tryHandleWithHook(
@@ -291,11 +332,11 @@ open class BotEngine(
             return
         }
         try {
-            logger.trace("Executing state: $state")
+            logger.trace("Executing state: {}", state)
             state.action.execute(this)
             withHook(AfterActionHook(botContext, request, reactions, activator, state))
         } catch (e: BotRequestRerouteException) {
-            logger.trace("Changing executable bot engine to: ${e.rerouteRequest}")
+            logger.trace("Changing executable bot engine to: {}", e.rerouteRequest)
             throw e
         } catch (e: Exception) {
             logger.trace("Error execute action message: ${e.message}")
@@ -323,9 +364,7 @@ open class BotEngine(
         val DefaultActivationSelector: ActivationSelector = ActivationSelector.default
         val DefaultConversationLoggers: Array<ConversationLogger> = arrayOf(Slf4jConversationLogger())
         val DefaultRequestExecutor: Executor = Executors.newCachedThreadPool()
-
-        suspend fun current() =
-            coroutineContext[Element.Key]?.engine
+        suspend fun current() = currentCoroutineContext()[Element.Key]?.engine
     }
 }
 

--- a/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/context/ExecutionContext.kt
@@ -5,6 +5,7 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.exceptions.BotException
 import com.justai.jaicf.logging.ConversationLogger
 import com.justai.jaicf.logging.Reaction
+import com.justai.jaicf.telemetry.TelemetrySpan
 
 /**
  * This class will accumulate all execution information obtained during processing request.
@@ -29,5 +30,6 @@ data class ExecutionContext(
     val reactions: MutableList<Reaction> = mutableListOf(),
     val input: String = request.input,
     var scenarioException: BotException? = null,
-    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false
+    val isNewUser: Boolean = (botContext.temp[BotContextKeys.IS_NEW_USER_KEY] as? Boolean) ?: false,
+    var telemetrySpan: TelemetrySpan? = null,
 )

--- a/core/src/main/kotlin/com/justai/jaicf/hook/BotHook.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/hook/BotHook.kt
@@ -4,6 +4,7 @@ import com.justai.jaicf.api.BotRequest
 import com.justai.jaicf.api.MutableBotRequest
 import com.justai.jaicf.context.ActivatorContext
 import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.RequestContext
 import com.justai.jaicf.exceptions.BotException
 import com.justai.jaicf.exceptions.BotExecutionException
 import com.justai.jaicf.helpers.logging.WithLogger
@@ -112,3 +113,13 @@ data class AnyErrorHook(
     override val reactions: Reactions,
     override val exception: BotException,
 ) : BotPreProcessHook, BotExceptionHandlingHook
+
+enum class RequestLifecycleStage { START, END }
+
+data class TelemetryStartProcessHook(
+    override val context: BotContext,
+    val request: BotRequest,
+    val requestContext: RequestContext,
+    val stage: RequestLifecycleStage,
+    val durationMs: Double = 0.0,
+) : BotHook

--- a/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryContext.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryContext.kt
@@ -1,0 +1,160 @@
+package com.justai.jaicf.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.helpers.context.tempProperty
+import com.justai.jaicf.reactions.Reactions
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Storage for active telemetry spans in BotContext.
+ * Spans are stored by name and can be retrieved by name.
+ */
+private var BotContext.activeTelemetrySpans by tempProperty<MutableMap<String, TelemetrySpan>>(saveDefault = true) { mutableMapOf() }
+
+/**
+ * Gets a telemetry span from BotContext by name.
+ */
+fun BotContext.getTelemetrySpan(spanName: String): TelemetrySpan? {
+    return activeTelemetrySpans[spanName]
+}
+
+/**
+ * Sets a telemetry span in BotContext by name.
+ */
+fun BotContext.setTelemetrySpan(spanName: String, span: TelemetrySpan) {
+    activeTelemetrySpans[spanName] = span
+}
+
+/**
+ * Removes a telemetry span from BotContext by name.
+ */
+fun BotContext.removeTelemetrySpan(spanName: String) {
+    activeTelemetrySpans.remove(spanName)
+}
+
+/**
+ * Gets the current active telemetry span from BotContext.
+ * Returns the span with name "current" or null if not present.
+ */
+fun BotContext.getCurrentTelemetrySpan(): TelemetrySpan? {
+    return activeTelemetrySpans["current"]
+}
+
+/**
+ * Sets the current active telemetry span in BotContext.
+ */
+fun BotContext.setCurrentTelemetrySpan(span: TelemetrySpan?) {
+    if (span != null) {
+        activeTelemetrySpans["current"] = span
+    } else {
+        activeTelemetrySpans.remove("current")
+    }
+}
+
+/**
+ * Closes all active telemetry spans in BotContext.
+ */
+fun BotContext.closeAllTelemetrySpans() {
+    activeTelemetrySpans.values.forEach { span ->
+        try {
+            span.close()
+        } catch (e: Throwable) {
+            // Ignore errors when closing spans
+        }
+    }
+    activeTelemetrySpans.clear()
+}
+
+/**
+ * Returns the current telemetry span from BotContext if available.
+ * Tries to get BotContext from Reactions (via BotEngine.current()) or returns null.
+ */
+suspend fun currentTelemetrySpan(): TelemetrySpan? {
+    val engine = BotEngine.current() ?: return null
+    // Try to get BotContext from current execution context
+    // This is a best-effort approach - BotContext should be available in most scenarios
+    return try {
+        // In scenarios, reactions.botContext should be available
+        // But we can't access it directly here, so we'll need to pass BotContext explicitly
+        // For now, return null - callers should pass BotContext explicitly
+        null
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Returns the current telemetry span from BotContext.
+ * Requires BotContext to be passed explicitly.
+ */
+fun currentTelemetrySpan(context: BotContext): TelemetrySpan? {
+    return context.getCurrentTelemetrySpan()
+}
+
+/**
+ * Returns the current telemetry span from BotContext, or null if not available.
+ * Can be called from both suspend and non-suspend contexts.
+ * Tries to get BotContext from Reactions if available.
+ */
+fun currentTelemetrySpanBlocking(): TelemetrySpan? {
+    // This function is kept for backward compatibility
+    // But it may not work reliably without BotContext
+    // Callers should prefer passing BotContext explicitly
+    return try {
+        runBlocking(EmptyCoroutineContext) {
+            currentTelemetrySpan()
+        }
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Returns the current telemetry span from BotContext (blocking version).
+ * Requires BotContext to be passed explicitly.
+ */
+fun currentTelemetrySpanBlocking(context: BotContext): TelemetrySpan? {
+    return context.getCurrentTelemetrySpan()
+}
+
+/**
+ * Legacy coroutine context element for backward compatibility.
+ * @deprecated Use BotContext-based span storage instead.
+ */
+@Deprecated("Use BotContext-based span storage instead", ReplaceWith("BotContext.setTelemetrySpan()"))
+class TelemetryContextElement(
+    val span: TelemetrySpan
+) : CoroutineContext.Element {
+
+    companion object Key : CoroutineContext.Key<TelemetryContextElement>
+
+    override val key: CoroutineContext.Key<TelemetryContextElement> = Key
+}
+
+/**
+ * Legacy function for setting span in coroutine context.
+ * @deprecated Use BotContext-based span storage instead.
+ */
+@Deprecated("Use BotContext-based span storage instead", ReplaceWith("context.setTelemetrySpan(name, span)"))
+suspend fun <T> withTelemetrySpan(
+    span: TelemetrySpan,
+    block: suspend () -> T
+): T = withContext(TelemetryContextElement(span)) { block() }
+
+/**
+ * Legacy function for setting span in coroutine context (blocking version).
+ * @deprecated Use BotContext-based span storage instead.
+ */
+@Deprecated("Use BotContext-based span storage instead", ReplaceWith("context.setTelemetrySpan(name, span)"))
+fun <T> withTelemetrySpanBlocking(span: TelemetrySpan, block: () -> T): T {
+    return runBlocking {
+        withTelemetrySpan(span) {
+            block()
+        }
+    }
+}

--- a/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryExtensions.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryExtensions.kt
@@ -1,0 +1,101 @@
+package com.justai.jaicf.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.context.BotContext
+
+/**
+ * Allows scenario actions to emit custom telemetry spans.
+ *
+ * ```
+ * action {
+ *     sendTelemetrySpan("jaicf.custom.event", mapOf("key" to "value")) {
+ *         addEvent("payload.sent")
+ *     }
+ * }
+ * ```
+ *
+ * @param name span name
+ * @param attributes span attributes recorded on creation
+ * @param block optional block executed with the created span as receiver
+ */
+suspend fun sendTelemetrySpan(
+    name: String,
+    attributes: TelemetryAttributes = emptyMap(),
+    block: suspend TelemetrySpan.() -> Unit = {},
+) {
+    val engine = BotEngine.current()
+    val provider = engine?.telemetryProvider ?: TelemetryProvider.NoOp
+    
+    // Try to get BotContext from Reactions if available
+    // In scenarios, reactions.botContext should be available
+    val botContext = try {
+        // This is a best-effort approach
+        // In most cases, BotContext should be available through reactions
+        // But we can't access it directly here without passing it explicitly
+        null
+    } catch (e: Exception) {
+        null
+    }
+    
+    val parent = botContext?.let { currentTelemetrySpan(it) } ?: currentTelemetrySpan()
+    val span = try {
+        provider.createSpan(name, attributes, parent)
+    } catch (e: Throwable) {
+        TelemetrySpan.NoOp
+    }
+
+    try {
+        // Set span in BotContext if available
+        botContext?.let {
+            it.setTelemetrySpan(name, span)
+            it.setCurrentTelemetrySpan(span)
+        }
+        span.block()
+    } catch (e: Throwable) {
+        span.recordException(e)
+        throw e
+    } finally {
+        span.close()
+        botContext?.let {
+            it.removeTelemetrySpan(name)
+            if (it.getCurrentTelemetrySpan() == span) {
+                it.setCurrentTelemetrySpan(null)
+            }
+        }
+    }
+}
+
+/**
+ * Sends a telemetry span with explicit BotContext.
+ * This is the preferred way to use telemetry spans in scenarios.
+ */
+suspend fun sendTelemetrySpan(
+    context: BotContext,
+    name: String,
+    attributes: TelemetryAttributes = emptyMap(),
+    block: suspend TelemetrySpan.() -> Unit = {},
+) {
+    val engine = BotEngine.current()
+    val provider = engine?.telemetryProvider ?: TelemetryProvider.NoOp
+    val parent = currentTelemetrySpan(context)
+    val span = try {
+        provider.createSpan(name, attributes, parent)
+    } catch (e: Throwable) {
+        TelemetrySpan.NoOp
+    }
+
+    try {
+        context.setTelemetrySpan(name, span)
+        context.setCurrentTelemetrySpan(span)
+        span.block()
+    } catch (e: Throwable) {
+        span.recordException(e)
+        throw e
+    } finally {
+        span.close()
+        context.removeTelemetrySpan(name)
+        if (context.getCurrentTelemetrySpan() == span) {
+            context.setCurrentTelemetrySpan(null)
+        }
+    }
+}

--- a/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryHookBinder.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryHookBinder.kt
@@ -1,0 +1,323 @@
+package com.justai.jaicf.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.api.BotRequest
+import com.justai.jaicf.context.BotContext
+import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.hook.ActionErrorHook
+import com.justai.jaicf.hook.AfterActionHook
+import com.justai.jaicf.hook.AfterProcessHook
+import com.justai.jaicf.hook.AnyErrorHook
+import com.justai.jaicf.hook.BeforeActionHook
+import com.justai.jaicf.hook.BeforeActivationHook
+import com.justai.jaicf.hook.BeforeProcessHook
+import com.justai.jaicf.hook.RequestLifecycleStage
+import com.justai.jaicf.hook.TelemetryStartProcessHook
+import com.justai.jaicf.test.reactions.answer
+
+/**
+ * Wraps the request processing in a parent telemetry span.
+ * Creates a span named "jaicf.bot.request" with request attributes and duration.
+ */
+suspend inline fun <T> BotEngine.runWithTelemetry(
+    request: BotRequest,
+    requestContext: RequestContext,
+    context: BotContext,
+    crossinline block: suspend () -> T
+): T {
+    val startedAt = System.nanoTime()
+    val attributes = mapOf(
+        "jaicf.request.type" to request.type.name,
+        "jaicf.request.client_id" to request.clientId,
+        "jaicf.session.new" to requestContext.newSession
+    )
+
+    val parentSpan = context.getCurrentTelemetrySpan()
+    val span = try {
+        telemetryProvider.createSpan("jaicf.bot.request", attributes, parentSpan)
+    } catch (e: Throwable) {
+        TelemetrySpan.NoOp
+    }
+
+    if (span != TelemetrySpan.NoOp) {
+        context.setTelemetrySpan("jaicf.bot.request", span)
+        context.setCurrentTelemetrySpan(span)
+    }
+
+    return try {
+        val startHook = TelemetryStartProcessHook(
+            context,
+            request,
+            requestContext,
+            RequestLifecycleStage.START,
+            durationMillis(startedAt)
+        )
+        this.hooks.triggerHook(startHook)
+        block()
+    } catch (e: Throwable) {
+        span.recordException(e)
+        throw e
+    } finally {
+        val endHook = TelemetryStartProcessHook(
+            context,
+            request,
+            requestContext,
+            RequestLifecycleStage.END,
+            durationMillis(startedAt)
+        )
+        this.hooks.triggerHook(endHook)
+
+        if (span != TelemetrySpan.NoOp) {
+            span.close()
+            context.removeTelemetrySpan("jaicf.bot.request")
+            // Only clear current span if it's the same one
+            if (context.getCurrentTelemetrySpan() == span) {
+                context.setCurrentTelemetrySpan(null)
+            }
+        }
+    }
+}
+
+
+internal fun BotEngine.installTelemetryHooks(telemetryProvider: TelemetryProvider = TelemetryProvider.NoOp) {
+
+//    hooks.addHookAction<BotRequestHook> {
+//        TelemetryHookProcessor.handleBotRequest(telemetryProvider, this)
+//    }
+
+    hooks.addHookAction<TelemetryStartProcessHook> {
+        TelemetryHookProcessor.handleRequestLifecycle(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<BeforeActivationHook> {
+        TelemetryHookProcessor.handleBeforeActivation(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<BeforeProcessHook> {
+        TelemetryHookProcessor.handleBeforeProcess(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<AfterProcessHook> {
+        TelemetryHookProcessor.handleAfterProcess(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<BeforeActionHook> {
+        TelemetryHookProcessor.handleBeforeAction(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<AfterActionHook> {
+        TelemetryHookProcessor.handleAfterAction(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<ActionErrorHook> {
+        TelemetryHookProcessor.handleActionError(telemetryProvider, this)
+    }
+
+    hooks.addHookAction<AnyErrorHook> {
+        TelemetryHookProcessor.handleAnyError(telemetryProvider, this)
+    }
+}
+
+private object TelemetryHookProcessor {
+
+//    fun handleBotRequest(telemetryProvider: TelemetryProvider, hook: BotRequestHook) {
+//        val name = "jaicf.request.received"
+//        val attributes = mapOf(
+//            "jaicf.request.type" to hook.request.type.name,
+//            "jaicf.request.client_id" to hook.request.clientId,
+//            "jaicf.request.input" to hook.request.input
+//        )
+//        telemetryProvider.record(name, attributes)
+//    }
+
+    fun handleRequestLifecycle(telemetryProvider: TelemetryProvider, hook: TelemetryStartProcessHook) {
+        if (hook.stage == RequestLifecycleStage.START) {
+            val name = "jaicf.request.start"
+            val attributes = mapOf(
+                "jaicf.request.input" to hook.request.input,
+                "jaicf.request.type" to hook.request.type.name,
+                "jaicf.request.client_id" to hook.request.clientId,
+                "jaicf.session.new" to hook.requestContext.newSession,
+                "jaicf.duration_ms" to hook.durationMs
+            )
+            // Создаем долгоживущий span как дочерний от текущего (jaicf.bot.request)
+            val parentSpan = hook.context.getCurrentTelemetrySpan()
+            val span = try {
+                telemetryProvider.createSpan(name, attributes, parentSpan)
+            } catch (e: Throwable) {
+                TelemetrySpan.NoOp
+            }
+            if (span != TelemetrySpan.NoOp) {
+                hook.context.setTelemetrySpan(name, span)
+                hook.context.setCurrentTelemetrySpan(span) // Устанавливаем как текущий!
+            }
+        } else {
+            // END stage - обновляем и закрываем span
+            val span = hook.context.getTelemetrySpan("jaicf.request.start")
+            span?.apply {
+                setAttribute("jaicf.duration_ms", hook.durationMs)
+                setAttribute("jaicf.current_state", hook.context.dialogContext.currentState)
+                close()
+            }
+            hook.context.removeTelemetrySpan("jaicf.request.start")
+            // Восстанавливаем родительский span (jaicf.bot.request) как текущий
+            val parentSpan = hook.context.getTelemetrySpan("jaicf.bot.request")
+            hook.context.setCurrentTelemetrySpan(parentSpan)
+        }
+    }
+
+    fun handleBeforeActivation(telemetryProvider: TelemetryProvider, hook: BeforeActivationHook) {
+        val name = "jaicf.activation.before"
+        val attributes = mapOf(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.request.input" to hook.request.input,
+            "jaicf.current_state" to hook.context.dialogContext.currentState
+        )
+        val parentSpan = hook.context.getTelemetrySpan("jaicf.bot.request")
+        val span = try {
+            telemetryProvider.createSpan(name, attributes, parentSpan)
+        } catch (e: Throwable) {
+            TelemetrySpan.NoOp
+        }
+        if (span != TelemetrySpan.NoOp) {
+            hook.context.setTelemetrySpan(name, span)
+            hook.context.setCurrentTelemetrySpan(span) // Устанавливаем как текущий!
+        }
+    }
+
+    fun handleBeforeProcess(telemetryProvider: TelemetryProvider, hook: BeforeProcessHook) {
+        // Закрываем jaicf.activation.before перед началом процесса
+        val activationSpan = hook.context.getTelemetrySpan("jaicf.activation.before")
+        activationSpan?.close()
+        hook.context.removeTelemetrySpan("jaicf.activation.before")
+        
+        val name = "jaicf.process.start"
+        val attributes = mapOf(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.request.input" to hook.request.input,
+            "jaicf.activator" to hook.activator.javaClass.name,
+            "jaicf.current_state" to hook.context.dialogContext.currentState
+        )
+        // Создаем долгоживущий span как дочерний от текущего (jaicf.request.start)
+        val parentSpan = hook.context.getTelemetrySpan("jaicf.activation.before")
+            ?: hook.context.getCurrentTelemetrySpan()
+        val span = try {
+            telemetryProvider.createSpan(name, attributes, parentSpan)
+        } catch (e: Throwable) {
+            TelemetrySpan.NoOp
+        }
+        if (span != TelemetrySpan.NoOp) {
+            hook.context.setTelemetrySpan(name, span)
+            hook.context.setCurrentTelemetrySpan(span) // Устанавливаем как текущий!
+        }
+    }
+
+    fun handleAfterProcess(telemetryProvider: TelemetryProvider, hook: AfterProcessHook) {
+        val name = "jaicf.process.end"
+        val attributes = mapOf(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.request.response" to hook.reactions.answer,
+            "jaicf.activator" to hook.activator.javaClass.name,
+            "jaicf.current_state" to hook.context.dialogContext.currentState
+        )
+        // Обновляем и закрываем текущий span (jaicf.process.start)
+        val span = hook.context.getTelemetrySpan("jaicf.process.start")
+        span?.apply {
+            attributes.forEach { (k, v) -> setAttribute(k, v) }
+            close()
+        }
+        hook.context.removeTelemetrySpan("jaicf.process.start")
+        // Восстанавливаем родительский span (jaicf.request.start) как текущий
+        val parentSpan = hook.context.getTelemetrySpan("jaicf.request.start")
+        hook.context.setCurrentTelemetrySpan(parentSpan)
+    }
+
+    fun handleBeforeAction(telemetryProvider: TelemetryProvider, hook: BeforeActionHook) {
+        val name = "jaicf.action.start"
+        val attributes = mapOf(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.state" to hook.state.path,
+            "jaicf.state_path" to hook.state.path.toString(),
+            "jaicf.activator" to hook.activator.javaClass.name,
+        )
+        // Создаем долгоживущий span как дочерний от текущего (jaicf.process.start)
+        val parentSpan = hook.context.getCurrentTelemetrySpan()
+        val span = try {
+            telemetryProvider.createSpan(name, attributes, parentSpan)
+        } catch (e: Throwable) {
+            TelemetrySpan.NoOp
+        }
+        if (span != TelemetrySpan.NoOp) {
+            hook.context.setTelemetrySpan(name, span)
+            hook.context.setCurrentTelemetrySpan(span) // Устанавливаем как текущий!
+        }
+    }
+
+    fun handleAfterAction(telemetryProvider: TelemetryProvider, hook: AfterActionHook) {
+        val name = "jaicf.action.end"
+        val attributes = mapOf(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.response.answers" to hook.reactions.answer,
+            "jaicf.state" to hook.state.path,
+            "jaicf.state_path" to hook.state.path.toString(),
+            "jaicf.activator" to hook.activator.javaClass.name,
+        )
+        // Обновляем и закрываем текущий span (jaicf.action.start)
+        val span = hook.context.getTelemetrySpan("jaicf.action.start")
+        span?.apply {
+            attributes.forEach { (k, v) -> setAttribute(k, v) }
+            close()
+        }
+        hook.context.removeTelemetrySpan("jaicf.action.start")
+        // Восстанавливаем родительский span (jaicf.process.start) как текущий
+        val parentSpan = hook.context.getTelemetrySpan("jaicf.process.start")
+        hook.context.setCurrentTelemetrySpan(parentSpan)
+    }
+
+    fun handleActionError(telemetryProvider: TelemetryProvider, hook: ActionErrorHook) {
+        val name = "jaicf.action.error"
+        val attributes = mutableMapOf<String, Any?>(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.state" to hook.state.path,
+            "jaicf.state_path" to hook.state.path.toString(),
+            "jaicf.activator" to hook.activator.javaClass.name,
+            "jaicf.error.type" to hook.exception::class.qualifiedName,
+            "jaicf.error.message" to hook.exception.message,
+            "jaicf.error.state" to hook.state.path
+        )
+        telemetryProvider.record(name, attributes, hook.context)
+        hook.context.getCurrentTelemetrySpan()?.recordException(hook.exception)
+    }
+
+    fun handleAnyError(telemetryProvider: TelemetryProvider, hook: AnyErrorHook) {
+        val name = "jaicf.error"
+        val attributes = mutableMapOf<String, Any?>(
+            "jaicf.request.client_id" to hook.request.clientId,
+            "jaicf.error.type" to hook.exception::class.qualifiedName,
+            "jaicf.error.message" to hook.exception.message,
+            "jaicf.current_state" to hook.context.dialogContext.currentState
+        )
+        telemetryProvider.record(name, attributes, hook.context)
+        hook.context.getCurrentTelemetrySpan()?.recordException(hook.exception)
+    }
+
+    fun TelemetryProvider.record(
+        name: String,
+        attributes: Map<String, Any?>,
+        context: BotContext? = null,
+    ) {
+        val parent = context?.getCurrentTelemetrySpan()
+        val span = try {
+            createSpan(name, attributes, parent)
+        } catch (e: Throwable) {
+            TelemetrySpan.NoOp
+        }
+        span.use { span ->
+            // Span is automatically closed by use block
+            // No need to set it in context for short-lived spans
+        }
+    }
+}
+
+fun durationMillis(startedAt: Long): Double =
+    (System.nanoTime() - startedAt) / 1_000_000.0

--- a/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryProvider.kt
+++ b/core/src/main/kotlin/com/justai/jaicf/telemetry/TelemetryProvider.kt
@@ -1,0 +1,62 @@
+package com.justai.jaicf.telemetry
+
+typealias TelemetryAttributes = Map<String, Any?>
+
+interface TelemetryProvider {
+    fun createSpan(
+        name: String,
+        attributes: TelemetryAttributes = emptyMap(),
+        parent: TelemetrySpan? = null
+    ): TelemetrySpan
+
+    companion object {
+        val NoOp: TelemetryProvider = object : TelemetryProvider {
+            override fun createSpan(
+                name: String,
+                attributes: TelemetryAttributes,
+                parent: TelemetrySpan?
+            ): TelemetrySpan = TelemetrySpan.NoOp
+        }
+    }
+}
+
+interface TelemetrySpan : AutoCloseable {
+    fun setAttribute(key: String, value: Any?)
+    fun addEvent(name: String, attributes: TelemetryAttributes = emptyMap())
+    fun recordException(exception: Throwable)
+
+    override fun close()
+
+    companion object {
+        val NoOp: TelemetrySpan = object : TelemetrySpan {
+            override fun setAttribute(key: String, value: Any?) = Unit
+            override fun addEvent(name: String, attributes: TelemetryAttributes) = Unit
+            override fun recordException(exception: Throwable) = Unit
+            override fun close() = Unit
+        }
+    }
+}
+
+suspend inline fun <T> TelemetryProvider.inSpan(
+    name: String,
+    attributes: TelemetryAttributes = emptyMap(),
+    parent: TelemetrySpan? = null,
+    crossinline block: suspend (TelemetrySpan) -> T
+): T {
+    val span = try {
+        createSpan(name, attributes, parent)
+    } catch (e: Throwable) {
+        TelemetrySpan.NoOp
+    }
+
+    try {
+        return withTelemetrySpan(span) {
+            block(span)
+        }
+    } catch (e: Throwable) {
+        span.recordException(e)
+        throw e
+    } finally {
+        span.close()
+    }
+}

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/scenario/MergeHooksTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/scenario/MergeHooksTest.kt
@@ -28,7 +28,7 @@ class MergeHooksTest {
     }
 
     private fun RootBuilder<*, *>.testHandle(list: MutableList<String>, name: String) {
-        handle<BeforeActionHook> { list += "$name hook from ${state.path.toString()}" }
+        handle<BeforeActionHook> { list += "$name hook from ${state.path}" }
     }
 
     private fun List<String>.assertHooks(vararg results: String) = assertEquals(results.toList(), this)

--- a/core/src/test/kotlin/com/justai/jaicf/core/test/telemetry/TelemetryTest.kt
+++ b/core/src/test/kotlin/com/justai/jaicf/core/test/telemetry/TelemetryTest.kt
@@ -1,0 +1,58 @@
+package com.justai.jaicf.core.test.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.builder.Scenario
+import com.justai.jaicf.channel.ConsoleChannel
+import com.justai.jaicf.hook.ActionErrorHook
+import com.justai.jaicf.hook.AnyErrorHook
+import com.justai.jaicf.telemetry.withTelemetrySpanBlocking
+import com.justai.jaicf.test.ScenarioTest
+import org.junit.jupiter.api.Test
+
+private val scenarioWithAnyErrorHook = Scenario {
+
+    handle<AnyErrorHook> {
+        reactions.say("anyError")
+    }
+
+    handle<ActionErrorHook> {
+        reactions.say("actionError")
+    }
+
+    state("error") {
+        activators {
+            regex("goToUnknownState")
+        }
+        action {
+            reactions.go("unknownState")
+        }
+    }
+
+    state("ok") {
+        activators {
+            regex("ok")
+        }
+        action {
+            reactions.say("ok")
+        }
+    }
+}
+
+class AnyErrorHookTest : ScenarioTest(scenarioWithAnyErrorHook) {
+
+    @Test
+    fun `should handle noStateFound exception with anyError hook`() {
+        query("goToUnknownState") responds "anyError"
+    }
+
+    @Test
+    fun `should not invoke error hook when no errors`() {
+        query("ok") responds "ok"
+    }
+
+}
+
+fun main() {
+    val botEngine = BotEngine(scenarioWithAnyErrorHook)
+    ConsoleChannel(botEngine).run("/start")
+}

--- a/docs/llm-activator-architecture.md
+++ b/docs/llm-activator-architecture.md
@@ -1,0 +1,84 @@
+# Архитектура LLM-активатора JAICF
+
+Документ описывает устройство `activators/llm` в `jaicf-kotlin-new`, поток обработки запросов и расширения (агенты, инструменты, векторные стора, тестовые утилиты). Материал основан на исходниках в `activators/llm/src/main/kotlin` и примерах `examples/llm-example`.
+
+## 1. Общий поток обработки
+- Состояния сценария подключают LLM через `llmState` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/scenario/LLMScenarioBuilder.kt:18`). Внутри создаётся `catchAll`‑активатор и вызывается `llmAction`.
+- `llmAction` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMAction.kt:35`) строит `LLMContext` и оборачивает user-блок в `LLMActionContext`, который управляет стримом, tool loop и реакциями. Исключения `LLMToolInterruptionException` перехватываются и выполняют отложенный callback (например, переход в другой state).
+- `LLMActionAPI.createContext` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt:31`) мержит дефолтные/внешние `LLMProps`, подставляет входные сообщения (через `LLMInputs.TextOnly` или кастомный builder) и учитывает сохранённые хенд-офф сообщения. Итоговый `ChatCompletionCreateParams` сразу дополняется специфическими свойствами OpenAI (tools, responseFormat, usage streaming).
+- Во время выполнения `LLMActionContext.startStream()` открывает `StreamResponse` к OpenAI, аккумулирует чанки и восстанавливает `ChatCompletion` (методы `startStream`, `chunkStream`, `chatCompletion`, `content`, `toolCalls` в `activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt:64`).
+- Перед каждым токеном выполняется `yield()` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt:70`), чтобы корректно реагировать на отмену корутины (например, при смене state).
+
+## 2. Конфигурация через `LLMProps`
+- `LLMProps` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMProps.kt:30`) хранит параметры модели (model, temperature, топ‑p, токены и т.д.), список сообщений, функцию подготовки входа, инструменты и клиента OpenAI.
+- Builder (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMProps.kt:83`) доступен в DSL `LLMPropsBuilder`, где есть shortcuts `tool(...)`, `vectorStore(...)`, `llmMemory(...)`. `withProps` позволяет поверхностно комбинировать пресеты.
+- `toChatCompletionCreateParams()` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMProps.kt:63`) добавляет инструменты по их определениям. Для кастомных схем используется `JsonSchemaLocalValidation` и билд произвольного JSON Schema.
+- `LLMInputs` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMInputs.kt:12`) содержит готовые билдеры входа (`TextOnly`, `WithImages`), которые генерируют `ChatCompletionMessageParam` из `BotRequest`.
+- `LLMMemory` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMMemory.kt:12`) хранит историю в `BotContext.session`, поддерживает трансформации (например, `withSystemMessage`). При handoff и после tool call результаты возвращаются обратно в память.
+- `LLMMessage` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMMessage.kt:8`) концентрирует фабрики для разных ролей (user, assistant, system, tool) и безопасно сериализует результаты tool вызовов.
+
+## 3. Цикл tool calls и события
+- После запроса `LLMContext.withToolCalls` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt:136`) запускает цикл: получение tool вызовов (`hasToolCalls`), обработка коллбеков, отправка результата обратно в чат и повторный `startStream`. Возвращается, когда LLM перестаёт запрашивать инструменты.
+- `callTools` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt:111`) параллелит выполнение инструментов, ошибки оборачивает в `Result`. Успешные вызовы превращаются в `LLMToolResult` и триггерят `LLMToolCallHook`/`LLMToolCallsHook` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMHooks.kt:7`).
+- `eventStream()` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt:156`) переводит поток чанков в `Stream<LLMEvent>`, позволяя прикладному коду реагировать на `Start`, `ContentDelta`, `ToolCalls`, `ToolCallResults`, `Finish`. Пример обработки показан в `examples/llm-example/src/main/kotlin/com/justai/jaicf/examples/llm/LLMEvents.kt`.
+- В `reactions` доступны хелперы: `sayFinalContent()`, `streamOrSay()` для работы со streaming/финальным контентом (`LLMActionContext.kt:50` и `LLMActionContext.kt:167`).
+
+## 4. Инструменты и подтверждение
+- `LLMTool` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/tool/LLMTool.kt:19`) инкапсулирует определение (тип аргументов, имя, описание) и функцию. Аргументы десериализуются через Jackson mapper, что позволяет использовать обычные data классы.
+- `LLMToolDefinition.CustomSchema` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/tool/LLMToolDefinition.kt:26`) создаёт OpenAI Function Tool c произвольной JSON Schema, удобно для динамических payload (см. `InlineTools` пример).
+- `withConfirmation` оборачивает инструмент в `LLMToolWithConfirmation` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/tool/LLMToolWithConfirmation.kt:13`), который добавляет дополнительный параметр `confirmToolCallId`. Реализация поддерживает сценарии с подтверждением через LLM (текстовый ответ) или через собственный callback.
+- Исключение `LLMToolInterruptionException` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/tool/LLMToolInterruptionException.kt:9`) позволяет временно прервать LLMAction и выполнить произвольный JAICF‑код (например, `Reactions.go(...)`).
+- `LLMToolCallsHook` и `LLMToolCallHook` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMHooks.kt:7`) дают срез данных о вызовах для логирования и тестов. Фикстура `LLMToolCallReaction` (`activators/llm/src/testFixtures/kotlin/com/justai/jaicf/activator/llm/LLMToolCallReaction.kt:6`) превращает hook в виртуальные реакции.
+- HTTP shortcut'ы (в примерах `HTTPTools.kt`) используют обёртки из `com.justai.jaicf.activator.llm.tool.http.*` (непоказаны выше, но подключаются в props) и демонстрируют, что инструменты могут быть сформированы on-the-fly.
+
+## 5. Векторные стора
+- Любой `LLMVectorStore` реализует `search` и может быть прикрут по `vectorStore(...).tool(...)` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/vectorstore/LLMVectorStore.kt:19`). Возврат преобразуется в tool результат, а кастомный `responseBuilder` позволяет постобработать данные (пример: `ScenarioWithVectorStore.kt`).
+- `OpenAIVectorStore` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/vectorstore/OpenAIVectorStore.kt:13`) оборачивает OpenAI Assistants API: поиск, загрузка файлов, список файлов. `OpenAIVectorStoreFactory` создаёт/удаляет стора.
+- `HTTPVectorStore` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/vectorstore/HTTPVectorStore.kt:8`) — базовый класс для REST‑сторандов: создаёт `HttpClient` с Jackson и отключённой строгой десериализацией.
+
+## 6. Агентный уровень
+- `LLMAgent` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMAgent.kt:37`) — высокоуровневое описание одного состояния‑агента: хранит имя, props DSL, условие активации `onlyIf`, action блок. При первом обращении строит модель со state `/Agent/<name>` и подготавливает handoff props (`setupHandoffProps`).
+- `withProps` (`agent/LLMAgent.kt:35`) позволяет модифицировать builder, например, выключить память (`withoutMemory`).
+- `asBot` (`agent/LLMAgent.kt:130`) создаёт полноценный `BotEngine`, `asTool` (`agent/LLMAgent.kt:144`) превращает агента в инструмент (используется, например, для компоновки цепочек LLMов). Tool запускает вложенный `BotEngine`, собирает `SayReaction` и возвращает агрегированный ответ.
+- `LLMAgentWithRole` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMAgentWithRole.kt:4`) дополнительно хранит роль; `LLMAgentWithGoal` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMAgentWithGoal.kt:9`) добавляет системные инструкции и auto-tool `goal_achieved` для контроля целей (тест `AgentWithGoalTest` проверяет цепочку).
+- Хенд-оффы (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMHandoff.kt:20`) добавляют системное сообщение и инструмент `handoff_to_agent`, который через `interrupt` переключает диалог на другой агентский state, сохраняя цепочку сообщений в `BotContext.handoffMessages`. Проверка на циклы исключает зацикливание (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/agent/LLMHandoff.kt:59`). Пример — `MultiAgentHandoff`.
+
+## 7. Память и handoff
+- `LLMMemory` поддерживает две роли: `initial` (для чистого старта) и фактический список сообщений. Методы `transform`, `withSystemMessage`, `ifLLMMemory` позволяют безопасно менять историю (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMMemory.kt:20`).
+- При хенд-оффе не-системные сообщения сохраняются в `BotContext.handoffMessages` и подставляются следующему агенту (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionAPI.kt:42`).
+
+## 8. События и реакции
+- Базовый набор событий описан в `LLMEvent` (`activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/LLMEvent.kt:7`) и используется как в `eventStream`, так и в тестах/пример. Это даёт возможность строить произвольные пайплайны отображения: например, `AgentWithTools` выводит промежуточные результаты, а `ScenarioWithStreaming` создаёт «CALLING / RESULTS» лог.
+- Реакции: помимо стандартных `say`, доступны `reactions.stream(...)` (через `Reactions.stream` extension) и `reactions.handoff` (`LLMHandoff.kt:83`) для самих handoff функций.
+
+## 9. Тестовая инфраструктура
+- Аннотация `@OpenAITest` (`activators/llm/src/testFixtures/kotlin/com/justai/jaicf/activator/llm/openai/OpenAITest.kt:8`) подключает `OpenAIExtension`, которая проверяет `OPENAI_API_KEY` и повторяет тесты при флаky‑ответах (`activators/llm/src/testFixtures/kotlin/com/justai/jaicf/activator/llm/openai/OpenAIExtension.kt:12`).
+- `LLMScenarioTest` (`activators/llm/src/testFixtures/kotlin/com/justai/jaicf/activator/llm/LLMScenarioTest.kt:8`) наследует `ScenarioTest`, перехватывает `LLMToolCallsHook`, добавляет DSL `callsTool`, `callsTools`, `withoutToolCalls` — см. `AgentWithToolsTest`.
+- `testWithLLM` (`activators/llm/src/testFixtures/kotlin/com/justai/jaicf/activator/llm/LLMTest.kt:52`) запускает отдельный «тестирующий» агент, который общается с target ботом и ожидает структурированный JSON‑ответ (`LLMTestResult`). Это позволяет формулировать требования на естественном языке и проверять их (пример: `SimpleLLMAgentTest`).
+
+## 10. Примеры использования
+- **Базовый state** — `ScenarioWithTools.kt` показывает, как `llmState` + `llmProps` создают чат с калькулятором и памятью.
+- **Streaming и tool loop** — `ScenarioWithStreaming.kt` и `AgentWithTools` реализуют `llm.withToolCalls {}` и логирование этапов.
+- **Подтверждение** — `ConfirmToolCall.kt` использует `.withConfirmation`, тест `ConfirmToolCallTest` проверяет повторный вызов только после подтверждения.
+- **Vector store** — `ScenarioWithVectorStore.kt` комбинирует OpenAI Vector Store с кастомным `responseBuilder`, собирая и выводя источники.
+- **Мультиагентность** — `MultiAgentHandoff.kt` строит два агента и связывает handoff цепью. Тест `MultiAgentHandoffTest` убеждается, что запросы уходят к нужному агенту.
+
+## 11. Ключевые точки расширения
+1. `LLMPropsBuilder` — точка настройки модели, инструментов, памяти и клиента.
+2. `LLMActionBlock`/`LLMActionContext` — управление стримом, доступ к `eventStream`, `withToolCalls`, `awaitStructuredContent`.
+3. `LLMTool` API — подключение кастомных функций, HTTP/VectorStore обёрток, подтверждений.
+4. `LLMAgent` — композиция LLM‑состояний, превращение в бота/инструмент, handoff цепочки.
+5. Хуки (`LLMToolCallHook`, `LLMToolCallsHook`) — наблюдаемость и тесты.
+
+## 12. Телеметрия (интеграция без LLMPipeline)
+- Подключение: через `BotEngine.withTelemetry(...)` (используется core‑`TelemetryProvider` и `installTelemetryHooks`). Дополнительно может быть опциональный `LLMTelemetryFeature`.
+- Точки инструментации в activators/llm:
+  - `LLMActionContext.startStream()` — старт `LLM Call` span и `Streaming` span, фиксация First‑Byte Latency, входных атрибутов (model/props/tools/memory и т.п.).
+  - `LLMActionContext.chunkStream()` / `eventStream()` — события стрима (`Start`, `ContentDelta` с редактированием/семплингом, `ToolCalls`, `ToolCallResults`, `Finish`).
+  - `LLMActionContext.withToolCalls {}` / `callTools()` — aggregate `ToolCalls` span и per‑call `ToolCall` спаны (latency, статус, размеры аргументов/результатов, ошибки; подтверждения для `.withConfirmation`).
+  - Vector Store вызовы — отдельный `VectorStore` span (тип стора, topK, latency, источники с обфускацией при необходимости).
+  - Агентный уровень (`LLMAgent`) — `Agent` span на входе; `LLMHandoff` — `Handoff` span, линки между агентами, цикл‑guard событие.
+- Контент и приватность: по умолчанию контент редактируется; аргументы/результаты инструментов не логируются целиком (только размеры/хеши). Семплинг для `ContentDelta`.
+- Метрики: счётчики (llm/tool/handoff/errors), гистограммы (latency, tokens, FBL), gauge (active_streams, agent_chain_depth); лейблы низкой кардинальности (model, agent, tool, finish_reason, error_kind, store_type).
+
+Эти компоненты формируют гибкий слой между JAICF-сценариями и OpenAI Chat Completions, позволяя строить stateful-agents, orchestrate tool calls и интегрировать внешние знания без переписывания основного движка.

--- a/docs/llm-telemetry.md
+++ b/docs/llm-telemetry.md
@@ -1,0 +1,112 @@
+## Телеметрия для LLM-активатора JAICF
+
+Цель — дать наблюдаемость для LLM-вызовов, tool calling, streaming и агентных handoff, не меняя сценарии. 
+Подход сочетает существующие механизмы JAICF (`TelemetryProvider`, hook-и) и 
+архитектуру koog (`SpanProcessor`-подобный lifecycle менеджер спанов), а также встроенные точки расширения 
+LLM-активатора (`LLMHooks`, `LLMActionContext`).
+
+### Цели и принципы
+- Минимальная инвазия: включается через `BotEngine.withTelemetry` и опциональный `LLMTelemetryFeature`.
+- Единая иерархия спанов для: Agent → LLM Call → Streaming → ToolCalls → ToolCall → VectorStore → Handoff.
+- Контекстная пропагация через все границы: агент→агент, агент→tool, tool→обратный LLM.
+- Безопасность по умолчанию: контент редактируется, семплируется; payload-инструментов агрегируется, а не
+- логируется целиком.
+- Совместимость с JAICF core-телеметрией: один `TelemetryProvider`, общие правила статусов/ошибок/атрибутов.
+
+### Модель спанов и событий
+Имена условные, провайдер может маппить их на свою нотацию.
+
+- Span: `Agent`
+  - attrs: `agent.name`, `state.path`, `session.id`, `request.id`, `chain.depth`
+- Span: `LLM Call` (child of Agent)
+  - attrs.in: `model`, `temperature`, `top_p`, `max_tokens`, `tools.declared`, `memory.enabled`, `vector_store.used`, `response_format`
+  - attrs.req: `input.msgs.count`, `input.tokens.prompt` (если доступно), `input.bytes.approx`
+  - attrs.out: `finish_reason`, `output.msgs.count`, `output.tokens.completion`, `output.tokens.total`, `tool_calls.count`
+  - timing: `latency.ms`
+  - status/error: `error.kind` (timeout, throttling, provider_error, internal), `error.message`
+- Span: `Streaming` (child of LLM Call)
+  - attrs: `chunks.count`, `streamed.tokens`, `first_byte_latency.ms`, `duration.ms`
+  - events: `Start`, `ContentDelta` (редактированный/семплированный), `ToolCalls`, `ToolCallResults`, `Finish`
+- Span: `ToolCalls` aggregate (child of LLM Call)
+  - attrs: `total.count`, `by.name` (map name→count), `total.latency.ms`, `errors.count`
+- Span: `ToolCall` per-call (child of ToolCalls)
+  - attrs: `tool.name`, `args.schema.hash`, `args.size.bytes`, `confirmed` (для withConfirmation), `confirmation.id`
+  - result: `result.size.bytes`
+  - timing/status: `latency.ms`, `error.kind`, `error.message`
+- Span: `VectorStore` (child of ToolCall или LLM Call, в зависимости от реализации)
+  - attrs: `store.type`, `query.len`, `top_k`, `latency.ms`, `sources.meta` (id/score, опционально, с обфускацией)
+- Span: `Handoff` (между агентами)
+  - attrs: `from.agent`, `to.agent`, `reason`, `chain.depth`, `preserved.msgs.count`, `cycle_detected`
+
+### Точки интеграции в activators/llm
+
+1) `LLMActionContext` (ядро вызова LLM)
+- Старт `LLM Call` span при начале запроса к провайдеру (в начале `startStream()`), запись входных атрибутов (model/props/messages/tools/memory и т.п.).
+- Завершение `LLM Call` после восстановления `ChatCompletion` (в конце цикла `startStream()`/`chunkStream()`), фиксация finish_reason, токенов и latency; статус/ошибки.
+
+2) `LLMActionContext` (streaming + tool loop)
+- `startStream()` — старт `Streaming` span; фиксируем First-Byte Latency.
+- `chunkStream()`/`eventStream()` — эмитим события (`ContentDelta`, `ToolCalls`, `ToolCallResults`), учитываем семплинг/редакцию.
+- `withToolCalls {}` — старт aggregate `ToolCalls` span; внутри `callTools()` создаём per-call `ToolCall` span: аргументы (размер/хеш), статус, Latency, результат (размер), ошибки.
+
+3) `LLMHooks` (наблюдаемость tool-вызовов)
+- `LLMToolCallHook`, `LLMToolCallsHook` — связываем с текущим контекстом спанов, дублируем агрегаты в метрики.
+
+4) Агентный уровень (`LLMAgent`, `LLMHandoff`)
+- При входе агента — `Agent` span с атрибутами state/имени.
+- В `handoff_to_agent` — `Handoff` span (child of текущего Agent), линкируем с новым `Agent` span.
+- Цикл-guard события: `HandoffCyclePrevented`.
+
+### Контекстная пропагация (в духе koog)
+- Внутренний менеджер «живых» спанов (по аналогии с koog `SpanProcessor`):
+  - потокобезопасный реестр активных доменных спанов (id→span), RW‑lock на update.
+  - хранение `Context` у каждого доменного спана, `parent.context` → корректная иерархия.
+  - утилиты: `getSpan<T>()`, форс‑закрытие висячих спанов по завершении сессии/ранa.
+- Контекст переносится через:
+  - `LLMActionContext` поля/корутины (parent span в coroutine context)
+  - вызовы инструментов (корутины дочерние)
+  - handoff (передача `Context` при `interrupt` / построении нового `Agent`)
+
+### Метрики (рекомендуемый набор)
+- Counters: `llm_calls_total`, `tool_calls_total`, `handoffs_total`, `errors_total{kind}`, `confirmations_total{status}`
+- Histograms: `llm_latency_ms`, `first_byte_latency_ms`, `tool_call_latency_ms`, `vector_search_latency_ms`, `tokens_prompt`, `tokens_completion`, `tokens_total`
+- Gauges: `active_streams`, `agent_chain_depth`
+- Лейблы: `model`, `agent`, `tool`, `finish_reason`, `error_kind`, `store_type` (низкая кардинальность)
+
+### Конфигурация и безопасность
+- `LLMTelemetryFeature` (поверх `LLMAgentFeature`) и/или глобальная регистрация через `installTelemetryHooks(provider)`:
+  - `samplingRate` (в т.ч. отдельный для streaming deltas)
+  - `redactContent(policy|fn)` — full/partial/none, кастомные детекторы PII
+  - `includeToolArgs` / `includeToolResults` (по имени инструмента)
+  - `vectorStore.sourcePolicy` (id/score/обфускация)
+- Значения по умолчанию: контент редактируется, аргументы/результаты инструментов не логируются, только размеры/хеши.
+
+### Ошибки и ретраи
+- Повторные попытки оформляем как siblings с link `retry_of` на первый `LLM Call`.
+- Статусы: `OK`, `ERROR{kind}`, `UNSET` для принудительно закрытых.
+
+### Интеграция с JAICF core
+- Один `TelemetryProvider` на всё приложение.
+- Регистрация LLM-инструментации при `BotEngine.withTelemetry(...)` через `installTelemetryHooks(provider)`; LLM-инструментация активируется внутри `LLMActionContext` и соответствующих LLM‑хуков.
+- События/статусы совместимы с `core` (`TelemetryHookBinder`, `runWithTelemetry`).
+
+### Тесты
+- `activators/llm/src/testFixtures` использовать для перехвата `LLMToolCallHook`/`LLMToolCallsHook`.
+- Проверять: иерархию спанов, атрибуты токенов/latency, события streaming, tool call ошибки/подтверждения, handoff links.
+
+### Минимальный пример включения
+
+```kotlin
+val engine = BotEngine(
+    scenario = MyScenario.model,
+).withTelemetry(OpenTelemetryProvider(/* ... */))
+
+val props = llmProps {
+    model = "gpt-4o-mini"
+    // Телеметрия активируется хук-установкой и точками в LLMActionContext (startStream/eventStream/withToolCalls)
+}
+```
+
+Эта архитектура повторяет сильные стороны koog (lifecycle-менеджер спанов, строгая пропагация контекста и финализация) и нативно интегрируется в LLM-активатор JAICF через `LLMPipeline` и хуки, покрывая streaming, tool loop и handoff без изменения существующих сценариев.
+
+

--- a/examples/game-clock/build.gradle.kts
+++ b/examples/game-clock/build.gradle.kts
@@ -28,7 +28,4 @@ tasks {
     test {
         useJUnitPlatform()
     }
-    build {
-        dependsOn(shadowJar)
-    }
 }

--- a/examples/llm-example/src/main/kotlin/com/justai/jaicf/examples/llm/LLMTelemetryJaegerExample.kt
+++ b/examples/llm-example/src/main/kotlin/com/justai/jaicf/examples/llm/LLMTelemetryJaegerExample.kt
@@ -1,0 +1,83 @@
+package com.justai.jaicf.examples.llm
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.telemetry.opentelemetry.OpenTelemetryTelemetryProvider
+import com.justai.jaicf.examples.llm.channel.ConsoleChannel
+import com.justai.jaicf.activator.llm.telemetry.installLLMActivatorTelemetryHooks
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.exporter.logging.LoggingSpanExporter
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.sdk.trace.samplers.Sampler
+
+private object OTelConfig {
+    private const val SERVICE_NAME = "jaicf-llm-example"
+    private const val SERVICE_VERSION = "1.0.0"
+
+    fun buildTracerWithOtlp(endpoint: String = "http://localhost:4317"): Tracer {
+        val resource = Resource.create(
+            Attributes.builder()
+                .put(AttributeKey.stringKey("service.name"), SERVICE_NAME)
+                .put(AttributeKey.stringKey("service.version"), SERVICE_VERSION)
+                .put(AttributeKey.stringKey("deployment.environment"), "development")
+                .build()
+        )
+
+        val tracerProvider = SdkTracerProvider.builder()
+            .setResource(resource)
+            .setSampler(Sampler.alwaysOn())
+            .addSpanProcessor(
+                SimpleSpanProcessor.create(
+                    OtlpGrpcSpanExporter.builder()
+                        .setEndpoint(endpoint)
+                        .build()
+                )
+            )
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+            .build()
+
+        val sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+
+        return sdk.getTracer(SERVICE_NAME, SERVICE_VERSION)
+    }
+}
+
+/**
+ * Example: run multi-agent LLM scenario with Jaeger/OTLP tracing.
+ * 
+ * Telemetry spans include:
+ * - LLM AgentInvoke (per request)
+ * - LLM Call, Streaming
+ * - ToolCalls/ToolCall (when tools are used)
+ * - Handoff (when agents transfer control)
+ * 
+ * IMPORTANT! Set OPENAI_API_KEY and (optionally) OPENAI_BASE_URL before running.
+ * Run Jaeger all-in-one locally: docker run -d -p 16686:16686 -p 4317:4317 jaegertracing/all-in-one
+ * Then view traces at http://localhost:16686
+ */
+fun main() {
+    val tracer = try {
+        println("Connecting OTLP exporter at http://localhost:4317 ...")
+        OTelConfig.buildTracerWithOtlp()
+    } catch (e: Exception) {
+        // fallback to console exporter only
+        println("Failed to init OTLP exporter: ${'$'}{e.message}")
+        OTelConfig.buildTracerWithOtlp("") // still returns tracer, logging processor enabled
+    }
+
+    val engine = BotEngine(HandoffScenario)
+        .withTelemetry(OpenTelemetryTelemetryProvider(tracer))
+        .apply { installLLMActivatorTelemetryHooks() }
+
+    // Demo: triggers agent handoffs and tool calls, visible in Jaeger
+    ConsoleChannel(engine).run("Calculate 2 + 2 and tell me a joke")
+}
+
+

--- a/examples/llm-example/src/test/kotlin/com/justai/jaicf/examples/llm/LLMTelemetryHooksTest.kt
+++ b/examples/llm-example/src/test/kotlin/com/justai/jaicf/examples/llm/LLMTelemetryHooksTest.kt
@@ -1,0 +1,60 @@
+package com.justai.jaicf.examples.llm
+
+import com.justai.jaicf.activator.llm.LLMScenarioTest
+import com.justai.jaicf.activator.llm.openai.OpenAITest
+import com.justai.jaicf.activator.llm.telemetry.AfterLLMCallHook
+import com.justai.jaicf.activator.llm.telemetry.BeforeLLMCallHook
+import com.justai.jaicf.activator.llm.telemetry.StreamingFirstByteHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallFinishHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallStartHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallsFinishHook
+import com.justai.jaicf.activator.llm.telemetry.ToolCallsStartHook
+import com.justai.jaicf.activator.llm.telemetry.installLLMActivatorTelemetryHooks
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OpenAITest
+class LLMTelemetryHooksTest : LLMScenarioTest(AgentWithTools) {
+
+    init {
+        // bind telemetry to ensure spans creation does not throw
+        bot.installLLMActivatorTelemetryHooks()
+
+        bot.hooks.addHookAction<BeforeLLMCallHook> { counters.before++ }
+        bot.hooks.addHookAction<StreamingFirstByteHook> { counters.firstByte++ }
+        bot.hooks.addHookAction<AfterLLMCallHook> { counters.after++ }
+
+        bot.hooks.addHookAction<ToolCallsStartHook> { counters.toolCallsStart++ }
+        bot.hooks.addHookAction<ToolCallStartHook> { counters.toolCallStart++ }
+        bot.hooks.addHookAction<ToolCallFinishHook> { counters.toolCallFinish++ }
+        bot.hooks.addHookAction<ToolCallsFinishHook> { counters.toolCallsFinish++ }
+    }
+
+    private val counters = object {
+        var before = 0
+        var firstByte = 0
+        var after = 0
+        var toolCallsStart = 0
+        var toolCallStart = 0
+        var toolCallFinish = 0
+        var toolCallsFinish = 0
+    }
+
+    @Test
+    fun `emits llm and tool hooks`() {
+        // triggers calculator tool
+        query("two plus two")
+
+        assertTrue(counters.before > 0, "BeforeLLMCallHook not emitted")
+        assertTrue(counters.firstByte > 0, "StreamingFirstByteHook not emitted")
+        assertTrue(counters.after > 0, "AfterLLMCallHook not emitted")
+
+        assertTrue(counters.toolCallsStart > 0, "ToolCallsStartHook not emitted")
+        assertTrue(counters.toolCallStart > 0, "ToolCallStartHook not emitted")
+        assertTrue(counters.toolCallFinish > 0, "ToolCallFinishHook not emitted")
+        assertTrue(counters.toolCallsFinish > 0, "ToolCallsFinishHook not emitted")
+    }
+}
+
+
+

--- a/examples/telemetry-example/QUICKSTART.md
+++ b/examples/telemetry-example/QUICKSTART.md
@@ -1,0 +1,110 @@
+# Telemetry Example - Quick Start
+
+## Что это?
+
+Пример показывает, как использовать OpenTelemetry с JAICF BotEngine для трассировки и мониторинга работы бота.
+
+## Запуск примера
+
+### 1. Консольный пример (самый простой способ)
+
+```bash
+cd /Users/admin/IdeaProjects/jaicf-kotlin-new
+./gradlew :examples:telemetry-example:run -PmainClass=com.justai.jaicf.examples.telemetry.ConsoleExampleKt
+```
+
+Этот пример:
+- Создает бота с telemetry
+- Отправляет несколько тестовых запросов
+- Выводит трейсы в консоль
+
+### 2. HTTP сервер пример
+
+```bash
+./gradlew :examples:telemetry-example:run -PmainClass=com.justai.jaicf.examples.telemetry.HttpServerExampleKt
+```
+
+Затем в другом терминале:
+
+```bash
+curl -X POST http://localhost:8080/bot \
+  -H "Content-Type: application/json" \
+  -d '{"query": "hello", "clientId": "test-user"}'
+```
+
+### 3. С визуализацией в Jaeger (опционально)
+
+Запустите Jaeger:
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+```
+
+Затем запустите пример и откройте http://localhost:16686
+
+## Ключевые концепции
+
+### 1. Включение telemetry
+
+```kotlin
+val bot = BotEngine(
+    scenario = MyScenario,
+    activators = arrayOf(RegexActivator)
+).withTelemetry(
+    OpenTelemetryTelemetryProvider(tracer)
+)
+```
+
+### 2. Что автоматически трейсится
+
+- **Жизненный цикл запроса**: начало и конец каждого запроса
+- **Активация**: какой активатор обработал запрос и какое состояние было выбрано
+- **Управление контекстом**: загрузка и сохранение контекста бота
+- **Заполнение слотов**: этапы процесса заполнения слотов
+- **Ошибки**: автоматическая запись исключений в спаны
+
+### 3. Атрибуты спанов
+
+Автоматически добавляются следующие атрибуты:
+
+- `jaicf.request.type` - тип запроса
+- `jaicf.request.client_id` - ID клиента
+- `jaicf.session.new` - новая ли сессия
+- `jaicf.activation.state` - путь к активированному состоянию
+- `jaicf.activation.activator` - имя активатора
+- `jaicf.duration_ms` - длительность в миллисекундах
+
+## Структура файлов
+
+```
+examples/telemetry-example/
+├── src/
+│   ├── main/
+│   │   └── kotlin/
+│   │       └── com/justai/jaicf/examples/telemetry/
+│   │           ├── TelemetryConfig.kt        # Конфигурация OpenTelemetry
+│   │           ├── TelemetryScenario.kt      # Сценарий бота
+│   │           ├── ConsoleExample.kt         # Консольный пример
+│   │           └── HttpServerExample.kt      # HTTP сервер пример
+│   └── test/
+│       └── kotlin/
+│           └── com/justai/jaicf/examples/telemetry/
+│               └── TelemetryScenarioTest.kt  # Тесты
+├── build.gradle.kts                          # Конфигурация сборки
+├── README.md                                 # Подробная документация
+├── TELEMETRY_GUIDE.md                        # Руководство по telemetry
+└── QUICKSTART.md                             # Этот файл
+```
+
+## Полезные ссылки
+
+- [README.md](README.md) - подробная документация
+- [TELEMETRY_GUIDE.md](TELEMETRY_GUIDE.md) - глубокое руководство по telemetry
+- [OpenTelemetry Docs](https://opentelemetry.io/docs/)
+- [JAICF Documentation](https://github.com/just-ai/jaicf-kotlin)
+
+
+

--- a/examples/telemetry-example/README.md
+++ b/examples/telemetry-example/README.md
@@ -1,0 +1,124 @@
+# Telemetry Example
+
+This example demonstrates how to use OpenTelemetry tracing with JAICF BotEngine.
+
+## Overview
+
+The example shows:
+- How to configure OpenTelemetry with JAICF
+- Automatic tracing of bot requests, activations, and actions
+- Integration with different exporters (logging and OTLP)
+- Custom span attributes and events
+
+## Features
+
+The telemetry integration automatically traces:
+- **Request lifecycle**: Start and end of each request with duration
+- **Context management**: Loading and saving bot context
+- **Activation**: Which activator handled the request and which state was selected
+- **Slot filling**: Slot filling process stages
+- **Errors**: Automatic exception recording in spans
+
+## Running the Example
+
+### 1. Simple Console Example
+
+Run the basic console example with logging exporter:
+
+```bash
+./gradlew :telemetry-example:run
+```
+
+This will:
+- Start a simple bot with telemetry enabled
+- Process a few test messages
+- Output traces to console logs
+
+### 2. With Jaeger (Optional)
+
+To visualize traces in Jaeger UI:
+
+1. Start Jaeger with Docker:
+```bash
+docker run -d --name jaeger \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 14250:14250 \
+  -p 9411:9411 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+2. Run the example
+3. Open http://localhost:16686 to view traces in Jaeger UI
+
+### 3. HTTP Server Example
+
+Run the HTTP server example:
+
+```bash
+./gradlew :telemetry-example:run -PmainClass=com.justai.jaicf.examples.telemetry.HttpServerExampleKt
+```
+
+Then send requests:
+```bash
+curl -X POST http://localhost:8080/bot \
+  -H "Content-Type: application/json" \
+  -d '{"query": "hello"}'
+```
+
+## Code Structure
+
+- `TelemetryScenario.kt` - Simple bot scenario with multiple states
+- `ConsoleExample.kt` - Console-based example
+- `HttpServerExample.kt` - HTTP server example
+- `TelemetryConfig.kt` - OpenTelemetry configuration utilities
+
+## Key Concepts
+
+### Enabling Telemetry
+
+```kotlin
+val bot = BotEngine(
+    scenario = MyScenario,
+    activators = arrayOf(RegexActivator)
+).withTelemetry(
+    OpenTelemetryTelemetryProvider(
+        tracer = buildTracer()
+    )
+)
+```
+
+### OpenTelemetry Configuration
+
+```kotlin
+val tracerProvider = SdkTracerProvider.builder()
+    .setResource(resource)
+    .setSampler(Sampler.alwaysOn())
+    .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+    .build()
+```
+
+## Span Attributes
+
+The telemetry integration adds these attributes automatically:
+
+- `jaicf.request.type` - Type of the request
+- `jaicf.request.client_id` - Client ID
+- `jaicf.session.new` - Whether it's a new session
+- `jaicf.activation.state` - Activated state path
+- `jaicf.activation.activator` - Name of the activator
+- `jaicf.duration_ms` - Duration in milliseconds
+
+## Learn More
+
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
+- [JAICF Documentation](https://github.com/just-ai/jaicf-kotlin)
+
+
+

--- a/examples/telemetry-example/TELEMETRY_GUIDE.md
+++ b/examples/telemetry-example/TELEMETRY_GUIDE.md
@@ -1,0 +1,306 @@
+# JAICF Telemetry Integration Guide
+
+## Overview
+
+JAICF BotEngine includes built-in support for OpenTelemetry distributed tracing. This allows you to monitor and debug your bot's behavior in production and development environments.
+
+## How It Works
+
+### Architecture
+
+The telemetry integration in JAICF uses a hook-based system:
+
+1. **TelemetryProvider**: Abstract interface for creating telemetry spans
+2. **TelemetryHookBinder**: Automatically installs hooks into BotEngine
+3. **OpenTelemetryTelemetryProvider**: Implementation for OpenTelemetry
+
+### Automatic Instrumentation
+
+When you enable telemetry with `.withTelemetry()`, JAICF automatically instruments:
+
+#### 1. Request Lifecycle
+- **jaicf.request.start**: Request begins processing
+- **jaicf.request.end**: Request completes processing
+- Attributes: `request.type`, `client_id`, `session.new`, `duration_ms`
+
+#### 2. Context Management
+- **jaicf.context.load**: Loading bot context from storage
+- **jaicf.context.save**: Saving bot context to storage
+- Attributes: `context.manager`, `context.stage`, `duration_ms`
+
+#### 3. Activation
+- **jaicf.activation.before**: Before activator selection
+- **jaicf.activation.after**: After activator selection
+- Attributes: `activation.state`, `activation.activator`, `duration_ms`
+
+#### 4. Slot Filling
+- **jaicf.slot_filling.start**: Slot filling begins
+- **jaicf.slot_filling.progress**: Slot filling in progress
+- **jaicf.slot_filling.finish**: Slot filling completes
+- Attributes: `activator`, `target_state`, `result`, `duration_ms`
+
+#### 5. Errors
+All exceptions are automatically captured with:
+- Full stack traces
+- Span status set to ERROR
+- Error message in span attributes
+
+## Usage
+
+### Basic Setup
+
+```kotlin
+// 1. Create OpenTelemetry tracer
+val tracer = buildTracer()
+
+// 2. Create bot with telemetry
+val bot = BotEngine(
+    scenario = MyScenario,
+    activators = arrayOf(RegexActivator)
+).withTelemetry(
+    OpenTelemetryTelemetryProvider(tracer)
+)
+
+// 3. Process requests as usual
+bot.process(request, reactions)
+```
+
+### OpenTelemetry Configuration
+
+```kotlin
+fun buildTracer(): Tracer {
+    val resource = Resource.create(
+        Attributes.builder()
+            .put(AttributeKey.stringKey("service.name"), "my-bot")
+            .put(AttributeKey.stringKey("service.version"), "1.0.0")
+            .build()
+    )
+    
+    val tracerProvider = SdkTracerProvider.builder()
+        .setResource(resource)
+        .setSampler(Sampler.alwaysOn())
+        .addSpanProcessor(
+            SimpleSpanProcessor.create(
+                OtlpGrpcSpanExporter.builder()
+                    .setEndpoint("http://localhost:4317")
+                    .build()
+            )
+        )
+        .build()
+
+    val sdk = OpenTelemetrySdk.builder()
+        .setTracerProvider(tracerProvider)
+        .build()
+
+    return sdk.getTracer("my-bot", "1.0.0")
+}
+```
+
+### Exporter Options
+
+#### 1. Console Logging (Development)
+```kotlin
+.addSpanProcessor(
+    SimpleSpanProcessor.create(LoggingSpanExporter.create())
+)
+```
+
+#### 2. OTLP (Jaeger, Tempo, etc.)
+```kotlin
+.addSpanProcessor(
+    SimpleSpanProcessor.create(
+        OtlpGrpcSpanExporter.builder()
+            .setEndpoint("http://localhost:4317")
+            .build()
+    )
+)
+```
+
+#### 3. Zipkin
+```kotlin
+.addSpanProcessor(
+    SimpleSpanProcessor.create(
+        ZipkinSpanExporter.builder()
+            .setEndpoint("http://localhost:9411/api/v2/spans")
+            .build()
+    )
+)
+```
+
+## Visualization with Jaeger
+
+### Running Jaeger
+
+```bash
+docker run -d --name jaeger \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 14250:14250 \
+  -p 9411:9411 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+### Viewing Traces
+
+1. Open http://localhost:16686
+2. Select your service name from the dropdown
+3. Click "Find Traces"
+4. Explore the trace timeline and spans
+
+### What You'll See
+
+- **Request timeline**: Complete flow from start to finish
+- **Activation details**: Which activator handled the request
+- **State transitions**: Path through your scenario
+- **Performance metrics**: Duration of each operation
+- **Error details**: Stack traces and error messages
+
+## Advanced Usage
+
+### Custom Spans in Actions
+
+You can create custom spans in your bot actions:
+
+```kotlin
+action {
+    val span = currentTelemetrySpan()
+    span?.setAttribute("custom.attribute", "value")
+    span?.addEvent("custom.event")
+    
+    // Your action logic
+    reactions.say("Hello!")
+}
+```
+
+### Context Propagation
+
+Telemetry spans are automatically propagated through:
+- Coroutine context
+- Thread local storage
+- Parent-child span relationships
+
+### Sampling
+
+Control which requests are traced:
+
+```kotlin
+// Always trace
+.setSampler(Sampler.alwaysOn())
+
+// Never trace (turn off)
+.setSampler(Sampler.alwaysOff())
+
+// Trace 10% of requests
+.setSampler(Sampler.traceIdRatioBased(0.1))
+
+// Parent-based sampling
+.setSampler(Sampler.parentBased(Sampler.traceIdRatioBased(0.1)))
+```
+
+## Best Practices
+
+### 1. Use Service Name and Version
+Always set service name and version in your resource:
+```kotlin
+Resource.create(
+    Attributes.builder()
+        .put(AttributeKey.stringKey("service.name"), "my-bot")
+        .put(AttributeKey.stringKey("service.version"), "1.0.0")
+        .build()
+)
+```
+
+### 2. Choose Appropriate Exporters
+- **Development**: Use `LoggingSpanExporter` for console output
+- **Production**: Use OTLP exporter with a tracing backend
+
+### 3. Set Up Sampling
+Don't trace every request in production:
+```kotlin
+.setSampler(Sampler.traceIdRatioBased(0.1)) // 10% sampling
+```
+
+### 4. Add Custom Attributes
+Add business-specific attributes to help with filtering:
+```kotlin
+span?.setAttribute("bot.scenario", "customer-support")
+span?.setAttribute("bot.language", "en")
+span?.setAttribute("user.tier", "premium")
+```
+
+### 5. Monitor Performance
+Watch for:
+- High activation duration (slow activators)
+- High context load/save duration (slow storage)
+- Error rates by state
+- Request distribution by activator
+
+## Troubleshooting
+
+### No Spans Appear
+
+1. Check that telemetry is enabled: `.withTelemetry(...)`
+2. Verify exporter configuration
+3. Check network connectivity to backend
+4. Ensure sampling is not set to `alwaysOff()`
+
+### Performance Impact
+
+Telemetry adds minimal overhead:
+- ~1-5ms per request
+- Most impact from network export
+- Use batch span processors in production:
+
+```kotlin
+.addSpanProcessor(
+    BatchSpanProcessor.builder(exporter)
+        .setScheduleDelay(5, TimeUnit.SECONDS)
+        .build()
+)
+```
+
+### Memory Issues
+
+If spans accumulate in memory:
+- Use batch processors instead of simple processors
+- Reduce sampling rate
+- Check that spans are being exported successfully
+
+## Integration with Other Systems
+
+### Kubernetes
+Add pod labels to trace attributes:
+```kotlin
+.put(AttributeKey.stringKey("k8s.pod.name"), System.getenv("HOSTNAME"))
+.put(AttributeKey.stringKey("k8s.namespace"), System.getenv("NAMESPACE"))
+```
+
+### Correlation IDs
+Use request IDs for correlation:
+```kotlin
+span?.setAttribute("correlation.id", request.clientId)
+```
+
+### APM Integration
+Telemetry works with:
+- Datadog APM
+- New Relic
+- Elastic APM
+- Dynatrace
+- AWS X-Ray
+
+## Resources
+
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
+- [OpenTelemetry Java SDK](https://opentelemetry.io/docs/languages/java/)
+- [Jaeger Documentation](https://www.jaegertracing.io/docs/)
+- [JAICF Documentation](https://github.com/just-ai/jaicf-kotlin)
+
+
+

--- a/examples/telemetry-example/build.gradle.kts
+++ b/examples/telemetry-example/build.gradle.kts
@@ -8,21 +8,25 @@ repositories {
 
 dependencies {
     implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization)
 
     core()
-    implementation(project(":activators:llm"))
-    implementation(libs.jline)
     implementation(project(":telemetry:opentelemetry"))
-    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.43.0")
+    implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.sdk.trace)
     implementation("io.opentelemetry:opentelemetry-exporter-logging:1.43.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.43.0")
 
-    testImplementation(testFixtures(project(":activators:llm")))
+    implementation(libs.slf4j.simple)
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.engine)
-    testImplementation(libs.opentelemetry.sdk)
-    testImplementation(libs.opentelemetry.sdk.trace)
+    testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.43.0")
 }
 
 tasks {
@@ -30,3 +34,4 @@ tasks {
         useJUnitPlatform()
     }
 }
+

--- a/examples/telemetry-example/src/main/kotlin/com/justai/jaicf/examples/telemetry/HttpServerExample.kt
+++ b/examples/telemetry-example/src/main/kotlin/com/justai/jaicf/examples/telemetry/HttpServerExample.kt
@@ -1,0 +1,132 @@
+package com.justai.jaicf.examples.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.activator.catchall.CatchAllActivator
+import com.justai.jaicf.activator.regex.RegexActivator
+import com.justai.jaicf.api.QueryBotRequest
+import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.logging.ImageReaction
+import com.justai.jaicf.logging.SayReaction
+import com.justai.jaicf.reactions.Reactions
+import com.justai.jaicf.telemetry.opentelemetry.OpenTelemetryTelemetryProvider
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * HTTP server example with OpenTelemetry integration
+ */
+fun main() {
+    val tracer = try {
+        println("Attempting to connect to OTLP endpoint at http://localhost:4317...")
+        TelemetryConfig.buildTracerWithOtlp()
+    } catch (e: Exception) {
+        println("Could not connect to OTLP endpoint, using console logging instead")
+        TelemetryConfig.buildTracerWithLogging()
+    }
+
+    val bot = BotEngine(
+        scenario = TelemetryScenario,
+        activators = arrayOf(
+            RegexActivator,
+            CatchAllActivator
+        )
+    ).withTelemetry(
+        OpenTelemetryTelemetryProvider(tracer)
+    )
+
+    embeddedServer(Netty, port = 8081) {
+        routing {
+            get("/") {
+                call.respondText(
+                    """
+                    JAICF Telemetry Example Server
+                    
+                    Send POST request to /bot with JSON body:
+                    {
+                        "query": "your message",
+                        "clientId": "optional-client-id"
+                    }
+                    
+                    Example:
+                    curl -X POST http://localhost:8080/bot \
+                      -H "Content-Type: application/json" \
+                      -d '{"query": "hello"}'
+                    """.trimIndent(),
+                    ContentType.Text.Plain
+                )
+            }
+
+            post("/bot") {
+                try {
+                    val json = call.receiveText()
+                    val jsonObj = Json.parseToJsonElement(json).jsonObject
+                    val query = jsonObj["query"]?.jsonPrimitive?.content ?: ""
+                    val clientId = jsonObj["clientId"]?.jsonPrimitive?.content ?: "anonymous"
+
+                    val request = QueryBotRequest(clientId = clientId, input = query)
+                    val reactions = HttpReactions()
+
+                    bot.process(request, reactions, RequestContext.DEFAULT)
+
+                    call.respond(
+                        HttpStatusCode.OK,
+                        reactions.toJson()
+                    )
+                } catch (e: Exception) {
+                    call.respond(
+                        HttpStatusCode.InternalServerError,
+                        mapOf("error" to (e.message ?: "Unknown error"))
+                    )
+                }
+            }
+
+            get("/health") {
+                call.respond(HttpStatusCode.OK, mapOf("status" to "ok"))
+            }
+        }
+    }.start(wait = true)
+}
+
+/**
+ * HTTP-specific reactions implementation
+ */
+private class HttpReactions : Reactions() {
+    private val responses = mutableListOf<Map<String, Any>>()
+
+    override fun say(text: String): SayReaction {
+        responses.add(mapOf("type" to "text", "text" to text))
+        return super.say(text)
+    }
+
+    override fun image(url: String): ImageReaction {
+        responses.add(mapOf("type" to "image", "url" to url))
+        return super.image(url)
+    }
+
+    override fun buttons(vararg buttons: String): ButtonsReaction {
+        responses.add(
+            mapOf(
+                "type" to "buttons",
+                "buttons" to buttons.toList()
+            )
+        )
+        return super.buttons(*buttons)
+    }
+
+    fun toJson(): Map<String, Any> {
+        return mapOf("responses" to responses)
+    }
+}
+

--- a/examples/telemetry-example/src/main/kotlin/com/justai/jaicf/examples/telemetry/TelemetryConfig.kt
+++ b/examples/telemetry-example/src/main/kotlin/com/justai/jaicf/examples/telemetry/TelemetryConfig.kt
@@ -1,0 +1,79 @@
+package com.justai.jaicf.examples.telemetry
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.exporter.logging.LoggingSpanExporter
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.sdk.trace.samplers.Sampler
+
+/**
+ * Configuration for OpenTelemetry tracing
+ */
+object TelemetryConfig {
+    
+    const val SERVICE_NAME = "jaicf-telemetry-example"
+    const val SERVICE_VERSION = "1.0.0"
+    
+    /**
+     * Build OpenTelemetry tracer with console logging exporter
+     */
+    fun buildTracerWithLogging(): Tracer {
+        val resource = createResource()
+        
+        val tracerProvider = SdkTracerProvider.builder()
+            .setResource(resource)
+            .setSampler(Sampler.alwaysOn())
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+            .build()
+
+        val sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+
+        return sdk.getTracer(SERVICE_NAME, SERVICE_VERSION)
+    }
+    
+    /**
+     * Build OpenTelemetry tracer with OTLP exporter (for Jaeger, etc.)
+     * Exports to http://localhost:4317 by default
+     */
+    fun buildTracerWithOtlp(endpoint: String = "http://localhost:4317"): Tracer {
+        val resource = createResource()
+        
+        val tracerProvider = SdkTracerProvider.builder()
+            .setResource(resource)
+            .setSampler(Sampler.alwaysOn())
+            .addSpanProcessor(
+                SimpleSpanProcessor.create(
+                    OtlpGrpcSpanExporter.builder()
+                        .setEndpoint(endpoint)
+                        .build()
+                )
+            )
+            // Also log to console
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+            .build()
+
+        val sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+
+        return sdk.getTracer(SERVICE_NAME, SERVICE_VERSION)
+    }
+    
+    private fun createResource(): Resource {
+        return Resource.create(
+            Attributes.builder()
+                .put(AttributeKey.stringKey("service.name"), SERVICE_NAME)
+                .put(AttributeKey.stringKey("service.version"), SERVICE_VERSION)
+                .put(AttributeKey.stringKey("deployment.environment"), "development")
+                .build()
+        )
+    }
+}
+

--- a/examples/telemetry-example/src/main/kotlin/com/justai/jaicf/examples/telemetry/TelemetryScenario.kt
+++ b/examples/telemetry-example/src/main/kotlin/com/justai/jaicf/examples/telemetry/TelemetryScenario.kt
@@ -1,0 +1,125 @@
+package com.justai.jaicf.examples.telemetry
+
+import com.justai.jaicf.builder.Scenario
+import com.justai.jaicf.reactions.buttons
+import com.justai.jaicf.reactions.toState
+import com.justai.jaicf.telemetry.sendTelemetrySpan
+
+/**
+ * Simple scenario to demonstrate telemetry
+ */
+val TelemetryScenario = Scenario {
+    
+    state("main") {
+        activators {
+            regex("start")
+            regex("hello")
+            catchAll()
+        }
+        
+        action {
+            val name = "jaicf.custom.event"
+            val attributes = mapOf(
+                "jaicf.custom.type" to "Custom type",
+                "jaicf.custom.client_id" to "Client Id",
+                "jaicf.custom.input" to "Test Input"
+            )
+            sendTelemetrySpan(name, attributes)
+
+            reactions.run {
+                say("Hello! I'm a bot with telemetry enabled.")
+                say("You can see traces of all bot operations in the logs.")
+                buttons(
+                    "Tell me a joke" toState "/joke",
+                    "Calculate" toState "/calculate",
+                    "Help" toState "/help"
+                )
+            }
+        }
+    }
+    
+    state("joke") {
+        activators {
+            regex("joke")
+            regex("tell.*joke")
+        }
+        
+        action {
+            val jokes = listOf(
+                "Why do programmers prefer dark mode? Because light attracts bugs!",
+                "How many programmers does it take to change a light bulb? None, that's a hardware problem.",
+                "Why do Java developers wear glasses? Because they can't C#!"
+            )
+            
+            reactions.run {
+                say(jokes.random())
+                say("Want another one?")
+                buttons(
+                    "Yes, another joke!" toState "/joke",
+                    "Back to main" toState "/main"
+                )
+            }
+        }
+    }
+    
+    state("calculate") {
+        activators {
+            regex("calculate")
+            regex("calc")
+            regex("math")
+        }
+        
+        action {
+            reactions.run {
+                say("Let me calculate something...")
+                // Simulate some processing
+                Thread.sleep(100)
+                
+                val result = (1..100).sum()
+                say("The sum of numbers from 1 to 100 is: $result")
+                
+                buttons(
+                    "Calculate again" toState "/calculate",
+                    "Back to main" toState "/main"
+                )
+            }
+        }
+    }
+    
+    state("help") {
+        activators {
+            regex("help")
+        }
+        
+        action {
+            reactions.run {
+                say("This is a demo bot with OpenTelemetry integration.")
+                say("Try these commands:")
+                say("- 'joke' - Tell a joke")
+                say("- 'calculate' - Do some calculations")
+                say("- 'hello' - Go to main menu")
+                
+                buttons("Back to main" toState "/main")
+            }
+        }
+    }
+    
+    state("error") {
+        activators {
+            regex("error")
+            regex("fail")
+        }
+        
+        action {
+            throw RuntimeException("This is a test error for telemetry demo")
+        }
+    }
+    
+    fallback {
+        reactions.run {
+            say("Sorry, I didn't understand that.")
+            say("Try 'hello' to start or 'help' for available commands.")
+        }
+    }
+}
+

--- a/examples/telemetry-example/src/main/resources/docker-compose.yaml
+++ b/examples/telemetry-example/src/main/resources/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:1.39
+    container_name: jaeger-all-in-one
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "4317:4317"
+      - "16686:16686"

--- a/examples/telemetry-example/src/test/kotlin/com/justai/jaicf/examples/telemetry/TelemetryScenarioTest.kt
+++ b/examples/telemetry-example/src/test/kotlin/com/justai/jaicf/examples/telemetry/TelemetryScenarioTest.kt
@@ -1,0 +1,173 @@
+package com.justai.jaicf.examples.telemetry
+
+import com.justai.jaicf.BotEngine
+import com.justai.jaicf.activator.catchall.CatchAllActivator
+import com.justai.jaicf.activator.regex.RegexActivator
+import com.justai.jaicf.api.QueryBotRequest
+import com.justai.jaicf.context.RequestContext
+import com.justai.jaicf.logging.ButtonsReaction
+import com.justai.jaicf.logging.ImageReaction
+import com.justai.jaicf.logging.SayReaction
+import com.justai.jaicf.reactions.Reactions
+import com.justai.jaicf.telemetry.opentelemetry.OpenTelemetryTelemetryProvider
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TelemetryScenarioTest {
+    
+    private lateinit var spanExporter: InMemorySpanExporter
+    private lateinit var tracer: Tracer
+    private lateinit var bot: BotEngine
+    
+    @BeforeEach
+    fun setup() {
+        // Create in-memory span exporter for testing
+        spanExporter = InMemorySpanExporter.create()
+        
+        val tracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+        
+        val sdk = OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+        
+        tracer = sdk.getTracer("test")
+        
+        // Create bot with telemetry
+        bot = BotEngine(
+            scenario = TelemetryScenario,
+            activators = arrayOf(
+                RegexActivator,
+                CatchAllActivator
+            )
+        ).withTelemetry(
+            OpenTelemetryTelemetryProvider(tracer)
+        )
+    }
+    
+    @Test
+    fun `should handle hello message`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("hello")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        assertTrue(reactions.responses.isNotEmpty())
+        assertTrue(reactions.responses.any { it.contains("telemetry") })
+    }
+    
+    @Test
+    fun `should handle joke request`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("joke")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        assertTrue(reactions.responses.isNotEmpty())
+        assertTrue(reactions.responses.any { it.contains("programmer") || it.contains("Java") })
+    }
+    
+    @Test
+    fun `should handle calculate request`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("calculate")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        assertTrue(reactions.responses.isNotEmpty())
+        assertTrue(reactions.responses.any { it.contains("5050") })
+    }
+    
+    @Test
+    fun `should handle help request`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("help")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        assertTrue(reactions.responses.isNotEmpty())
+        assertTrue(reactions.responses.any { it.contains("demo bot") })
+    }
+    
+    @Test
+    fun `should create telemetry spans`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("hello")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        // Give some time for spans to be exported
+        Thread.sleep(100)
+        
+        val spans = spanExporter.finishedSpanItems
+        assertFalse(spans.isEmpty(), "Should have created telemetry spans")
+        
+        // Check that we have request lifecycle spans
+        val hasRequestSpans = spans.any { span ->
+            span.name.contains("jaicf.request")
+        }
+        assertTrue(hasRequestSpans, "Should have request lifecycle spans")
+    }
+    
+    @Test
+    fun `should capture activation information in spans`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("joke")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        // Give some time for spans to be exported
+        Thread.sleep(200)
+        
+        val spans = spanExporter.finishedSpanItems
+        
+        // Check that we have some spans
+        assertTrue(spans.isNotEmpty(), "Should have created some spans")
+    }
+    
+    @Test
+    fun `should handle unknown commands with fallback`() = runBlocking {
+        val reactions = TestReactions()
+        val request = createRequest("unknown command xyz")
+        
+        bot.process(request, reactions, RequestContext.DEFAULT)
+        
+        // Should get some response (either from fallback or default handler)
+        assertTrue(reactions.responses.isNotEmpty(), "Should have at least one response")
+    }
+    
+    private fun createRequest(query: String): QueryBotRequest {
+        return QueryBotRequest(
+            clientId = "test-client",
+            input = query
+        )
+    }
+    
+    private class TestReactions : Reactions() {
+        val responses = mutableListOf<String>()
+        
+        override fun say(text: String): SayReaction {
+            responses.add(text)
+            return super.say(text)
+        }
+        
+        override fun image(url: String): ImageReaction {
+            responses.add("[Image: $url]")
+            return super.image(url)
+        }
+        
+        override fun buttons(vararg buttons: String): ButtonsReaction {
+            responses.add("[Buttons: ${buttons.joinToString(", ")}]")
+            return super.buttons(*buttons)
+        }
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ modelcontextprotocol = "0.5.0"
 lexruntimev2 = "2.32.4"
 grpc-okhttp = "1.73.0"
 google-dialogflow = "4.74.0"
+otel = "1.43.0"
 
 [libraries]
 github-release = { module = "com.github.breadmoirai:github-release", version.ref = "github" }
@@ -86,6 +87,9 @@ lexruntimev2 = { module = "software.amazon.awssdk:lexruntimev2", version.ref = "
 google-dialogflow = { module = "com.google.cloud:google-cloud-dialogflow", version.ref = "google-dialogflow"}
 grpc-okhttp = { module = "io.grpc:grpc-okhttp", version.ref = "grpc-okhttp"}
 
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "otel" }
+opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "otel" }
+opentelemetry-sdk-trace = { module = "io.opentelemetry:opentelemetry-sdk-trace", version.ref = "otel" }
 
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jUnit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jUnit" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,8 @@ include("examples:multilingual-bot")
 findProject(":examples:multilingual-bot")?.name = "multilingual-bot"
 include("examples:llm-example")
 findProject(":examples:llm-example")?.name = "llm-example"
+include("examples:telemetry-example")
+findProject(":examples:telemetry-example")?.name = "telemetry-example"
 
 include("activators:dialogflow")
 findProject(":activators:dialogflow")?.name = "dialogflow"
@@ -49,3 +51,6 @@ include("activators:rasa")
 findProject(":activators:rasa")?.name = "rasa"
 include("activators:llm")
 findProject(":activators:llm")?.name = "llm"
+
+include("telemetry:opentelemetry")
+findProject(":telemetry:opentelemetry")?.name = "opentelemetry"

--- a/telemetry/opentelemetry/build.gradle.kts
+++ b/telemetry/opentelemetry/build.gradle.kts
@@ -1,0 +1,16 @@
+import plugins.publish.POM_DESCRIPTION
+import plugins.publish.POM_NAME
+
+ext[POM_NAME] = "JAICF-Kotlin OpenTelemetry integration"
+ext[POM_DESCRIPTION] = "Optional OpenTelemetry tracing support for JAICF BotEngine."
+
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    `jaicf-publish`
+}
+
+dependencies {
+    core()
+    api(libs.opentelemetry.api)
+    implementation(libs.kotlin.stdlib)
+}

--- a/telemetry/opentelemetry/src/main/kotlin/com/justai/jaicf/telemetry/opentelemetry/OpenTelemetryTelemetryProvider.kt
+++ b/telemetry/opentelemetry/src/main/kotlin/com/justai/jaicf/telemetry/opentelemetry/OpenTelemetryTelemetryProvider.kt
@@ -1,0 +1,134 @@
+package com.justai.jaicf.telemetry.opentelemetry
+
+import com.justai.jaicf.telemetry.TelemetryAttributes
+import com.justai.jaicf.telemetry.TelemetryProvider
+import com.justai.jaicf.telemetry.TelemetrySpan
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+
+class OpenTelemetryTelemetryProvider(
+    private val tracer: Tracer,
+) : TelemetryProvider {
+
+    constructor(
+        openTelemetry: OpenTelemetry,
+        instrumentationName: String = DEFAULT_INSTRUMENTATION_NAME,
+        instrumentationVersion: String? = null,
+    ) : this(
+        instrumentationVersion?.let { version ->
+            openTelemetry.getTracer(instrumentationName, version)
+        } ?: openTelemetry.getTracer(instrumentationName)
+    )
+
+    override fun createSpan(
+        name: String,
+        attributes: TelemetryAttributes,
+        parent: TelemetrySpan?
+    ): TelemetrySpan {
+        val builder = tracer.spanBuilder(name).applyParent(parent)
+        val span = builder.startSpan()
+        val scope = span.makeCurrent()
+        attributes.forEach { (key, value) -> span.setDynamicAttribute(key, value) }
+        return OtelTelemetrySpan(span, scope)
+    }
+
+    private fun SpanBuilder.applyParent(parent: TelemetrySpan?): SpanBuilder = when (parent) {
+        is OtelTelemetrySpan -> setParent(Context.current().with(parent.unwrap()))
+        else -> setParent(Context.current())
+    }
+
+    private class OtelTelemetrySpan(
+        private val span: Span,
+        private val scope: Scope,
+    ) : TelemetrySpan {
+
+        override fun setAttribute(key: String, value: Any?) {
+            span.setDynamicAttribute(key, value)
+        }
+
+        override fun addEvent(name: String, attributes: TelemetryAttributes) {
+            if (attributes.isEmpty()) {
+                span.addEvent(name)
+            } else {
+                span.addEvent(name, attributes.toOtelAttributes())
+            }
+        }
+
+        override fun recordException(exception: Throwable) {
+            span.recordException(exception)
+            span.setStatus(StatusCode.ERROR, exception.message ?: exception::class.java.simpleName ?: "error")
+        }
+
+        override fun close() {
+            scope.close()
+            span.end()
+        }
+
+        fun unwrap(): Span = span
+    }
+
+    companion object {
+        private const val DEFAULT_INSTRUMENTATION_NAME = "com.justai.jaicf"
+    }
+}
+
+fun OpenTelemetry.asJaicfTelemetryProvider(
+    instrumentationName: String = "com.justai.jaicf",
+    instrumentationVersion: String? = null,
+): TelemetryProvider = OpenTelemetryTelemetryProvider(this, instrumentationName, instrumentationVersion)
+
+private fun TelemetryAttributes.toOtelAttributes(): Attributes {
+    if (isEmpty()) return Attributes.empty()
+    val builder = Attributes.builder()
+    forEach { (key, value) ->
+        when (value) {
+            null -> Unit
+            is String -> builder.put(key, value)
+            is Boolean -> builder.put(key, value)
+            is Double -> builder.put(key, value)
+            is Float -> builder.put(key, value.toDouble())
+            is Long -> builder.put(key, value)
+            is Int -> builder.put(key, value.toLong())
+            is Short -> builder.put(key, value.toLong())
+            is Byte -> builder.put(key, value.toLong())
+            is Number -> builder.put(key, value.toDouble())
+            is Iterable<*> -> {
+                val strings = value.mapNotNull { it?.toString() }
+                if (strings.isNotEmpty()) {
+                    builder.put(AttributeKey.stringArrayKey(key), strings)
+                }
+            }
+            else -> builder.put(key, value.toString())
+        }
+    }
+    return builder.build()
+}
+
+private fun Span.setDynamicAttribute(key: String, value: Any?) {
+    when (value) {
+        null -> Unit
+        is String -> setAttribute(key, value)
+        is Boolean -> setAttribute(key, value)
+        is Double -> setAttribute(key, value)
+        is Float -> setAttribute(key, value.toDouble())
+        is Long -> setAttribute(key, value)
+        is Int -> setAttribute(key, value.toLong())
+        is Short -> setAttribute(key, value.toLong())
+        is Byte -> setAttribute(key, value.toLong())
+        is Number -> setAttribute(key, value.toDouble())
+        is Iterable<*> -> {
+            val strings = value.mapNotNull { it?.toString() }
+            if (strings.isNotEmpty()) {
+                setAttribute(AttributeKey.stringArrayKey(key), strings)
+            }
+        }
+        else -> setAttribute(key, value.toString())
+    }
+}


### PR DESCRIPTION
This PR fixes two connected issues:

- Inability to pass a custom OpenAI client ([LLMActionContext](activators/llm/src/main/kotlin/com/justai/jaicf/activator/llm/action/LLMActionContext.kt) would use default client instead whichever supplied in agent constructor)
- Inability to correctly start an agent without credentials provided in ENV