### PR TITLE
VS-13660: create channels/max Gradle module

### DIFF
--- a/channels/max/README.md
+++ b/channels/max/README.md
@@ -1,0 +1,9 @@
+# Max channel
+
+Allows to create chatbots for [Max](https://max.ru) messenger.
+
+_Built on top of the [Max Bot API](https://dev.max.ru/docs)._
+
+## How to use
+
+Please refer the JAICF [Max channel page](https://help.jaicf.com/Max)

--- a/channels/max/build.gradle.kts
+++ b/channels/max/build.gradle.kts
@@ -1,0 +1,14 @@
+import plugins.publish.POM_DESCRIPTION
+import plugins.publish.POM_NAME
+
+ext[POM_NAME] = "JAICF-Kotlin Max Channel"
+ext[POM_DESCRIPTION] = "JAICF-Kotlin Max Channel implementation. Enables JAICF-Kotlin integration with Max messenger"
+
+plugins {
+    `jaicf-kotlin`
+    `jaicf-publish`
+}
+
+dependencies {
+    core()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,8 @@ include("channels:google-actions")
 findProject(":channels:google-actions")?.name = "google-actions"
 include("channels:jaicp")
 findProject(":channels:jaicp")?.name = "jaicp"
+include("channels:max")
+findProject(":channels:max")?.name = "max"
 
 include("managers:mongo")
 findProject(":managers:mongo")?.name = "mongo"


### PR DESCRIPTION
## Summary
- New Gradle module `channels/max`, wired into `settings.gradle.kts`; produces artifact `com.just-ai.jaicf:max`.
- Build scaffold only: plugins `jaicf-kotlin` + `jaicf-publish`, `core()` dependency, README. No channel logic yet.

## Test Plan
- [ ] `./gradlew :channels:max:build` succeeds (JDK 8 — Gradle 6.8.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)